### PR TITLE
[Codex & IDA Pro MCP] 对于yuzuex.dll的一些逆向工作

### DIFF
--- a/cpp/core/plugin/PluginImpl.cpp
+++ b/cpp/core/plugin/PluginImpl.cpp
@@ -29,6 +29,7 @@
 #include "tjs.h"
 #include "tjsConfig.h"
 #include "ncbind.hpp"
+#include "combase.h"
 
 #ifdef TVP_SUPPORT_KPI
 #include "kmp_pi.h"
@@ -47,6 +48,7 @@ bool TVPLoadInternalPlugin(const ttstr &_name);
 bool TVPRegisterGlobalObject(const tjs_char *name, iTJSDispatch2 *dsp);
 
 static iTJSDispatch2 *s_ProxyStorageMap = nullptr;
+static iTVPStorageMedia *s_ProxyStorageMedia = nullptr;
 
 class tTJSNI_GamepadStub : public tTJSNativeInstance {
 public:
@@ -242,62 +244,190 @@ protected:
 tjs_uint32 tTJSNC_GamepadStub::ClassID = static_cast<tjs_uint32>(-1);
 tjs_uint32 tTJSNC_gfxFireStub::ClassID = static_cast<tjs_uint32>(-1);
 
+static ttstr TVPGetNormalizedPluginName(const ttstr &name) {
+    ttstr shortName = TVPExtractStorageName(name);
+    shortName.ToLowerCase();
+    return shortName;
+}
+
+static bool TVPIsProxyPluginName(const ttstr &name) {
+    return name == TJS_W("proxyfs.dll") || name == TJS_W("yuzuex.dll");
+}
+
+static bool TVPHasRegisteredProxyPluginAlias() {
+    return TVPRegisteredPlugins.find(TJS_W("proxyfs.dll")) !=
+               TVPRegisteredPlugins.end() ||
+           TVPRegisteredPlugins.find(TJS_W("yuzuex.dll")) !=
+               TVPRegisteredPlugins.end();
+}
+
+static bool TVPQueryProxyValue(const ttstr &name, tTJSVariant &value) {
+    if(!s_ProxyStorageMap)
+        return false;
+
+    ttstr key = TVPExtractStorageName(name);
+    if(key.IsEmpty())
+        return false;
+
+    key.ToLowerCase();
+
+    return TJS_SUCCEEDED(s_ProxyStorageMap->PropGet(
+        TJS_MEMBERMUSTEXIST, key.c_str(), nullptr, &value, s_ProxyStorageMap));
+}
+
+static bool TVPLookupProxyTarget(const ttstr &name, ttstr *resolved) {
+    tTJSVariant value;
+    if(!TVPQueryProxyValue(name, value) || value.Type() != tvtString)
+        return false;
+
+    if(resolved) {
+        *resolved = value.GetString();
+        return !resolved->IsEmpty();
+    }
+
+    return true;
+}
+
+class tTVPProxyObjectLister : public tTJSDispatch {
+    iTVPStorageLister *Lister;
+    ttstr RequestedPath;
+
+public:
+    tTVPProxyObjectLister(const ttstr &requestedPath, iTVPStorageLister *lister) :
+        Lister(lister), RequestedPath(requestedPath) {}
+
+    tjs_error FuncCall(tjs_uint32, const tjs_char *, tjs_uint32 *,
+                       tTJSVariant *result, tjs_int numparams,
+                       tTJSVariant **param, iTJSDispatch2 *) override {
+        if(numparams > 1 && !(param[1]->AsInteger() & TJS_HIDDENMEMBER)) {
+            ttstr memberName = param[0]->GetString();
+            if(TVPExtractStoragePath(memberName) == RequestedPath)
+                Lister->Add(TVPExtractStorageName(memberName));
+        }
+
+        if(result)
+            *result = true;
+
+        return TJS_S_OK;
+    }
+};
+
+struct tTVPProxyLocalNameTryData {
+    ttstr *Name;
+};
+
+static void TJS_USERENTRY TVPProxyLocalNameTry(void *data) {
+    auto *arg = static_cast<tTVPProxyLocalNameTryData *>(data);
+    TVPGetLocalName(*arg->Name);
+}
+
+static bool TJS_USERENTRY TVPProxyLocalNameCatch(void *data,
+                                                 const tTVPExceptionDesc &) {
+    auto *arg = static_cast<tTVPProxyLocalNameTryData *>(data);
+    arg->Name->Clear();
+    return false;
+}
+
 class tTVPProxyStorageMedia : public iTVPStorageMedia {
     tjs_uint RefCount = 1;
-
-    ttstr ResolveProxy(const ttstr &name) {
-        if(!s_ProxyStorageMap) return ttstr();
-        tjs_int lastSlash = -1;
-        const tjs_char *p = name.c_str();
-        for(tjs_int i = 0; p[i]; i++) {
-            if(p[i] == TJS_W('/')) lastSlash = i;
-        }
-        ttstr key = (lastSlash >= 0) ? ttstr(p + lastSlash + 1) : name;
-        tTJSVariant val;
-        if(s_ProxyStorageMap->PropGet(TJS_MEMBERMUSTEXIST, key.c_str(),
-            nullptr, &val, s_ProxyStorageMap) == TJS_S_OK) {
-            return val.GetString();
-        }
-        return ttstr();
-    }
 public:
     void AddRef() override { RefCount++; }
     void Release() override { if(RefCount == 1) delete this; else RefCount--; }
     void GetName(ttstr &name) override { name = TJS_W("proxy"); }
-    void NormalizeDomainName(ttstr &name) override {
-        tjs_char *p = name.Independ();
-        while(*p) { if(*p >= TJS_W('A') && *p <= TJS_W('Z')) *p += TJS_W('a') - TJS_W('A'); p++; }
-    }
-    void NormalizePathName(ttstr &name) override {
-        tjs_char *p = name.Independ();
-        while(*p) { if(*p == TJS_W('\\')) *p = TJS_W('/'); if(*p >= TJS_W('A') && *p <= TJS_W('Z')) *p += TJS_W('a') - TJS_W('A'); p++; }
-    }
+    void NormalizeDomainName(ttstr &) override {}
+    void NormalizePathName(ttstr &) override {}
     bool CheckExistentStorage(const ttstr &name) override {
-        ttstr resolved = ResolveProxy(name);
-        if(resolved.IsEmpty()) return false;
-        return TVPIsExistentStorage(resolved);
+        return TVPLookupProxyTarget(name, nullptr);
     }
     tTJSBinaryStream *Open(const ttstr &name, tjs_uint32 flags) override {
-        ttstr resolved = ResolveProxy(name);
-        if(resolved.IsEmpty()) return nullptr;
-        return TVPCreateStream(resolved, flags);
+        ttstr resolved;
+        if(!TVPLookupProxyTarget(name, &resolved)) {
+            TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+            return nullptr;
+        }
+
+        IStream *stream = nullptr;
+        tTJSBinaryStream *adapter = nullptr;
+
+        try {
+            stream = TVPCreateIStream(resolved, flags);
+            if(stream)
+                adapter = TVPCreateBinaryStreamAdapter(stream);
+        } catch(...) {
+            if(stream)
+                stream->Release();
+            TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+            return nullptr;
+        }
+
+        if(stream)
+            stream->Release();
+
+        if(adapter)
+            return adapter;
+
+        TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+        return nullptr;
     }
-    void GetListAt(const ttstr &, iTVPStorageLister *) override {}
-    void GetLocallyAccessibleName(ttstr &name) override { name.Clear(); }
+    void GetListAt(const ttstr &name, iTVPStorageLister *lister) override {
+        if(!s_ProxyStorageMap)
+            return;
+
+        tTJSVariantClosure closure(new tTVPProxyObjectLister(name, lister));
+        s_ProxyStorageMap->EnumMembers(TJS_IGNOREPROP, &closure,
+                                       s_ProxyStorageMap);
+        closure.Release();
+    }
+    void GetLocallyAccessibleName(ttstr &name) override {
+        ttstr resolved;
+        if(!TVPLookupProxyTarget(name, &resolved)) {
+            name.Clear();
+            return;
+        }
+
+        name = resolved;
+        tTVPProxyLocalNameTryData data{ &name };
+        TVPDoTryBlock(TVPProxyLocalNameTry, TVPProxyLocalNameCatch, nullptr,
+                      &data);
+    }
 };
 
-static void TVPRegisterProxyFsStub() {
+static bool TVPRegisterProxyFsStub() {
+    if(s_ProxyStorageMap && s_ProxyStorageMedia)
+        return true;
+
     iTJSDispatch2 *dict = TJSCreateDictionaryObject();
-    if(!dict) return;
+    if(!dict)
+        return false;
+
+    if(!TVPRegisterGlobalObject(TJS_W("ProxyStorageMap"), dict)) {
+        dict->Release();
+        return false;
+    }
+
     s_ProxyStorageMap = dict;
     s_ProxyStorageMap->AddRef();
-    TVPRegisterGlobalObject(TJS_W("ProxyStorageMap"), dict);
     dict->Release();
 
-    auto *media = new tTVPProxyStorageMedia();
-    TVPRegisterStorageMedia(media);
-    media->Release();
-    spdlog::info("Registered proxy storage media stub for missing proxyfs.dll");
+    s_ProxyStorageMedia = new tTVPProxyStorageMedia();
+    TVPRegisterStorageMedia(s_ProxyStorageMedia);
+
+    spdlog::info("Registered proxy storage media compatibility layer");
+    return true;
+}
+
+static void TVPUnregisterProxyFsStub() {
+    if(s_ProxyStorageMedia) {
+        TVPUnregisterStorageMedia(s_ProxyStorageMedia);
+        s_ProxyStorageMedia->Release();
+        s_ProxyStorageMedia = nullptr;
+    }
+
+    if(s_ProxyStorageMap) {
+        TVPRemoveGlobalObject(TJS_W("ProxyStorageMap"));
+        s_ProxyStorageMap->Release();
+        s_ProxyStorageMap = nullptr;
+    }
 }
 
 // gamepad.dll 未实现时注册 stub，避免 exgamepad.tjs 访问 GamepadPort 报错（逆向见：global["GamepadPort"]/["Gamepad"]，脚本用 SystemConfig.GamepadPort）
@@ -348,23 +478,33 @@ static void TVPRegisterGfxFireStub() {
 }
 
 void TVPLoadPlugin(const ttstr &name) {
+    ttstr normalizedShortName = TVPGetNormalizedPluginName(name);
+
     auto pluginName = name;
-    if(name == TJS_W("emoteplayer.dll"))
+    if(normalizedShortName == TJS_W("emoteplayer.dll"))
         pluginName = "motionplayer.dll";
 
-    if(TVPLoadInternalPlugin(pluginName)) {
+    const char *stub = nullptr;
+    bool loaded = TVPLoadInternalPlugin(pluginName);
+    if(!loaded && TVPIsProxyPluginName(normalizedShortName)) {
+        loaded = TVPRegisterProxyFsStub();
+        if(loaded) {
+            TVPRegisteredPlugins.insert(normalizedShortName);
+            stub = "ProxyStorageMap compatibility layer";
+        }
+    }
+
+    if(loaded) {
         spdlog::debug("Loading Plugin: {} Success", name.AsStdString());
-        PluginCallTracer::Instance().LogPluginLoad(name.AsStdString(), true, nullptr);
+        PluginCallTracer::Instance().LogPluginLoad(name.AsStdString(), true,
+                                                   stub);
     } else {
         spdlog::error("Loading Plugin: {} Failed", name.AsStdString());
-        const char *stub = nullptr;
-        if(name == TJS_W("proxyfs.dll")) {
-            TVPRegisterProxyFsStub();
-            stub = "ProxyStorageMap stub";
-        } else if(name == TJS_W("gamepad.dll")) {
+        if(normalizedShortName == TJS_W("gamepad.dll")) {
             TVPRegisterGamepadStub();
             stub = "GamepadStub";
-        } else if(name == TJS_W("gfxEffect.dll") || name == TJS_W("gfxfire.dll") || name == TJS_W("gfxFire.dll")) {
+        } else if(normalizedShortName == TJS_W("gfxeffect.dll") ||
+                  normalizedShortName == TJS_W("gfxfire.dll")) {
             TVPRegisterGfxFireStub();
             stub = "gfxFireStub";
         }
@@ -374,6 +514,14 @@ void TVPLoadPlugin(const ttstr &name) {
 
 //---------------------------------------------------------------------------
 bool TVPUnloadPlugin(const ttstr &name) {
+    ttstr normalizedShortName = TVPGetNormalizedPluginName(name);
+    if(TVPIsProxyPluginName(normalizedShortName)) {
+        TVPRegisteredPlugins.erase(normalizedShortName);
+        if(!TVPHasRegisteredProxyPluginAlias())
+            TVPUnregisterProxyFsStub();
+        return true;
+    }
+
     // unload plugin
     return true;
 }


### PR DESCRIPTION
# `yuzuex.dll` / `proxyfs.dll` 移植说明

> [!WARNING]
> 该内容使用 ChatGPT 5.4 & IDA Pro MCP逆向还原，未经验证，仅作为参考可以等待测试有效后再合入

## 概述

本文档总结了：

- 原始闭源 DLL 的功能
- `AetherKiri` 中已经实现的内容
- 当前仍然只是近似实现、尚未完全一致的部分

在 IDA Pro MCP 中分析的目标 DLL 当前文件名为 `yuzuex.dll`。  
其 PE/模块标识表明，它很可能最初是以 `proxyfs.dll` 的名称发布的。

## 逆向得到的 DLL 行为

### 高层角色

该 DLL 是一个小型 krkr2 插件。它并不实现完整的独立文件系统。  
其主要作用是注册一个名为 `proxy` 的 storage media，并暴露一个全局 TJS 字典 `ProxyStorageMap`。

插件导出：

- `V2Link`
- `V2Unlink`

`V2Link` 会保存 krkr2 的导出解析器并注册 storage media。  
`V2Unlink` 在安全时注销该 storage media。

### 核心对象与注册

插件会创建一个 `ProxyStorage` 对象，并通过以下方式注册：

- `TVPRegisterStorageMedia(iTVPStorageMedia *)`

同时还会创建并注册：

- 全局对象 `ProxyStorageMap`

`GetName()` 返回的 storage media 名称为：

- `proxy`

### `ProxyStorage` 的主要行为

基于 IDA MCP 分析，原始 DLL 实现了以下行为：

- `CheckExistentStorage`
  - 检查 `ProxyStorageMap` 中是否存在字符串映射
  - 似乎不会验证最终目标 storage 是否在磁盘上存在

- `Open`
  - 从 `ProxyStorageMap` 解析 proxy key
  - 调用 `TVPCreateIStream(resolved, flags)`
  - 使用 `TVPCreateBinaryStreamAdapter` 进行封装
  - 失败时抛出 `cannot open proxyfile:%1`

- `GetListAt`
  - 枚举与请求路径相关的字典成员
  - 原始逻辑使用一个辅助对象（`DictMemberGetCaller`）以及成员枚举回调路径

- `GetLocallyAccessibleName`
  - 解析映射目标
  - 使用一个安全封装调用 `TVPGetLocalName`
  - 内部使用 `TVPDoTryBlock`

### 其他观察到的细节

- DLL 动态解析大量 krkr2 导出函数，而不是直接导入
- 行为保持轻量且面向宿主：
  - 注册/注销 storage media
  - 注册/移除全局对象
  - 打开流
  - 枚举成员
  - 本地路径转换

## `AetherKiri` 中已完成的工作

所有实现工作位于：

- [PluginImpl.cpp](cpp/core/plugin/PluginImpl.cpp)

### 已实现的兼容层

此前 `AetherKiri` 中的 `proxyfs` fallback stub 已被升级为一个可用的兼容层。

实现的变更包括：

- 同时支持两种插件身份：
  - `proxyfs.dll`
  - `yuzuex.dll`

- 注册真实的 `proxy` storage media，而非占位实现

- 创建并注册全局对象：
  - `ProxyStorageMap`

- 实现 proxy media 的 `iTVPStorageMedia` 方法：
  - `GetName`
  - `CheckExistentStorage`
  - `Open`
  - `GetListAt`
  - `GetLocallyAccessibleName`

- 添加卸载清理：
  - 注销 storage media
  - 移除 `ProxyStorageMap`
  - 释放持有对象

### 加载行为修复

插件 fallback 匹配逻辑也已修复。

在此前版本中，fallback 比较使用的是原始插件输入（可能包含完整路径），因此会漏匹配：

- `proxyfs.dll`
- `yuzuex.dll`
- 其他基于文件名的 fallback

现在匹配基于 `TVPExtractStorageName(name)` 并转换为小写进行。

## 当前实现行为

### Proxy key 查找

当前实现：

- 从请求的 proxy 路径中提取最终 storage 名称
- 转为小写
- 查询 `ProxyStorageMap`
- 仅将字符串值视为有效目标

### `CheckExistentStorage`

当前行为更接近逆向得到的 DLL：

- 当存在字符串映射时返回成功
- 不要求映射目标必须是实际存在的本地文件

### `Open`

当前行为：

- 从 `ProxyStorageMap` 解析目标字符串
- 调用 `TVPCreateIStream`
- 使用 `TVPCreateBinaryStreamAdapter` 包装
- 失败时抛出 `cannot open proxyfile:%1`

相比之前的 stub 实现，这已经更加接近原始 DLL。

### `GetListAt`

当前行为：

- 枚举 `ProxyStorageMap` 的成员
- 过滤 storage 路径前缀匹配请求路径的条目
- 将 basename 返回给 lister

该部分是在再次通过 IDA MCP 检查原 DLL 后更新的。

### `GetLocallyAccessibleName`

当前行为：

- 解析映射字符串目标
- 通过 `TVPDoTryBlock` 调用 `TVPGetLocalName`
- 若转换抛异常，则清空结果

该实现已与原 DLL 的安全路径转换策略对齐。

## 仍未保证完全 1:1 的部分

当前移植已不再是简单 stub，但仍未验证为完全语义等价实现。

存在的不确定性：

- `GetListAt`
  - 原 DLL 使用专用辅助对象和精确回调路径
  - 当前实现旨在匹配行为，但尚未与真实游戏脚本运行对比

- proxy key/path 规则
  - 主体逻辑已与观察一致
  - 对于复杂嵌套路径的边界情况仍需验证

- 卸载/生命周期边界行为
  - 已实现基础清理
  - 多次 link/unlink 在真实游戏启动/关闭流程中的表现仍需测试

## 验证状态

已完成：

- 对原 DLL 的 IDA MCP 逆向分析
- 在 `AetherKiri` 中实现
- `git diff --check` 通过

当前环境未完成：

- 使用真实游戏脚本进行运行验证

## 建议的后续步骤

1. 在完整工具链环境中构建 `AetherKiri`
2. 编写最小 TJS 验证脚本：
   - `Plugins.link("yuzuex.dll")`
   - 验证 `ProxyStorageMap`
   - 将一个 key 映射到已知 storage 目标
   - 通过 `proxy://...` 读取
3. 测试两种名称：
   - `yuzuex.dll`
   - `proxyfs.dll`
4. 在依赖该插件的真实游戏中对比 `GetListAt` 行为