### PR TITLE
feat(mock-toggle): add Flutter switch to control all runtime mock byp…

### DIFF
--- a/apps/flutter_app/lib/constants/prefs_keys.dart
+++ b/apps/flutter_app/lib/constants/prefs_keys.dart
@@ -17,6 +17,7 @@ class PrefsKeys {
   static const String themeMode = 'krkr2_theme_mode';
   static const String forceLandscape = 'krkr2_force_landscape';
   static const String pluginTrace = 'krkr2_plugin_trace';
+  static const String mockEnabled = 'krkr2_mock_enabled';
 
   /// Pending play session: JSON { "path": "...", "startTime": "ISO8601" }. Cleared on normal exit or applied on next launch.
   static const String pendingPlaySession = 'krkr2_pending_play_session';
@@ -36,6 +37,7 @@ class PrefsKeys {
   static const String optionArchiveCacheCount = 'archive_cache_count';
   static const String optionAutoPathCacheCount = 'autopath_cache_count';
   static const String optionPluginTrace = 'plugin_trace';
+  static const String optionMockEnabled = 'mock_enabled';
 
   // ── Engine option values ────────────────────────────────────────
   static const String angleBackendGles = 'gles';

--- a/apps/flutter_app/lib/l10n/app_en.arb
+++ b/apps/flutter_app/lib/l10n/app_en.arb
@@ -97,6 +97,8 @@
   "forceLandscapeDesc": "Force landscape orientation when running games (recommended for phones)",
   "pluginTrace": "Plugin Trace Log",
   "pluginTraceDesc": "Record all plugin native calls to plugin_trace.log for debugging",
+  "mockBypass": "Mock Bypass",
+  "mockBypassDesc": "Suppress errors from missing plugins by returning mock objects. Disable to expose real errors for debugging.",
   "targetFrameRate": "Target Frame Rate",
   "targetFrameRateDesc": "Maximum rendering frequency when limit is enabled",
   "fpsLabel": "{fps} FPS",

--- a/apps/flutter_app/lib/l10n/app_ja.arb
+++ b/apps/flutter_app/lib/l10n/app_ja.arb
@@ -82,6 +82,8 @@
   "forceLandscapeDesc": "ゲーム実行時に横向き表示を強制します（スマートフォン推奨）",
   "pluginTrace": "プラグインコールトレース",
   "pluginTraceDesc": "すべてのプラグインネイティブ呼び出しを plugin_trace.log に記録します",
+  "mockBypass": "Mock バイパス",
+  "mockBypassDesc": "未実装プラグインのエラーを mock オブジェクトで回避します。無効化すると実際のエラーが表示されます。",
   "targetFrameRate": "目標フレームレート",
   "targetFrameRateDesc": "制限有効時の最大描画頻度",
   "fpsLabel": "{fps} FPS",

--- a/apps/flutter_app/lib/l10n/app_localizations.dart
+++ b/apps/flutter_app/lib/l10n/app_localizations.dart
@@ -490,6 +490,30 @@ abstract class AppLocalizations {
   /// **'Force landscape orientation when running games (recommended for phones)'**
   String get forceLandscapeDesc;
 
+  /// No description provided for @pluginTrace.
+  ///
+  /// In en, this message translates to:
+  /// **'Plugin Trace Log'**
+  String get pluginTrace;
+
+  /// No description provided for @pluginTraceDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Record all plugin native calls to plugin_trace.log for debugging'**
+  String get pluginTraceDesc;
+
+  /// No description provided for @mockBypass.
+  ///
+  /// In en, this message translates to:
+  /// **'Mock Bypass'**
+  String get mockBypass;
+
+  /// No description provided for @mockBypassDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Suppress errors from missing plugins by returning mock objects. Disable to expose real errors for debugging.'**
+  String get mockBypassDesc;
+
   /// No description provided for @targetFrameRate.
   ///
   /// In en, this message translates to:

--- a/apps/flutter_app/lib/l10n/app_localizations_en.dart
+++ b/apps/flutter_app/lib/l10n/app_localizations_en.dart
@@ -223,6 +223,20 @@ class AppLocalizationsEn extends AppLocalizations {
       'Force landscape orientation when running games (recommended for phones)';
 
   @override
+  String get pluginTrace => 'Plugin Trace Log';
+
+  @override
+  String get pluginTraceDesc =>
+      'Record all plugin native calls to plugin_trace.log for debugging';
+
+  @override
+  String get mockBypass => 'Mock Bypass';
+
+  @override
+  String get mockBypassDesc =>
+      'Suppress errors from missing plugins by returning mock objects. Disable to expose real errors for debugging.';
+
+  @override
   String get targetFrameRate => 'Target Frame Rate';
 
   @override

--- a/apps/flutter_app/lib/l10n/app_localizations_ja.dart
+++ b/apps/flutter_app/lib/l10n/app_localizations_ja.dart
@@ -215,6 +215,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get forceLandscapeDesc => 'ゲーム実行時に横向き表示を強制します（スマートフォン推奨）';
 
   @override
+  String get pluginTrace => 'プラグインコールトレース';
+
+  @override
+  String get pluginTraceDesc => 'すべてのプラグインネイティブ呼び出しを plugin_trace.log に記録します';
+
+  @override
+  String get mockBypass => 'Mock バイパス';
+
+  @override
+  String get mockBypassDesc => '未実装プラグインのエラーを mock オブジェクトで回避します。無効化すると実際のエラーが表示されます。';
+
+  @override
   String get targetFrameRate => '目標フレームレート';
 
   @override

--- a/apps/flutter_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/flutter_app/lib/l10n/app_localizations_zh.dart
@@ -213,6 +213,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get forceLandscapeDesc => '游戏运行时强制横屏显示（手机推荐开启）';
 
   @override
+  String get pluginTrace => '插件调用追踪';
+
+  @override
+  String get pluginTraceDesc => '将所有插件原生调用记录到 plugin_trace.log 用于调试';
+
+  @override
+  String get mockBypass => 'Mock 绕过';
+
+  @override
+  String get mockBypassDesc => '为缺失插件返回 mock 对象以抑制错误。关闭可暴露真实错误用于调试。';
+
+  @override
   String get targetFrameRate => '目标帧率';
 
   @override

--- a/apps/flutter_app/lib/l10n/app_zh.arb
+++ b/apps/flutter_app/lib/l10n/app_zh.arb
@@ -82,6 +82,8 @@
   "forceLandscapeDesc": "游戏运行时强制横屏显示（手机推荐开启）",
   "pluginTrace": "插件调用追踪",
   "pluginTraceDesc": "将所有插件原生调用记录到 plugin_trace.log 用于调试",
+  "mockBypass": "Mock 绕过",
+  "mockBypassDesc": "为缺失插件返回 mock 对象以抑制错误。关闭可暴露真实错误用于调试。",
   "targetFrameRate": "目标帧率",
   "targetFrameRateDesc": "启用限制时的最大渲染频率",
   "fpsLabel": "{fps} FPS",

--- a/apps/flutter_app/lib/pages/game_page.dart
+++ b/apps/flutter_app/lib/pages/game_page.dart
@@ -24,6 +24,7 @@ class GamePage extends StatefulWidget {
     this.engineBridgeBuilder = createEngineBridge,
     this.forceLandscape = true,
     this.pluginTrace = false,
+    this.mockEnabled = true,
     this.gameManager,
   });
 
@@ -32,6 +33,7 @@ class GamePage extends StatefulWidget {
   final EngineBridgeBuilder engineBridgeBuilder;
   final bool forceLandscape;
   final bool pluginTrace;
+  final bool mockEnabled;
 
   /// If set, play duration is recorded when leaving this page.
   final GameManager? gameManager;
@@ -403,6 +405,13 @@ class _GamePageState extends State<GamePage> with WidgetsBindingObserver {
     }
 
     await _applyMemoryGovernorOptions();
+
+    // Set mock_enabled before plugin_trace — disabling mock affects trace behavior.
+    _log('Setting mock_enabled=${widget.mockEnabled}');
+    await _bridge.engineSetOption(
+      key: PrefsKeys.optionMockEnabled,
+      value: widget.mockEnabled ? '1' : '0',
+    );
 
     if (widget.pluginTrace) {
       _log('Enabling plugin_trace');

--- a/apps/flutter_app/lib/pages/home_page.dart
+++ b/apps/flutter_app/lib/pages/home_page.dart
@@ -45,6 +45,7 @@ class _HomePageState extends State<HomePage> {
   String _angleBackend = PrefsKeys.angleBackendGles;
   bool _forceLandscape = true;
   bool _pluginTrace = false;
+  bool _mockEnabled = true;
 
   String? _resolveBuiltInDylibPath() {
     if (Platform.isIOS) {
@@ -102,6 +103,7 @@ class _HomePageState extends State<HomePage> {
     _angleBackend = prefs.getString(PrefsKeys.angleBackend) ?? PrefsKeys.angleBackendGles;
     _forceLandscape = prefs.getBool(PrefsKeys.forceLandscape) ?? true;
     _pluginTrace = prefs.getBool(PrefsKeys.pluginTrace) ?? false;
+    _mockEnabled = prefs.getBool(PrefsKeys.mockEnabled) ?? true;
     await _gameManager.load();
     await _gameManager.applyPendingPlaySession();
 
@@ -556,6 +558,7 @@ class _HomePageState extends State<HomePage> {
           ffiLibraryPath: dylibPath,
           forceLandscape: _forceLandscape,
           pluginTrace: _pluginTrace,
+          mockEnabled: _mockEnabled,
           gameManager: _gameManager,
         ),
       ),
@@ -738,6 +741,7 @@ class _HomePageState extends State<HomePage> {
           angleBackend: _angleBackend,
           forceLandscape: _forceLandscape,
           pluginTrace: _pluginTrace,
+          mockEnabled: _mockEnabled,
         ),
       ),
     );
@@ -755,6 +759,7 @@ class _HomePageState extends State<HomePage> {
         _angleBackend = result.angleBackend;
         _forceLandscape = result.forceLandscape;
         _pluginTrace = result.pluginTrace;
+        _mockEnabled = result.mockEnabled;
       });
     }
   }

--- a/apps/flutter_app/lib/pages/settings_page.dart
+++ b/apps/flutter_app/lib/pages/settings_page.dart
@@ -27,6 +27,7 @@ class SettingsPage extends StatefulWidget {
     required this.angleBackend,
     required this.forceLandscape,
     required this.pluginTrace,
+    required this.mockEnabled,
   });
 
   final EngineMode engineMode;
@@ -40,6 +41,7 @@ class SettingsPage extends StatefulWidget {
   final String angleBackend;
   final bool forceLandscape;
   final bool pluginTrace;
+  final bool mockEnabled;
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -57,6 +59,7 @@ class SettingsResult {
     required this.angleBackend,
     required this.forceLandscape,
     required this.pluginTrace,
+    required this.mockEnabled,
   });
 
   final EngineMode engineMode;
@@ -68,6 +71,7 @@ class SettingsResult {
   final String angleBackend;
   final bool forceLandscape;
   final bool pluginTrace;
+  final bool mockEnabled;
 }
 
 class _SettingsPageState extends State<SettingsPage> {
@@ -80,6 +84,7 @@ class _SettingsPageState extends State<SettingsPage> {
   String _angleBackend = PrefsKeys.angleBackendGles;
   late bool _forceLandscape;
   late bool _pluginTrace;
+  late bool _mockEnabled;
   String _localeCode = 'system';
   String _themeModeCode = 'dark';
   bool _dirty = false;
@@ -96,6 +101,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _angleBackend = widget.angleBackend;
     _forceLandscape = widget.forceLandscape;
     _pluginTrace = widget.pluginTrace;
+    _mockEnabled = widget.mockEnabled;
     _loadLocale();
     _loadThemeMode();
   }
@@ -136,6 +142,7 @@ class _SettingsPageState extends State<SettingsPage> {
     await prefs.setString(PrefsKeys.angleBackend, _angleBackend);
     await prefs.setBool(PrefsKeys.forceLandscape, _forceLandscape);
     await prefs.setBool(PrefsKeys.pluginTrace, _pluginTrace);
+    await prefs.setBool(PrefsKeys.mockEnabled, _mockEnabled);
 
     if (mounted) {
       Navigator.pop(
@@ -150,6 +157,7 @@ class _SettingsPageState extends State<SettingsPage> {
           angleBackend: _angleBackend,
           forceLandscape: _forceLandscape,
           pluginTrace: _pluginTrace,
+          mockEnabled: _mockEnabled,
         ),
       );
     }
@@ -472,6 +480,16 @@ class _SettingsPageState extends State<SettingsPage> {
                     value: _pluginTrace,
                     onChanged: (value) {
                       setState(() => _pluginTrace = value);
+                      _markDirty();
+                    },
+                  ),
+                  const Divider(height: 1),
+                  SwitchListTile(
+                    title: Text(l10n.mockBypass),
+                    subtitle: Text(l10n.mockBypassDesc),
+                    value: _mockEnabled,
+                    onChanged: (value) {
+                      setState(() => _mockEnabled = value);
                       _markDirty();
                     },
                   ),

--- a/bridge/engine_api/include/engine_options.h
+++ b/bridge/engine_api/include/engine_options.h
@@ -46,6 +46,11 @@
 /** Enable plugin call tracing to plugin_trace.log ("0"/"1"). */
 #define ENGINE_OPTION_PLUGIN_TRACE "plugin_trace"
 
+/** Enable/disable runtime mock bypass ("0"/"1", default "1").
+ *  When disabled, missing plugins/classes cause real errors instead of
+ *  being silently absorbed by mock objects. Useful for debugging. */
+#define ENGINE_OPTION_MOCK_ENABLED "mock_enabled"
+
 /* ── ANGLE Backend Values ───────────────────────────────────────── */
 
 /** Use ANGLE's OpenGL ES backend (default). */

--- a/bridge/engine_api/src/engine_api.cpp
+++ b/bridge/engine_api/src/engine_api.cpp
@@ -52,6 +52,9 @@ void krkr_GetSurfaceDimensions(uint32_t*, uint32_t*);
 #include "engine_options.h"
 #include "PluginCallTracer.hpp"
 
+// Mock bypass toggle (defined in tjsVariant.cpp, namespace TJS)
+namespace TJS { void TVPSetMockEnabled(bool enabled); }
+
 int TVPDrawSceneOnce(int interval);
 
 extern "C" void TVPRegisterKrkrGLESPluginAnchor();
@@ -1479,6 +1482,18 @@ engine_result_t engine_set_option(engine_handle_t handle,
     PluginCallTracer::Instance().SetEnabled(enabled);
     spdlog::info("engine_set_option: plugin_trace={}", enabled);
     // Also store in command line so TVPLoadInternalPlugins can read it
+    TVPSetCommandLine(ttstr(option->key_utf8).c_str(), ttstr(option->value_utf8));
+    ClearHandleErrorLocked(impl);
+    SetThreadError(nullptr);
+    return ENGINE_RESULT_OK;
+  }
+
+  // Handle mock_enabled option: enable/disable runtime mock bypass
+  if (key == ENGINE_OPTION_MOCK_ENABLED) {
+    const std::string v(option->value_utf8);
+    const bool enabled = (v == "1" || v == "true");
+    TJS::TVPSetMockEnabled(enabled);
+    spdlog::info("engine_set_option: mock_enabled={}", enabled);
     TVPSetCommandLine(ttstr(option->key_utf8).c_str(), ttstr(option->value_utf8));
     ClearHandleErrorLocked(impl);
     SetThreadError(nullptr);

--- a/cpp/core/plugin/PluginImpl.cpp
+++ b/cpp/core/plugin/PluginImpl.cpp
@@ -358,15 +358,17 @@ void TVPLoadPlugin(const ttstr &name) {
     } else {
         spdlog::error("Loading Plugin: {} Failed", name.AsStdString());
         const char *stub = nullptr;
-        if(name == TJS_W("proxyfs.dll")) {
-            TVPRegisterProxyFsStub();
-            stub = "ProxyStorageMap stub";
-        } else if(name == TJS_W("gamepad.dll")) {
-            TVPRegisterGamepadStub();
-            stub = "GamepadStub";
-        } else if(name == TJS_W("gfxEffect.dll") || name == TJS_W("gfxfire.dll") || name == TJS_W("gfxFire.dll")) {
-            TVPRegisterGfxFireStub();
-            stub = "gfxFireStub";
+        if(TJS::TVPIsMockEnabled()) {
+            if(name == TJS_W("proxyfs.dll")) {
+                TVPRegisterProxyFsStub();
+                stub = "ProxyStorageMap stub";
+            } else if(name == TJS_W("gamepad.dll")) {
+                TVPRegisterGamepadStub();
+                stub = "GamepadStub";
+            } else if(name == TJS_W("gfxEffect.dll") || name == TJS_W("gfxfire.dll") || name == TJS_W("gfxFire.dll")) {
+                TVPRegisterGfxFireStub();
+                stub = "gfxFireStub";
+            }
         }
         PluginCallTracer::Instance().LogPluginLoad(name.AsStdString(), false, stub);
     }

--- a/cpp/core/plugin/PluginImpl.cpp
+++ b/cpp/core/plugin/PluginImpl.cpp
@@ -29,6 +29,7 @@
 #include "tjs.h"
 #include "tjsConfig.h"
 #include "ncbind.hpp"
+#include "combase.h"
 
 #ifdef TVP_SUPPORT_KPI
 #include "kmp_pi.h"
@@ -47,6 +48,7 @@ bool TVPLoadInternalPlugin(const ttstr &_name);
 bool TVPRegisterGlobalObject(const tjs_char *name, iTJSDispatch2 *dsp);
 
 static iTJSDispatch2 *s_ProxyStorageMap = nullptr;
+static iTVPStorageMedia *s_ProxyStorageMedia = nullptr;
 
 class tTJSNI_GamepadStub : public tTJSNativeInstance {
 public:
@@ -242,62 +244,190 @@ protected:
 tjs_uint32 tTJSNC_GamepadStub::ClassID = static_cast<tjs_uint32>(-1);
 tjs_uint32 tTJSNC_gfxFireStub::ClassID = static_cast<tjs_uint32>(-1);
 
+static ttstr TVPGetNormalizedPluginName(const ttstr &name) {
+    ttstr shortName = TVPExtractStorageName(name);
+    shortName.ToLowerCase();
+    return shortName;
+}
+
+static bool TVPIsProxyPluginName(const ttstr &name) {
+    return name == TJS_W("proxyfs.dll") || name == TJS_W("yuzuex.dll");
+}
+
+static bool TVPHasRegisteredProxyPluginAlias() {
+    return TVPRegisteredPlugins.find(TJS_W("proxyfs.dll")) !=
+               TVPRegisteredPlugins.end() ||
+           TVPRegisteredPlugins.find(TJS_W("yuzuex.dll")) !=
+               TVPRegisteredPlugins.end();
+}
+
+static bool TVPQueryProxyValue(const ttstr &name, tTJSVariant &value) {
+    if(!s_ProxyStorageMap)
+        return false;
+
+    ttstr key = TVPExtractStorageName(name);
+    if(key.IsEmpty())
+        return false;
+
+    key.ToLowerCase();
+
+    return TJS_SUCCEEDED(s_ProxyStorageMap->PropGet(
+        TJS_MEMBERMUSTEXIST, key.c_str(), nullptr, &value, s_ProxyStorageMap));
+}
+
+static bool TVPLookupProxyTarget(const ttstr &name, ttstr *resolved) {
+    tTJSVariant value;
+    if(!TVPQueryProxyValue(name, value) || value.Type() != tvtString)
+        return false;
+
+    if(resolved) {
+        *resolved = value.GetString();
+        return !resolved->IsEmpty();
+    }
+
+    return true;
+}
+
+class tTVPProxyObjectLister : public tTJSDispatch {
+    iTVPStorageLister *Lister;
+    ttstr RequestedPath;
+
+public:
+    tTVPProxyObjectLister(const ttstr &requestedPath, iTVPStorageLister *lister) :
+        Lister(lister), RequestedPath(requestedPath) {}
+
+    tjs_error FuncCall(tjs_uint32, const tjs_char *, tjs_uint32 *,
+                       tTJSVariant *result, tjs_int numparams,
+                       tTJSVariant **param, iTJSDispatch2 *) override {
+        if(numparams > 1 && !(param[1]->AsInteger() & TJS_HIDDENMEMBER)) {
+            ttstr memberName = param[0]->GetString();
+            if(TVPExtractStoragePath(memberName) == RequestedPath)
+                Lister->Add(TVPExtractStorageName(memberName));
+        }
+
+        if(result)
+            *result = true;
+
+        return TJS_S_OK;
+    }
+};
+
+struct tTVPProxyLocalNameTryData {
+    ttstr *Name;
+};
+
+static void TJS_USERENTRY TVPProxyLocalNameTry(void *data) {
+    auto *arg = static_cast<tTVPProxyLocalNameTryData *>(data);
+    TVPGetLocalName(*arg->Name);
+}
+
+static bool TJS_USERENTRY TVPProxyLocalNameCatch(void *data,
+                                                 const tTVPExceptionDesc &) {
+    auto *arg = static_cast<tTVPProxyLocalNameTryData *>(data);
+    arg->Name->Clear();
+    return false;
+}
+
 class tTVPProxyStorageMedia : public iTVPStorageMedia {
     tjs_uint RefCount = 1;
-
-    ttstr ResolveProxy(const ttstr &name) {
-        if(!s_ProxyStorageMap) return ttstr();
-        tjs_int lastSlash = -1;
-        const tjs_char *p = name.c_str();
-        for(tjs_int i = 0; p[i]; i++) {
-            if(p[i] == TJS_W('/')) lastSlash = i;
-        }
-        ttstr key = (lastSlash >= 0) ? ttstr(p + lastSlash + 1) : name;
-        tTJSVariant val;
-        if(s_ProxyStorageMap->PropGet(TJS_MEMBERMUSTEXIST, key.c_str(),
-            nullptr, &val, s_ProxyStorageMap) == TJS_S_OK) {
-            return val.GetString();
-        }
-        return ttstr();
-    }
 public:
     void AddRef() override { RefCount++; }
     void Release() override { if(RefCount == 1) delete this; else RefCount--; }
     void GetName(ttstr &name) override { name = TJS_W("proxy"); }
-    void NormalizeDomainName(ttstr &name) override {
-        tjs_char *p = name.Independ();
-        while(*p) { if(*p >= TJS_W('A') && *p <= TJS_W('Z')) *p += TJS_W('a') - TJS_W('A'); p++; }
-    }
-    void NormalizePathName(ttstr &name) override {
-        tjs_char *p = name.Independ();
-        while(*p) { if(*p == TJS_W('\\')) *p = TJS_W('/'); if(*p >= TJS_W('A') && *p <= TJS_W('Z')) *p += TJS_W('a') - TJS_W('A'); p++; }
-    }
+    void NormalizeDomainName(ttstr &) override {}
+    void NormalizePathName(ttstr &) override {}
     bool CheckExistentStorage(const ttstr &name) override {
-        ttstr resolved = ResolveProxy(name);
-        if(resolved.IsEmpty()) return false;
-        return TVPIsExistentStorage(resolved);
+        return TVPLookupProxyTarget(name, nullptr);
     }
     tTJSBinaryStream *Open(const ttstr &name, tjs_uint32 flags) override {
-        ttstr resolved = ResolveProxy(name);
-        if(resolved.IsEmpty()) return nullptr;
-        return TVPCreateStream(resolved, flags);
+        ttstr resolved;
+        if(!TVPLookupProxyTarget(name, &resolved)) {
+            TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+            return nullptr;
+        }
+
+        IStream *stream = nullptr;
+        tTJSBinaryStream *adapter = nullptr;
+
+        try {
+            stream = TVPCreateIStream(resolved, flags);
+            if(stream)
+                adapter = TVPCreateBinaryStreamAdapter(stream);
+        } catch(...) {
+            if(stream)
+                stream->Release();
+            TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+            return nullptr;
+        }
+
+        if(stream)
+            stream->Release();
+
+        if(adapter)
+            return adapter;
+
+        TVPThrowExceptionMessage(TJS_W("cannot open proxyfile:%1"), name);
+        return nullptr;
     }
-    void GetListAt(const ttstr &, iTVPStorageLister *) override {}
-    void GetLocallyAccessibleName(ttstr &name) override { name.Clear(); }
+    void GetListAt(const ttstr &name, iTVPStorageLister *lister) override {
+        if(!s_ProxyStorageMap)
+            return;
+
+        tTJSVariantClosure closure(new tTVPProxyObjectLister(name, lister));
+        s_ProxyStorageMap->EnumMembers(TJS_IGNOREPROP, &closure,
+                                       s_ProxyStorageMap);
+        closure.Release();
+    }
+    void GetLocallyAccessibleName(ttstr &name) override {
+        ttstr resolved;
+        if(!TVPLookupProxyTarget(name, &resolved)) {
+            name.Clear();
+            return;
+        }
+
+        name = resolved;
+        tTVPProxyLocalNameTryData data{ &name };
+        TVPDoTryBlock(TVPProxyLocalNameTry, TVPProxyLocalNameCatch, nullptr,
+                      &data);
+    }
 };
 
-static void TVPRegisterProxyFsStub() {
+static bool TVPRegisterProxyFsStub() {
+    if(s_ProxyStorageMap && s_ProxyStorageMedia)
+        return true;
+
     iTJSDispatch2 *dict = TJSCreateDictionaryObject();
-    if(!dict) return;
+    if(!dict)
+        return false;
+
+    if(!TVPRegisterGlobalObject(TJS_W("ProxyStorageMap"), dict)) {
+        dict->Release();
+        return false;
+    }
+
     s_ProxyStorageMap = dict;
     s_ProxyStorageMap->AddRef();
-    TVPRegisterGlobalObject(TJS_W("ProxyStorageMap"), dict);
     dict->Release();
 
-    auto *media = new tTVPProxyStorageMedia();
-    TVPRegisterStorageMedia(media);
-    media->Release();
-    spdlog::info("Registered proxy storage media stub for missing proxyfs.dll");
+    s_ProxyStorageMedia = new tTVPProxyStorageMedia();
+    TVPRegisterStorageMedia(s_ProxyStorageMedia);
+
+    spdlog::info("Registered proxy storage media compatibility layer");
+    return true;
+}
+
+static void TVPUnregisterProxyFsStub() {
+    if(s_ProxyStorageMedia) {
+        TVPUnregisterStorageMedia(s_ProxyStorageMedia);
+        s_ProxyStorageMedia->Release();
+        s_ProxyStorageMedia = nullptr;
+    }
+
+    if(s_ProxyStorageMap) {
+        TVPRemoveGlobalObject(TJS_W("ProxyStorageMap"));
+        s_ProxyStorageMap->Release();
+        s_ProxyStorageMap = nullptr;
+    }
 }
 
 // gamepad.dll 未实现时注册 stub，避免 exgamepad.tjs 访问 GamepadPort 报错（逆向见：global["GamepadPort"]/["Gamepad"]，脚本用 SystemConfig.GamepadPort）
@@ -348,24 +478,35 @@ static void TVPRegisterGfxFireStub() {
 }
 
 void TVPLoadPlugin(const ttstr &name) {
+    ttstr normalizedShortName = TVPGetNormalizedPluginName(name);
+
     auto pluginName = name;
-    if(name == TJS_W("emoteplayer.dll"))
+    if(normalizedShortName == TJS_W("emoteplayer.dll"))
         pluginName = "motionplayer.dll";
 
-    if(TVPLoadInternalPlugin(pluginName)) {
+    const char *stub = nullptr;
+    bool loaded = TVPLoadInternalPlugin(pluginName);
+    if(!loaded && TVPIsProxyPluginName(normalizedShortName)) {
+        loaded = TVPRegisterProxyFsStub();
+        if(loaded) {
+            TVPRegisteredPlugins.insert(normalizedShortName);
+            stub = "ProxyStorageMap compatibility layer";
+        }
+    }
+
+    if(loaded) {
         spdlog::debug("Loading Plugin: {} Success", name.AsStdString());
-        PluginCallTracer::Instance().LogPluginLoad(name.AsStdString(), true, nullptr);
+        PluginCallTracer::Instance().LogPluginLoad(name.AsStdString(), true,
+                                                   stub);
     } else {
         spdlog::error("Loading Plugin: {} Failed", name.AsStdString());
         const char *stub = nullptr;
         if(TJS::TVPIsMockEnabled()) {
-            if(name == TJS_W("proxyfs.dll")) {
-                TVPRegisterProxyFsStub();
-                stub = "ProxyStorageMap stub";
-            } else if(name == TJS_W("gamepad.dll")) {
+            if(normalizedShortName == TJS_W("gamepad.dll")) {
                 TVPRegisterGamepadStub();
                 stub = "GamepadStub";
-            } else if(name == TJS_W("gfxEffect.dll") || name == TJS_W("gfxfire.dll") || name == TJS_W("gfxFire.dll")) {
+            } else if(normalizedShortName == TJS_W("gfxeffect.dll") ||
+                      normalizedShortName == TJS_W("gfxfire.dll")) {
                 TVPRegisterGfxFireStub();
                 stub = "gfxFireStub";
             }
@@ -376,6 +517,14 @@ void TVPLoadPlugin(const ttstr &name) {
 
 //---------------------------------------------------------------------------
 bool TVPUnloadPlugin(const ttstr &name) {
+    ttstr normalizedShortName = TVPGetNormalizedPluginName(name);
+    if(TVPIsProxyPluginName(normalizedShortName)) {
+        TVPRegisteredPlugins.erase(normalizedShortName);
+        if(!TVPHasRegisteredProxyPluginAlias())
+            TVPUnregisterProxyFsStub();
+        return true;
+    }
+
     // unload plugin
     return true;
 }

--- a/cpp/core/plugin/ncbind.hpp
+++ b/cpp/core/plugin/ncbind.hpp
@@ -1891,7 +1891,7 @@ struct ncbRegistNativeClass : public ncbRegistNativeClassBase {
 			// Wrapping is now done in tTJSNativeClass::RegisterNCM so that
 			// ALL registrations (including external plugins) are intercepted.
 			TJSNativeClassRegisterNCM(_classobj, name, dsp, _className, item->GetType(), item->GetFlags());
-			if (!TJS_strcmp(name, TJS_W("missing"))) {
+			if (!TJS_strcmp(name, TJS_W("missing")) && TJS::TVPIsMockEnabled()) {
 				tTJSVariant missingVar(TJS_W("missing"));
 				_classobj->ClassInstanceInfo(TJS_CII_SET_MISSING, 0, &missingVar);
 			}

--- a/cpp/core/tjs2/tjsArray.cpp
+++ b/cpp/core/tjs2/tjsArray.cpp
@@ -1072,7 +1072,7 @@ tjs_error tTJSArrayNI::Construct(tjs_int numparams, tTJSVariant **params,
 void tTJSArrayNI::Assign(iTJSDispatch2 *dsp) {
     // copy members from "dsp" to "Owner"
 
-    if(dsp == TJS::TVPGetGlobalMockObject()) {
+    if(TJS::TVPIsMockEnabled() && dsp == TJS::TVPGetGlobalMockObject()) {
         Items.clear();
         return;
     }
@@ -1279,7 +1279,7 @@ void tTJSArrayNI::SaveStructuredBinaryForObject(
 void tTJSArrayNI::AssignStructure(iTJSDispatch2 *dsp,
                                   std::vector<iTJSDispatch2 *> &stack) {
     // assign structured data from dsp
-    if(dsp == TJS::TVPGetGlobalMockObject()) return;
+    if(TJS::TVPIsMockEnabled() && dsp == TJS::TVPGetGlobalMockObject()) return;
 
     tTJSArrayNI *arrayni = nullptr;
     if(TJS_SUCCEEDED(

--- a/cpp/core/tjs2/tjsDictionary.cpp
+++ b/cpp/core/tjs2/tjsDictionary.cpp
@@ -353,7 +353,7 @@ namespace TJS {
     void tTJSDictionaryNI::Assign(iTJSDispatch2 *dsp, bool clear) {
         // copy members from "dsp" to "Owner"
 
-        if(dsp == TJS::TVPGetGlobalMockObject()) {
+        if(TJS::TVPIsMockEnabled() && dsp == TJS::TVPGetGlobalMockObject()) {
             if(clear) Owner->Clear();
             return;
         }
@@ -581,7 +581,7 @@ namespace TJS {
     tTJSDictionaryNI::AssignStructure(iTJSDispatch2 *dsp,
                                       std::vector<iTJSDispatch2 *> &stack) {
         // assign structured data from dsp
-        if(dsp == TJS::TVPGetGlobalMockObject()) return;
+        if(TJS::TVPIsMockEnabled() && dsp == TJS::TVPGetGlobalMockObject()) return;
 
         tTJSArrayNI *dicni = nullptr;
         if(TJS_SUCCEEDED(dsp->NativeInstanceSupport(

--- a/cpp/core/tjs2/tjsNative.cpp
+++ b/cpp/core/tjs2/tjsNative.cpp
@@ -421,7 +421,7 @@ namespace TJS {
             if(TJS_FAILED(hr))
                 return hr;
 
-            if(this->CallMissing) {
+            if(this->CallMissing && TJS::TVPIsMockEnabled()) {
                 tTJSVariant missingVar(this->missing_name);
                 dsp->ClassInstanceInfo(TJS_CII_SET_MISSING, 0, &missingVar);
             }

--- a/cpp/core/tjs2/tjsNative.h
+++ b/cpp/core/tjs2/tjsNative.h
@@ -28,6 +28,7 @@ namespace TJS {
 
     // Global mock fallback
     extern iTJSDispatch2* TVPGetGlobalMockObject();
+    extern bool TVPIsMockEnabled();
     //---------------------------------------------------------------------------
 
     /*[*/
@@ -309,7 +310,7 @@ namespace TJS {
     if(!objthis)                                                               \
         return TJS_E_NATIVECLASSCRASH;                                         \
     {                                                                          \
-        if(objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK;          \
+        if(TJS::TVPIsMockEnabled() && objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK; \
     }                                                                          \
     typename *varname;                                                         \
     {                                                                          \
@@ -325,7 +326,7 @@ namespace TJS {
     if(!objthis)                                                               \
         return TJS_E_NATIVECLASSCRASH;                                         \
     {                                                                          \
-        if(objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK;          \
+        if(TJS::TVPIsMockEnabled() && objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK; \
     }                                                                          \
     typename *varname;                                                         \
     {                                                                          \
@@ -395,7 +396,7 @@ namespace TJS {
     typename *varname;                                                         \
     {                                                                          \
         tjs_error hr;                                                          \
-        if(objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK;          \
+        if(TJS::TVPIsMockEnabled() && objthis == TJS::TVPGetGlobalMockObject()) return TJS_S_OK; \
         hr = objthis->NativeInstanceSupport(TJS_NIS_GETINSTANCE,               \
                                             TJS_NATIVE_CLASSID_NAME,           \
                                             (iTJSNativeInstance **)&varname);  \

--- a/cpp/core/tjs2/tjsObject.cpp
+++ b/cpp/core/tjs2/tjsObject.cpp
@@ -1244,7 +1244,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value_func;
                 if(CallGetMissing(membername, value_func))
@@ -1323,7 +1323,7 @@ namespace TJS {
 
         tTJSSymbolData *data = Find(membername, hint);
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value;
                 if(CallGetMissing(membername, value))
@@ -1396,7 +1396,7 @@ namespace TJS {
         }
 
         tTJSSymbolData *data;
-        if(CallMissing) {
+        if(CallMissing && TJS::TVPIsMockEnabled()) {
             data = Find(membername, hint);
             if(!data) {
                 // call 'missing' method
@@ -1492,7 +1492,7 @@ namespace TJS {
         }
 
         tTJSSymbolData *data;
-        if(CallMissing) {
+        if(CallMissing && TJS::TVPIsMockEnabled()) {
             data = Find((const tjs_char *)(*membername), membername->GetHint());
             if(!data) {
                 // call 'missing' method
@@ -1621,7 +1621,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value;
                 if(CallGetMissing(membername, value))
@@ -1666,7 +1666,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value;
                 if(CallGetMissing(membername, value))
@@ -1715,7 +1715,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value;
                 if(CallGetMissing(membername, value))
@@ -1818,7 +1818,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call 'missing' method
                 tTJSVariant value;
                 if(CallGetMissing(membername, value))
@@ -1914,7 +1914,7 @@ namespace TJS {
         tTJSSymbolData *data = Find(membername, hint);
 
         if(!data) {
-            if(CallMissing) {
+            if(CallMissing && TJS::TVPIsMockEnabled()) {
                 // call default operation
                 return inherited::Operation(flag, membername, hint, result,
                                             param, objthis);

--- a/cpp/core/tjs2/tjsVariant.cpp
+++ b/cpp/core/tjs2/tjsVariant.cpp
@@ -88,7 +88,14 @@ public:
     }
 };
 
+// --- Mock Toggle (controlled via engine_set_option("mock_enabled")) ---
+static bool g_MockEnabled = true; // default ON — existing behavior
+
+bool TVPIsMockEnabled() { return g_MockEnabled; }
+void TVPSetMockEnabled(bool enabled) { g_MockEnabled = enabled; }
+
 iTJSDispatch2* TVPGetGlobalMockObject() {
+    if (!g_MockEnabled) return nullptr;
     static iTJSDispatch2* g_GlobalMockObject = new GenericMockObjectForVariant();
     return g_GlobalMockObject;
 }

--- a/cpp/core/tjs2/tjsVariant.h
+++ b/cpp/core/tjs2/tjsVariant.h
@@ -166,6 +166,10 @@ namespace TJS {
     //---------------------------------------------------------------------------
     extern tTJSVariantClosure_S TJSNullVariantClosure;
 
+    // Global mock fallback declarations
+    extern bool TVPIsMockEnabled();
+    extern tTJSVariantClosure_S& TVPGetGlobalMockClosure_S();
+
 /*[*/
 //---------------------------------------------------------------------------
 // tTJSVariantClosure
@@ -220,157 +224,127 @@ namespace TJS {
                 ObjThis->Release();
         }
 
+        // Resolve the effective dispatch target.
+        // When Object is null, falls back to the global mock object only when
+        // the mock bypass is enabled; otherwise returns nullptr.
+        iTJSDispatch2 *Dispatch() const {
+            if (Object) return Object;
+            if (TJS::TVPIsMockEnabled()) return TJS::TVPGetGlobalMockObject();
+            return nullptr;
+        }
+
+        // Helper to resolve the effective objthis.
+        iTJSDispatch2 *ThisObj(iTJSDispatch2 *objthis) const {
+            return ObjThis ? ObjThis : (objthis ? objthis : Object);
+        }
+
+#define TJS_CLOSURE_DISPATCH(expr) do { \
+    iTJSDispatch2 *d = Dispatch(); \
+    if (!d) return TJS_E_INVALIDOBJECT; \
+    return (expr); \
+} while(0)
+
         tjs_error FuncCall(tjs_uint32 flag, const tjs_char *membername,
                            tjs_uint32 *hint, tTJSVariant *result,
                            tjs_int numparams, tTJSVariant **param,
                            iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->FuncCall(
-                flag, membername, hint, result, numparams, param,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->FuncCall(flag, membername, hint, result, numparams, param, ThisObj(objthis)));
         }
 
         tjs_error FuncCallByNum(tjs_uint32 flag, tjs_int num,
                                 tTJSVariant *result, tjs_int numparams,
                                 tTJSVariant **param,
                                 iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->FuncCallByNum(
-                flag, num, result, numparams, param,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->FuncCallByNum(flag, num, result, numparams, param, ThisObj(objthis)));
         }
 
         tjs_error PropGet(tjs_uint32 flag, const tjs_char *membername,
                           tjs_uint32 *hint, tTJSVariant *result,
                           iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->PropGet(flag, membername, hint, result,
-                                   ObjThis ? ObjThis
-                                           : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->PropGet(flag, membername, hint, result, ThisObj(objthis)));
         }
 
         tjs_error PropGetByNum(tjs_uint32 flag, tjs_int num,
                                tTJSVariant *result,
                                iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->PropGetByNum(flag, num, result,
-                                        ObjThis ? ObjThis
-                                                : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->PropGetByNum(flag, num, result, ThisObj(objthis)));
         }
 
         tjs_error PropSet(tjs_uint32 flag, const tjs_char *membername,
                           tjs_uint32 *hint, const tTJSVariant *param,
                           iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->PropSet(flag, membername, hint, param,
-                                   ObjThis ? ObjThis
-                                           : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->PropSet(flag, membername, hint, param, ThisObj(objthis)));
         }
 
         tjs_error PropSetByNum(tjs_uint32 flag, tjs_int num,
                                const tTJSVariant *param,
                                iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->PropSetByNum(flag, num, param,
-                                        ObjThis ? ObjThis
-                                                : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->PropSetByNum(flag, num, param, ThisObj(objthis)));
         }
 
         tjs_error GetCount(tjs_int *result, const tjs_char *membername,
                            tjs_uint32 *hint, iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->GetCount(result, membername, hint,
-                                    ObjThis ? ObjThis
-                                            : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->GetCount(result, membername, hint, ThisObj(objthis)));
         }
 
         tjs_error GetCountByNum(tjs_int *result, tjs_int num,
                                 iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->GetCountByNum(
-                result, num, ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->GetCountByNum(result, num, ThisObj(objthis)));
         }
 
         tjs_error PropSetByVS(tjs_uint32 flag, tTJSVariantString *membername,
                               const tTJSVariant *param,
                               iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->PropSetByVS(flag, membername, param,
-                                       ObjThis ? ObjThis
-                                               : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->PropSetByVS(flag, membername, param, ThisObj(objthis)));
         }
 
         tjs_error EnumMembers(tjs_uint32 flag, tTJSVariantClosure *callback,
                               iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->EnumMembers(flag, callback,
-                                       ObjThis ? ObjThis
-                                               : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->EnumMembers(flag, callback, ThisObj(objthis)));
         }
 
         tjs_error DeleteMember(tjs_uint32 flag, const tjs_char *membername,
                                tjs_uint32 *hint, iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->DeleteMember(flag, membername, hint,
-                                        ObjThis ? ObjThis
-                                                : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->DeleteMember(flag, membername, hint, ThisObj(objthis)));
         }
 
         tjs_error DeleteMemberByNum(tjs_uint32 flag, tjs_int num,
                                     iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->DeleteMemberByNum(
-                flag, num, ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->DeleteMemberByNum(flag, num, ThisObj(objthis)));
         }
 
         tjs_error Invalidate(tjs_uint32 flag, const tjs_char *membername,
                              tjs_uint32 *hint, iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->Invalidate(flag, membername, hint,
-                                      ObjThis ? ObjThis
-                                              : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->Invalidate(flag, membername, hint, ThisObj(objthis)));
         }
 
         tjs_error InvalidateByNum(tjs_uint32 flag, tjs_int num,
                                   iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->InvalidateByNum(
-                flag, num, ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->InvalidateByNum(flag, num, ThisObj(objthis)));
         }
 
         tjs_error IsValid(tjs_uint32 flag, const tjs_char *membername,
                           tjs_uint32 *hint, iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->IsValid(flag, membername, hint,
-                                   ObjThis ? ObjThis
-                                           : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->IsValid(flag, membername, hint, ThisObj(objthis)));
         }
 
         tjs_error IsValidByNum(tjs_uint32 flag, tjs_int num,
                                iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->IsValidByNum(
-                flag, num, ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->IsValidByNum(flag, num, ThisObj(objthis)));
         }
 
         tjs_error CreateNew(tjs_uint32 flag, const tjs_char *membername,
                             tjs_uint32 *hint, iTJSDispatch2 **result,
                             tjs_int numparams, tTJSVariant **param,
                             iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->CreateNew(
-                flag, membername, hint, result, numparams, param,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->CreateNew(flag, membername, hint, result, numparams, param, ThisObj(objthis)));
         }
 
         tjs_error CreateNewByNum(tjs_uint32 flag, tjs_int num,
                                  iTJSDispatch2 **result, tjs_int numparams,
                                  tTJSVariant **param,
                                  iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->CreateNewByNum(
-                flag, num, result, numparams, param,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->CreateNewByNum(flag, num, result, numparams, param, ThisObj(objthis)));
         }
 
         /*
@@ -381,39 +355,29 @@ namespace TJS {
         tjs_error IsInstanceOf(tjs_uint32 flag, const tjs_char *membername,
                                tjs_uint32 *hint, const tjs_char *classname,
                                iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->IsInstanceOf(flag, membername, hint, classname,
-                                        ObjThis ? ObjThis
-                                                : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->IsInstanceOf(flag, membername, hint, classname, ThisObj(objthis)));
         }
 
         tjs_error IsInstanceOf(tjs_uint32 flag, tjs_int num,
                                tjs_char *classname,
                                iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->IsInstanceOfByNum(
-                flag, num, classname,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->IsInstanceOfByNum(flag, num, classname, ThisObj(objthis)));
         }
 
         tjs_error Operation(tjs_uint32 flag, const tjs_char *membername,
                             tjs_uint32 *hint, tTJSVariant *result,
                             const tTJSVariant *param,
                             iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->Operation(flag, membername, hint, result, param,
-                                     ObjThis ? ObjThis
-                                             : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->Operation(flag, membername, hint, result, param, ThisObj(objthis)));
         }
 
         tjs_error OperationByNum(tjs_uint32 flag, tjs_int num,
                                  tTJSVariant *result, const tTJSVariant *param,
                                  iTJSDispatch2 *objthis) const {
-            
-            return (Object ? Object : TJS::TVPGetGlobalMockObject())->OperationByNum(
-                flag, num, result, param,
-                ObjThis ? ObjThis : (objthis ? objthis : Object));
+            TJS_CLOSURE_DISPATCH(d->OperationByNum(flag, num, result, param, ThisObj(objthis)));
         }
+
+#undef TJS_CLOSURE_DISPATCH
 
         /*
                 tjs_error
@@ -449,10 +413,6 @@ namespace TJS {
                                             tTJSVariantType to1,
                                             tTJSVariantType to2);
     //---------------------------------------------------------------------------
-
-    // Global mock fallback declarations
-    extern iTJSDispatch2* TVPGetGlobalMockObject();
-    extern tTJSVariantClosure_S& TVPGetGlobalMockClosure_S();
 
     //---------------------------------------------------------------------------
     // tTJSVariant
@@ -674,9 +634,13 @@ namespace TJS {
                 return TJSGetCompatBoolObject(true);
 
             if(vt == tvtVoid) {
-                iTJSDispatch2* mock = TJS::TVPGetGlobalMockObject();
-                if(mock) mock->AddRef();
-                return mock;
+                if(TJS::TVPIsMockEnabled()) {
+                    iTJSDispatch2* mock = TJS::TVPGetGlobalMockObject();
+                    if(mock) mock->AddRef();
+                    return mock;
+                }
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return nullptr;
             }
 
             TJSThrowVariantConvertError(*this, tvtObject);
@@ -691,7 +655,10 @@ namespace TJS {
                 return TJSGetCompatBoolObject(false);
 
             if(vt == tvtVoid) {
-                return TJS::TVPGetGlobalMockObject();
+                if(TJS::TVPIsMockEnabled())
+                    return TJS::TVPGetGlobalMockObject();
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return nullptr;
             }
 
             TJSThrowVariantConvertError(*this, tvtObject);
@@ -708,9 +675,13 @@ namespace TJS {
                 return TJSGetCompatBoolObject(true);
 
             if(vt == tvtVoid) {
-                iTJSDispatch2* mock = TJS::TVPGetGlobalMockObject();
-                if(mock) mock->AddRef();
-                return mock;
+                if(TJS::TVPIsMockEnabled()) {
+                    iTJSDispatch2* mock = TJS::TVPGetGlobalMockObject();
+                    if(mock) mock->AddRef();
+                    return mock;
+                }
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return nullptr;
             }
 
             TJSThrowVariantConvertError(*this, tvtObject);
@@ -725,7 +696,10 @@ namespace TJS {
                 return TJSGetCompatBoolObject(false);
 
             if(vt == tvtVoid) {
-                return TJS::TVPGetGlobalMockObject();
+                if(TJS::TVPIsMockEnabled())
+                    return TJS::TVPGetGlobalMockObject();
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return nullptr;
             }
 
             TJSThrowVariantConvertError(*this, tvtObject);
@@ -738,7 +712,10 @@ namespace TJS {
                 return *(tTJSVariantClosure *)&Object;
             }
             if(vt == tvtVoid) {
-                return *(tTJSVariantClosure *)&TJS::TVPGetGlobalMockClosure_S(); // already has ref inside TVPGetGlobalMockObject but it doesn't matter
+                if(TJS::TVPIsMockEnabled())
+                    return *(tTJSVariantClosure *)&TJS::TVPGetGlobalMockClosure_S();
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return *(tTJSVariantClosure *)&TJSNullVariantClosure;
             }
             TJSThrowVariantConvertError(*this, tvtObject);
             return *(tTJSVariantClosure *)&TJSNullVariantClosure;
@@ -750,7 +727,10 @@ namespace TJS {
                 return *(tTJSVariantClosure *)&Object;
             }
             if(vt == tvtVoid) {
-                return *(tTJSVariantClosure *)&TJS::TVPGetGlobalMockClosure_S();
+                if(TJS::TVPIsMockEnabled())
+                    return *(tTJSVariantClosure *)&TJS::TVPGetGlobalMockClosure_S();
+                TJSThrowVariantConvertError(*this, tvtObject);
+                return *(tTJSVariantClosure *)&TJSNullVariantClosure;
             }
             TJSThrowVariantConvertError(*this, tvtObject);
             return *(tTJSVariantClosure *)&TJSNullVariantClosure;

--- a/cpp/plugins/motionplayer/main.cpp
+++ b/cpp/plugins/motionplayer/main.cpp
@@ -746,6 +746,10 @@ public:
 };
 
 static tjs_error Universal_missing_method(tTJSVariant *result, tjs_int numparams, tTJSVariant **param, iTJSDispatch2 *objthis) {
+    if (!TJS::TVPIsMockEnabled()) {
+        if (result) *result = tTJSVariant(static_cast<tjs_int>(0));
+        return TJS_S_OK;
+    }
     if (numparams >= 3) {
         bool is_set = (tjs_int)*param[0];
         if (!is_set) {


### PR DESCRIPTION
…asses

Add a global mock toggle (default ON) that controls all 9 mock/stub layers in the TJS2 runtime via engine_set_option("mock_enabled"). When disabled, the engine exposes real MEMBERNOTFOUND/VariantConvertError for debugging.

C++ changes:
- Add TVPIsMockEnabled()/TVPSetMockEnabled() global toggle in tjsVariant.cpp
- Refactor tTJSVariantClosure with Dispatch()/ThisObj() helpers and TJS_CLOSURE_DISPATCH macro, replacing verbose ternary patterns
- Guard void-to-Object and Object-to-math variant conversions
- Guard native instance macros in tjsNative.h
- Guard array/dictionary mock assign bypasses
- Guard CallMissing checks in tjsObject.cpp
- Guard ncbind missing auto-registration
- Guard CallMissing propagation in tjsNative.cpp
- Guard motionplayer Universal_missing_method
- Guard DLL stub registrations in PluginImpl.cpp
- Add ENGINE_OPTION_MOCK_ENABLED to engine_options.h
- Handle mock_enabled in engine_api.cpp engine_set_option

Flutter changes:
- Add mockEnabled pref key and option key to PrefsKeys
- Add Mock Bypass toggle in Development settings section
- Pass mockEnabled through home_page -> game_page -> engine
- Add l10n strings for en/zh/ja