### PR TITLE
Use native dialogs for file and error prompts

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -103,6 +103,18 @@ jobs:
           fi
           echo "VCPKG_ROOT=${GITHUB_WORKSPACE}/.devtools/vcpkg" >> "$GITHUB_ENV"
 
+      - name: Build iOS Release
+        run: |
+          set -euo pipefail
+          chmod +x ./build.sh
+          export CMAKE_C_COMPILER_LAUNCHER=ccache
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          ./build.sh ios release --jobs=4 2>&1 | tee "${RUNNER_TEMP}/ios-release-build.log"
+          if grep -E "SCRIPT ERROR|Failed to load script|Can't open GDExtension|Can't open dynamic library" "${RUNNER_TEMP}/ios-release-build.log"; then
+            echo "Godot iOS release export logged script or GDExtension load errors." >&2
+            exit 1
+          fi
+
       - name: Build iOS Debug
         run: |
           set -euo pipefail
@@ -115,22 +127,10 @@ jobs:
             exit 1
           fi
 
-      - name: Build iOS Release
-        run: |
-          set -euo pipefail
-          chmod +x ./build.sh
-          export CMAKE_C_COMPILER_LAUNCHER=ccache
-          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          ./build.sh ios release --jobs=4 2>&1 | tee "${RUNNER_TEMP}/ios-build.log"
-          if grep -E "SCRIPT ERROR|Failed to load script|Can't open GDExtension|Can't open dynamic library" "${RUNNER_TEMP}/ios-build.log"; then
-            echo "Godot iOS release export logged script or GDExtension load errors." >&2
-            exit 1
-          fi
-
       - name: Verify exported Xcode project
         run: |
           set -euo pipefail
-          for build_type in debug release; do
+          for build_type in release debug; do
             if [[ ! -d "out/godot/ios/${build_type}/AetherKiri.xcodeproj" ]]; then
               echo "Godot iOS ${build_type} Xcode project not found" >&2
               exit 1
@@ -141,16 +141,24 @@ jobs:
             fi
           done
 
-      - name: Upload Artifact
+      - name: Upload Release Xcode Project
         if: success()
         uses: actions/upload-artifact@v7
         with:
           name: AetherKiri-iOS-XcodeProject
           path: |
-            out/godot/ios/debug/AetherKiri.xcodeproj
-            out/godot/ios/debug/AetherKiri
             out/godot/ios/release/AetherKiri.xcodeproj
             out/godot/ios/release/AetherKiri
+          retention-days: 7
+
+      - name: Upload Debug Xcode Project
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: AetherKiri-iOS-Debug-XcodeProject
+          path: |
+            out/godot/ios/debug/AetherKiri.xcodeproj
+            out/godot/ios/debug/AetherKiri
           retention-days: 7
 
       - name: Save vcpkg cache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -103,23 +103,26 @@ jobs:
           fi
           echo "VCPKG_ROOT=${GITHUB_WORKSPACE}/.devtools/vcpkg" >> "$GITHUB_ENV"
 
+      - name: Build macOS Release
+        run: |
+          set -euo pipefail
+          chmod +x ./build.sh
+          export CMAKE_C_COMPILER_LAUNCHER=ccache
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          ./build.sh macos release --jobs=4
+
       - name: Build macOS Debug
         run: |
+          set -euo pipefail
           chmod +x ./build.sh
           export CMAKE_C_COMPILER_LAUNCHER=ccache
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
           ./build.sh macos debug --jobs=4
 
-      - name: Build macOS Release
-        run: |
-          export CMAKE_C_COMPILER_LAUNCHER=ccache
-          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          ./build.sh macos release --jobs=4
-
       - name: Verify built .app
         run: |
           set -euo pipefail
-          for build_type in debug release; do
+          for build_type in release debug; do
             APP_PATH="out/godot/macos/${build_type}/AetherKiri.app"
             if [[ ! -d "$APP_PATH" ]]; then
               echo "Built Godot ${build_type} .app bundle not found: $APP_PATH" >&2
@@ -128,14 +131,20 @@ jobs:
             codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           done
 
-      - name: Upload Artifact
+      - name: Upload Release App
         if: success()
         uses: actions/upload-artifact@v7
         with:
           name: AetherKiri-macOS
-          path: |
-            out/godot/macos/debug/AetherKiri.app
-            out/godot/macos/release/AetherKiri.app
+          path: out/godot/macos/release/AetherKiri.app
+          retention-days: 7
+
+      - name: Upload Debug App
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: AetherKiri-macOS-Debug
+          path: out/godot/macos/debug/AetherKiri.app
           retention-days: 7
 
       - name: Save vcpkg cache

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -57,6 +57,7 @@ var detail_touch_scroll_active := false
 var rounded_card_shader: Shader
 var upscale_shader: Shader
 var opaque_frame_shader: Shader
+var shown_system_alerts := {}
 
 var player = null
 var selected_backend := "Godot Native"
@@ -1103,34 +1104,40 @@ func _show_import_guide() -> void:
     box.add_child(ok)
 
 func _show_message(message: String) -> void:
-    modal_layer.visible = true
-    for child in modal_layer.get_children():
-        child.queue_free()
-    var dim := ColorRect.new()
-    dim.color = Color(0, 0, 0, 0.38)
-    dim.set_anchors_preset(Control.PRESET_FULL_RECT)
-    modal_layer.add_child(dim)
-    var dialog := PanelContainer.new()
-    dialog.anchor_left = 0.5
-    dialog.anchor_top = 0.5
-    dialog.anchor_right = 0.5
-    dialog.anchor_bottom = 0.5
-    dialog.position = Vector2(-260, -120)
-    dialog.size = Vector2(520, 240)
-    dialog.add_theme_stylebox_override("panel", _panel_style(20, COLOR_CARD, Color(0, 0, 0, 0.06), 1))
-    modal_layer.add_child(dialog)
-    var box := VBoxContainer.new()
-    box.add_theme_constant_override("separation", 18)
-    dialog.add_child(box)
-    var label := Label.new()
-    label.text = message
-    label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-    label.add_theme_font_size_override("font_size", 22)
-    label.add_theme_color_override("font_color", COLOR_TEXT)
-    box.add_child(label)
-    var ok := _pill_button("知道了")
-    ok.pressed.connect(func(): modal_layer.visible = false)
-    box.add_child(ok)
+    _show_system_alert(message, "AetherKiri")
+
+func _show_system_alert(message: String, title: String = "AetherKiri") -> void:
+    if message.strip_edges().is_empty():
+        return
+    OS.alert(message, title)
+
+func _show_system_alert_once(key: String, message: String, title: String = "AetherKiri") -> void:
+    if shown_system_alerts.has(key):
+        return
+    shown_system_alerts[key] = true
+    _show_system_alert(message, title)
+
+func _maybe_show_log_alert(line: String) -> void:
+    var message := line.strip_edges()
+    if message.is_empty():
+        return
+    var lower := message.to_lower()
+    var is_warning := lower.contains("warning") or lower.contains("(warning)") or lower.contains("警告")
+    var is_error := lower.contains("error") or lower.contains("exception") or lower.contains("fatal") or lower.contains("failed") or lower.contains("错误") or lower.contains("失败")
+    if not is_warning and not is_error:
+        return
+    var title := "AetherKiri 错误" if is_error else "AetherKiri 警告"
+    _show_system_alert_once("log:%s" % message, message, title)
+
+func _create_file_dialog(title: String, file_mode: int, filters: PackedStringArray = PackedStringArray()) -> FileDialog:
+    var dialog := FileDialog.new()
+    dialog.file_mode = file_mode
+    dialog.access = FileDialog.ACCESS_FILESYSTEM
+    dialog.use_native_dialog = true
+    dialog.title = title
+    for filter in filters:
+        dialog.add_filter(filter)
+    return dialog
 
 func _offer_scrape_after_add(game: Dictionary) -> void:
     modal_layer.visible = true
@@ -1182,11 +1189,11 @@ func _set_cover_for_selected() -> void:
     var path := String(selected_game.get("path", ""))
     if path.is_empty():
         return
-    var dialog := FileDialog.new()
-    dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
-    dialog.access = FileDialog.ACCESS_FILESYSTEM
-    dialog.title = "选择封面图片"
-    dialog.add_filter("*.png, *.jpg, *.jpeg, *.webp;Image")
+    var dialog := _create_file_dialog(
+        "选择封面图片",
+        FileDialog.FILE_MODE_OPEN_FILE,
+        PackedStringArray(["*.png,*.jpg,*.jpeg,*.webp;Image;image/png,image/jpeg,image/webp"])
+    )
     dialog.file_selected.connect(func(cover_path: String):
         _update_game(path, {"coverPath": cover_path})
         _show_detail(selected_game)
@@ -1602,12 +1609,12 @@ func _show_web_import_picker() -> void:
     box.add_child(cancel)
 
 func _open_import_dialog(xp3: bool) -> void:
-    var dialog := FileDialog.new()
-    dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE if xp3 else FileDialog.FILE_MODE_OPEN_DIR
-    dialog.access = FileDialog.ACCESS_FILESYSTEM
-    dialog.title = "选择 XP3 文件" if xp3 else "选择游戏目录"
-    if xp3:
-        dialog.add_filter("*.xp3, *.XP3;KiriKiri XP3 archive")
+    var filters := PackedStringArray(["*.xp3,*.XP3;KiriKiri XP3 archive"]) if xp3 else PackedStringArray()
+    var dialog := _create_file_dialog(
+        "选择 XP3 文件" if xp3 else "选择游戏目录",
+        FileDialog.FILE_MODE_OPEN_FILE if xp3 else FileDialog.FILE_MODE_OPEN_DIR,
+        filters
+    )
     dialog.dir_selected.connect(func(path: String):
         _add_game_path(path)
     )
@@ -2061,13 +2068,17 @@ func _ready() -> void:
 
 func _create_runtime_player() -> bool:
     if not ClassDB.class_exists("AetherKiriPlayer"):
-        _append_log("AetherKiri runtime extension class is unavailable.")
-        _show_message("运行时扩展加载失败：AetherKiriPlayer 不可用")
+        var message := "AetherKiri runtime extension class is unavailable."
+        push_error(message)
+        _append_log(message)
+        _show_system_alert("运行时扩展加载失败：AetherKiriPlayer 不可用", "AetherKiri 错误")
         return false
     var instance: Object = ClassDB.instantiate("AetherKiriPlayer")
     if instance == null or not (instance is Node):
-        _append_log("AetherKiri runtime extension could not create AetherKiriPlayer.")
-        _show_message("运行时扩展加载失败：无法创建 AetherKiriPlayer")
+        var create_message := "AetherKiri runtime extension could not create AetherKiriPlayer."
+        push_error(create_message)
+        _append_log(create_message)
+        _show_system_alert("运行时扩展加载失败：无法创建 AetherKiriPlayer", "AetherKiri 错误")
         return false
     player = instance
     add_child(instance as Node)
@@ -2081,10 +2092,11 @@ func _finish_ready_after_first_frame() -> void:
     DirAccess.make_dir_recursive_absolute(cache_dir)
     if not player.initialize_engine(user_dir, cache_dir):
         render_errors += 1
-        _append_log("Engine init failed: %s %s" % [
+        var init_error_message := "Engine init failed: %s %s" % [
             player.get_last_result(),
             player.get_last_error(),
-        ])
+        ]
+        _append_log(init_error_message)
     else:
         _append_log("AetherKiri engine initialized.")
 
@@ -2224,7 +2236,8 @@ func _process(delta: float) -> void:
             game_view.visible = false
             game_running = false
             render_errors += 1
-            _append_log("Startup failed: %s" % player.get_last_error())
+            var startup_error := "Startup failed: %s" % player.get_last_error()
+            _append_log(startup_error)
 
     perf_accum += delta
     state_log_accum += delta
@@ -2356,10 +2369,11 @@ func _apply_backend(log_selection: bool) -> void:
     var result: int = int(player.set_render_backend(selected_backend))
     if result != ENGINE_RESULT_OK:
         render_errors += 1
-        _append_log("Renderer selection failed: %s %s" % [
+        var backend_error_message := "Renderer selection failed: %s %s" % [
             player.get_last_result(),
             player.get_last_error(),
-        ])
+        ]
+        _append_log(backend_error_message)
         return
     restart_notice.text = ""
     if log_selection:
@@ -2418,10 +2432,11 @@ func _on_open_game() -> void:
             player.get_last_result(),
             player.get_last_error(),
         ])
-        _append_log("Game launch failed: %s %s" % [
+        var launch_error_message := "Game launch failed: %s %s" % [
             player.get_last_result(),
             player.get_last_error(),
-        ])
+        ]
+        _append_log(launch_error_message)
         return
 
     game_running = true
@@ -2498,10 +2513,11 @@ func _sync_player_surface_size(force: bool) -> void:
     var result: int = int(player.set_surface_size(target_size.x, target_size.y))
     if result != ENGINE_RESULT_OK:
         render_errors += 1
-        _append_log("Surface resize failed: %s %s" % [
+        var surface_error_message := "Surface resize failed: %s %s" % [
             player.get_last_result(),
             player.get_last_error(),
-        ])
+        ]
+        _append_log(surface_error_message)
         return
     if current_surface_size != target_size:
         last_texture_size = Vector2i.ZERO
@@ -2944,6 +2960,7 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _append_log(line: String) -> void:
     _write_probe_marker("log %s" % line)
+    _maybe_show_log_alert(line)
     log_lines.append(line)
     while log_lines.size() > MAX_LOG_LINES:
         log_lines.remove_at(0)

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -50,6 +50,8 @@ var mock_enabled := true
 var console_log_file := true
 var trace_log := false
 var export_scripts := false
+var log_alerts := false
+var error_dialog_logs := false
 var dirty_settings := false
 var active_game_path := ""
 var active_game_started_msec := 0
@@ -192,6 +194,8 @@ func _load_shell_settings() -> void:
     console_log_file = bool(cfg.get_value("developer", "console_log_file", console_log_file))
     trace_log = bool(cfg.get_value("developer", "trace_log", trace_log))
     export_scripts = bool(cfg.get_value("developer", "export_scripts", export_scripts))
+    log_alerts = bool(cfg.get_value("developer", "log_alerts", log_alerts))
+    error_dialog_logs = bool(cfg.get_value("developer", "error_dialog_logs", error_dialog_logs))
 
 func _save_shell_settings() -> void:
     var cfg := ConfigFile.new()
@@ -206,6 +210,8 @@ func _save_shell_settings() -> void:
     cfg.set_value("developer", "console_log_file", console_log_file)
     cfg.set_value("developer", "trace_log", trace_log)
     cfg.set_value("developer", "export_scripts", export_scripts)
+    cfg.set_value("developer", "log_alerts", log_alerts)
+    cfg.set_value("developer", "error_dialog_logs", error_dialog_logs)
     cfg.save(SETTINGS_FILE)
     ProjectSettings.set_setting(SETTINGS_KEY, selected_backend)
     ProjectSettings.save()
@@ -229,6 +235,7 @@ func _apply_engine_options() -> void:
     player.set_engine_option("console_log_file", "1" if console_log_file else "0")
     player.set_engine_option("trace_log", "1" if trace_log else "0")
     player.set_engine_option("export_scripts", "1" if export_scripts else "0")
+    player.set_engine_option("error_dialog_logs", "1" if error_dialog_logs else "0")
 
 func _apply_shell_runtime_settings() -> void:
     if OS.get_name() == "iOS" or OS.get_name() == "Android":
@@ -567,6 +574,8 @@ func _rebuild_settings_view() -> void:
     dev_card.add_child(_settings_toggle_row("控制台日志文件", "将引擎控制台日志写入 krkr.console.log 文件", console_log_file, "console_log"))
     dev_card.add_child(_settings_toggle_row("追踪日志", "启用 spdlog trace 级别详细日志，输出最大调试信息", trace_log, "trace_log"))
     dev_card.add_child(_settings_toggle_row("导出 TJS 脚本", "游戏加载时自动从 XP3 中导出反汇编的 TJS 字节码脚本", export_scripts, "export_tjs"))
+    dev_card.add_child(_settings_toggle_row("日志级别弹窗", "将 warning/error/fatal 等日志行额外显示为系统提示；默认关闭", log_alerts, "log_alerts"))
+    dev_card.add_child(_settings_toggle_row("错误弹窗附带日志", "真正异常弹窗中追加最近 20 行引擎日志；默认关闭", error_dialog_logs, "error_dialog_logs"))
 
     page.add_child(_section_title("ⓘ  关于"))
     var about_card := _settings_card()
@@ -908,6 +917,10 @@ func _on_setting_toggle(key: String, value: bool) -> void:
         trace_log = value
     elif key == "export_tjs":
         export_scripts = value
+    elif key == "log_alerts":
+        log_alerts = value
+    elif key == "error_dialog_logs":
+        error_dialog_logs = value
     _mark_settings_dirty()
     _apply_engine_options()
     _apply_shell_runtime_settings()
@@ -1118,6 +1131,8 @@ func _show_system_alert_once(key: String, message: String, title: String = "Aeth
     _show_system_alert(message, title)
 
 func _maybe_show_log_alert(line: String) -> void:
+    if not log_alerts:
+        return
     var message := line.strip_edges()
     if message.is_empty():
         return

--- a/bridge/engine_api/include/engine_options.h
+++ b/bridge/engine_api/include/engine_options.h
@@ -63,6 +63,10 @@
  *  When enabled, disassembles bytecode and exports scripts during game load. */
 #define ENGINE_OPTION_EXPORT_SCRIPTS "export_scripts"
 
+/** Enable/disable appending recent engine logs to fatal error dialogs
+ *  ("0"/"1", default "0"). */
+#define ENGINE_OPTION_ERROR_DIALOG_LOGS "error_dialog_logs"
+
 /* ── Renderer Values ────────────────────────────────────────────── */
 
 #define ENGINE_RENDERER_GODOT_NATIVE      "godot_native"

--- a/bridge/engine_api/src/engine_api.cpp
+++ b/bridge/engine_api/src/engine_api.cpp
@@ -2271,6 +2271,16 @@ engine_result_t engine_set_option(engine_handle_t handle,
     return ENGINE_RESULT_OK;
   }
 
+  if (key == ENGINE_OPTION_ERROR_DIALOG_LOGS) {
+    const std::string v(option->value_utf8);
+    const bool enabled = (v == "1" || v == "true");
+    spdlog::info("engine_set_option: error_dialog_logs={}", enabled);
+    TVPSetCommandLine(ttstr(option->key_utf8).c_str(), ttstr(option->value_utf8));
+    ClearHandleErrorLocked(impl);
+    SetThreadError(nullptr);
+    return ENGINE_RESULT_OK;
+  }
+
   TVPSetCommandLine(ttstr(option->key_utf8).c_str(), ttstr(option->value_utf8));
 
   if (key == ENGINE_OPTION_ARCHIVE_CACHE_COUNT) {

--- a/bridge/godot_extension/CMakeLists.txt
+++ b/bridge/godot_extension/CMakeLists.txt
@@ -35,6 +35,9 @@ else()
 endif()
 
 target_compile_features(aether_kiri_godot PRIVATE cxx_std_17)
+target_compile_definitions(aether_kiri_godot PRIVATE
+    $<$<CONFIG:Debug>:DEBUG_ENABLED DEBUG_METHODS_ENABLED HOT_RELOAD_ENABLED>
+)
 target_include_directories(aether_kiri_godot PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../engine_api/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp/core/visual/godot
@@ -61,7 +64,9 @@ if(TARGET krkr2plugin)
     endif()
 endif()
 
-target_link_libraries(aether_kiri_godot PRIVATE unofficial::godot::cpp)
+target_link_libraries(aether_kiri_godot PRIVATE
+    "$<LINK_LIBRARY:WHOLE_ARCHIVE,unofficial::godot::cpp>"
+)
 
 set_target_properties(aether_kiri_godot PROPERTIES
     OUTPUT_NAME "aether_kiri_godot"

--- a/cpp/core/environ/Application.cpp
+++ b/cpp/core/environ/Application.cpp
@@ -552,8 +552,18 @@ void TVPEngineApi_SetGlobalException(const std::string& msg) { g_EngineApiGlobal
 
 void tTVPApplication::ShowException(const ttstr &e) {
     ttstr msg = e;
-    msg += TJS_W("\n\n--- Recent Engine Logs ---\n");
-    msg += TVPGetLastLog(20);
+
+    tTJSVariant includeLogsOpt;
+    bool includeLogs = false;
+    if(TVPGetCommandLine(TJS_W("error_dialog_logs"), &includeLogsOpt)) {
+        ttstr val = includeLogsOpt.AsStringNoAddRef();
+        includeLogs = (val == TJS_W("1") || val == TJS_W("true"));
+    }
+    if(includeLogs) {
+        msg += TJS_W("\n\n--- Recent Engine Logs ---\n");
+        msg += TVPGetLastLog(20);
+    }
+
     TVPEngineApi_SetGlobalException(msg.AsStdString());
     spdlog::error("FATAL SCRIPT EXCEPTION:\n{}", msg.AsStdString());
 

--- a/cpp/core/environ/android/AndroidUtils.cpp
+++ b/cpp/core/environ/android/AndroidUtils.cpp
@@ -562,6 +562,353 @@ namespace kr2android {
 } // namespace kr2android
 using namespace kr2android;
 
+namespace {
+
+void ClearJniException(JNIEnv *env) {
+    if(env != nullptr && env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+}
+
+jobject GetApplicationContextLocal(JNIEnv *env) {
+    if(env == nullptr) return nullptr;
+
+    jobject ctx = krkr_GetApplicationContext();
+    if(ctx != nullptr) {
+        return env->NewLocalRef(ctx);
+    }
+
+    jclass activityThreadClass = env->FindClass("android/app/ActivityThread");
+    if(activityThreadClass == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+
+    jmethodID currentApplication = env->GetStaticMethodID(
+        activityThreadClass, "currentApplication",
+        "()Landroid/app/Application;");
+    if(currentApplication == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(activityThreadClass);
+        return nullptr;
+    }
+
+    jobject app = env->CallStaticObjectMethod(activityThreadClass,
+                                             currentApplication);
+    env->DeleteLocalRef(activityThreadClass);
+    if(env->ExceptionCheck() || app == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+    return app;
+}
+
+jclass FindClassWithAppClassLoader(JNIEnv *env, const char *className) {
+    if(env == nullptr || className == nullptr) return nullptr;
+
+    jclass cls = env->FindClass(className);
+    if(cls != nullptr && !env->ExceptionCheck()) {
+        return cls;
+    }
+    ClearJniException(env);
+
+    jobject appContext = GetApplicationContextLocal(env);
+    if(appContext == nullptr) return nullptr;
+
+    jclass contextClass = env->FindClass("android/content/Context");
+    if(contextClass == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(appContext);
+        return nullptr;
+    }
+
+    jmethodID getClassLoader = env->GetMethodID(
+        contextClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+    if(getClassLoader == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(contextClass);
+        env->DeleteLocalRef(appContext);
+        return nullptr;
+    }
+
+    jobject classLoader = env->CallObjectMethod(appContext, getClassLoader);
+    env->DeleteLocalRef(contextClass);
+    env->DeleteLocalRef(appContext);
+    if(env->ExceptionCheck() || classLoader == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+
+    jclass classLoaderClass = env->FindClass("java/lang/ClassLoader");
+    if(classLoaderClass == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(classLoader);
+        return nullptr;
+    }
+
+    jmethodID loadClass = env->GetMethodID(
+        classLoaderClass, "loadClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;");
+    if(loadClass == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(classLoaderClass);
+        env->DeleteLocalRef(classLoader);
+        return nullptr;
+    }
+
+    std::string dottedName(className);
+    for(char &c : dottedName) {
+        if(c == '/') c = '.';
+    }
+    jstring classNameJava = env->NewStringUTF(dottedName.c_str());
+    jobject classObject =
+        env->CallObjectMethod(classLoader, loadClass, classNameJava);
+
+    env->DeleteLocalRef(classNameJava);
+    env->DeleteLocalRef(classLoaderClass);
+    env->DeleteLocalRef(classLoader);
+
+    if(env->ExceptionCheck() || classObject == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+
+    return static_cast<jclass>(classObject);
+}
+
+jobject GetGodotActivity(JNIEnv *env) {
+    if(env == nullptr) return nullptr;
+
+    jobject appContext = GetApplicationContextLocal(env);
+    if(appContext == nullptr) return nullptr;
+
+    jclass godotClass = FindClassWithAppClassLoader(env,
+                                                    "org/godotengine/godot/Godot");
+    if(godotClass == nullptr) {
+        env->DeleteLocalRef(appContext);
+        return nullptr;
+    }
+
+    jmethodID getInstance = env->GetStaticMethodID(
+        godotClass, "getInstance",
+        "(Landroid/content/Context;)Lorg/godotengine/godot/Godot;");
+    if(getInstance == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(godotClass);
+        env->DeleteLocalRef(appContext);
+        return nullptr;
+    }
+
+    jobject godot = env->CallStaticObjectMethod(godotClass, getInstance,
+                                                appContext);
+    env->DeleteLocalRef(appContext);
+    if(env->ExceptionCheck() || godot == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(godotClass);
+        return nullptr;
+    }
+
+    jmethodID getActivity = env->GetMethodID(
+        godotClass, "getActivity", "()Landroid/app/Activity;");
+    if(getActivity == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(godot);
+        env->DeleteLocalRef(godotClass);
+        return nullptr;
+    }
+
+    jobject activity = env->CallObjectMethod(godot, getActivity);
+    env->DeleteLocalRef(godot);
+    env->DeleteLocalRef(godotClass);
+    if(env->ExceptionCheck() || activity == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+    return activity;
+}
+
+void JNICALL GodotDialogCallback(JNIEnv * /* env */, jclass /* clazz */,
+                                 jint result) {
+    std::lock_guard<std::mutex> lk(MessageBoxLock);
+    MsgBoxRet = static_cast<int>(result);
+    MessageBoxCond.notify_all();
+}
+
+bool RegisterGodotDialogCallback(JNIEnv *env, jclass dialogUtilsClass) {
+    static std::mutex registerMutex;
+    static bool registered = false;
+
+    if(env == nullptr || dialogUtilsClass == nullptr) return false;
+    std::lock_guard<std::mutex> guard(registerMutex);
+    if(registered) return true;
+
+    JNINativeMethod methods[] = {
+        {const_cast<char *>("dialogCallback"), const_cast<char *>("(I)V"),
+         reinterpret_cast<void *>(&GodotDialogCallback)},
+    };
+    if(env->RegisterNatives(dialogUtilsClass, methods, 1) != JNI_OK) {
+        ClearJniException(env);
+        __android_log_print(ANDROID_LOG_WARN, "krkr2",
+                            "RegisterNatives(DialogUtils.dialogCallback) failed");
+        return false;
+    }
+
+    registered = true;
+    return true;
+}
+
+jobjectArray NewJavaButtonArray(JNIEnv *env, unsigned int nButton,
+                                const char **btnText) {
+    if(env == nullptr) return nullptr;
+    jclass strcls = env->FindClass("java/lang/String");
+    if(strcls == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+
+    jobjectArray btns = env->NewObjectArray(nButton, strcls, nullptr);
+    env->DeleteLocalRef(strcls);
+    if(btns == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+
+    for(unsigned int i = 0; i < nButton; ++i) {
+        const char *text = (btnText != nullptr && btnText[i] != nullptr)
+            ? btnText[i]
+            : "";
+        jstring jstrBtn = env->NewStringUTF(text);
+        if(jstrBtn == nullptr) {
+            ClearJniException(env);
+            continue;
+        }
+        env->SetObjectArrayElement(btns, i, jstrBtn);
+        env->DeleteLocalRef(jstrBtn);
+    }
+    return btns;
+}
+
+jobject GetStaticObjectFieldByName(JNIEnv *env, jclass cls,
+                                   const char *firstName,
+                                   const char *secondName,
+                                   const char *signature) {
+    if(env == nullptr || cls == nullptr || signature == nullptr) return nullptr;
+
+    jfieldID field = nullptr;
+    if(firstName != nullptr) {
+        field = env->GetStaticFieldID(cls, firstName, signature);
+        if(field == nullptr) ClearJniException(env);
+    }
+    if(field == nullptr && secondName != nullptr) {
+        field = env->GetStaticFieldID(cls, secondName, signature);
+        if(field == nullptr) ClearJniException(env);
+    }
+    if(field == nullptr) return nullptr;
+
+    jobject value = env->GetStaticObjectField(cls, field);
+    if(env->ExceptionCheck() || value == nullptr) {
+        ClearJniException(env);
+        return nullptr;
+    }
+    return value;
+}
+
+int WaitForMessageBoxResult() {
+    std::unique_lock<std::mutex> lk(MessageBoxLock);
+    while(MsgBoxRet == -2) {
+        MessageBoxCond.wait_for(lk, std::chrono::milliseconds(200));
+        if(MsgBoxRet == -2) {
+            TVPForceSwapBuffer(); // update opengl events
+        }
+    }
+    return MsgBoxRet;
+}
+
+bool ShowGodotMessageBox(const char *pszText, const char *pszTitle,
+                         unsigned int nButton, const char **btnText) {
+    JNIEnv *env = JniHelper::getEnv();
+    if(env == nullptr) return false;
+
+    jobject activity = GetGodotActivity(env);
+    if(activity == nullptr) return false;
+
+    jclass dialogUtilsClass = FindClassWithAppClassLoader(
+        env, "org/godotengine/godot/utils/DialogUtils");
+    if(dialogUtilsClass == nullptr) {
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    if(!RegisterGodotDialogCallback(env, dialogUtilsClass)) {
+        env->DeleteLocalRef(dialogUtilsClass);
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    jobject companion = GetStaticObjectFieldByName(
+        env, dialogUtilsClass, "INSTANCE", "Companion",
+        "Lorg/godotengine/godot/utils/DialogUtils$Companion;");
+    if(companion == nullptr) {
+        env->DeleteLocalRef(dialogUtilsClass);
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    jclass companionClass = env->GetObjectClass(companion);
+    if(companionClass == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(companion);
+        env->DeleteLocalRef(dialogUtilsClass);
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    jmethodID showDialog = env->GetMethodID(
+        companionClass, "showDialog$lib_templateDebug",
+        "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;"
+        "[Ljava/lang/String;)V");
+    if(showDialog == nullptr) {
+        ClearJniException(env);
+        env->DeleteLocalRef(companionClass);
+        env->DeleteLocalRef(companion);
+        env->DeleteLocalRef(dialogUtilsClass);
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    jstring jstrTitle = env->NewStringUTF(pszTitle != nullptr ? pszTitle : "");
+    jstring jstrText = env->NewStringUTF(pszText != nullptr ? pszText : "");
+    jobjectArray btns = NewJavaButtonArray(env, nButton, btnText);
+    if(jstrTitle == nullptr || jstrText == nullptr || btns == nullptr) {
+        ClearJniException(env);
+        if(jstrTitle != nullptr) env->DeleteLocalRef(jstrTitle);
+        if(jstrText != nullptr) env->DeleteLocalRef(jstrText);
+        if(btns != nullptr) env->DeleteLocalRef(btns);
+        env->DeleteLocalRef(companionClass);
+        env->DeleteLocalRef(companion);
+        env->DeleteLocalRef(dialogUtilsClass);
+        env->DeleteLocalRef(activity);
+        return false;
+    }
+
+    MsgBoxRet = -2;
+    env->CallVoidMethod(companion, showDialog, activity, jstrTitle, jstrText,
+                        btns);
+    const bool ok = !env->ExceptionCheck();
+    ClearJniException(env);
+
+    env->DeleteLocalRef(jstrTitle);
+    env->DeleteLocalRef(jstrText);
+    env->DeleteLocalRef(btns);
+    env->DeleteLocalRef(companionClass);
+    env->DeleteLocalRef(companion);
+    env->DeleteLocalRef(dialogUtilsClass);
+    env->DeleteLocalRef(activity);
+    return ok;
+}
+
+} // namespace
+
 int TVPShowSimpleMessageBox(const char *pszText, const char *pszTitle,
                             unsigned int nButton, const char **btnText) {
     JniMethodInfo methodInfo;
@@ -572,31 +919,21 @@ int TVPShowSimpleMessageBox(const char *pszText, const char *pszTitle,
         MsgBoxRet = -2;
         jstring jstrTitle = methodInfo.env->NewStringUTF(pszTitle);
         jstring jstrText = methodInfo.env->NewStringUTF(pszText);
-        jclass strcls = methodInfo.env->FindClass("java/lang/String");
-        jobjectArray btns =
-            methodInfo.env->NewObjectArray(nButton, strcls, nullptr);
-        for(unsigned int i = 0; i < nButton; ++i) {
-            jstring jstrBtn = methodInfo.env->NewStringUTF(btnText[i]);
-            methodInfo.env->SetObjectArrayElement(btns, i, jstrBtn);
-            methodInfo.env->DeleteLocalRef(jstrBtn);
-        }
+        jobjectArray btns = NewJavaButtonArray(methodInfo.env, nButton, btnText);
 
         methodInfo.env->CallStaticVoidMethod(
             methodInfo.classID, methodInfo.methodID, jstrTitle, jstrText, btns);
 
         methodInfo.env->DeleteLocalRef(jstrTitle);
         methodInfo.env->DeleteLocalRef(jstrText);
-        methodInfo.env->DeleteLocalRef(btns);
+        if(btns != nullptr) methodInfo.env->DeleteLocalRef(btns);
         methodInfo.env->DeleteLocalRef(methodInfo.classID);
 
-        std::unique_lock<std::mutex> lk(MessageBoxLock);
-        while(MsgBoxRet == -2) {
-            MessageBoxCond.wait_for(lk, std::chrono::milliseconds(200));
-            if(MsgBoxRet == -2) {
-                TVPForceSwapBuffer(); // update opengl events
-            }
-        }
-        return MsgBoxRet;
+        return WaitForMessageBoxResult();
+    }
+
+    if(ShowGodotMessageBox(pszText, pszTitle, nButton, btnText)) {
+        return WaitForMessageBoxResult();
     }
     return -1;
 }
@@ -618,6 +955,12 @@ Java_org_tvp_kirikiri2_KR2Activity_nativeOnInputBoxResult(
     MessageBoxRetText = JniHelper::jstring2string(text);
     MessageBoxCond.notify_all();
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_godotengine_godot_utils_DialogUtils_dialogCallback(
+    JNIEnv* env, jclass clazz, jint result) {
+    GodotDialogCallback(env, clazz, result);
+}
 #endif
 
 int TVPShowSimpleMessageBox(const ttstr &text, const ttstr &caption,
@@ -633,7 +976,7 @@ int TVPShowSimpleMessageBox(const ttstr &text, const ttstr &caption,
         btnText.emplace_back(btnTextHold.back().c_str());
     }
     return TVPShowSimpleMessageBox(pszText, pszTitle, btnText.size(),
-                                   &btnText[0]);
+                                   btnText.empty() ? nullptr : &btnText[0]);
 }
 
 int TVPShowSimpleInputBox(ttstr &text, const ttstr &caption,

--- a/cpp/core/environ/apple/macos/platform.mm
+++ b/cpp/core/environ/apple/macos/platform.mm
@@ -361,17 +361,18 @@ tjs_int TVPGetSystemFreeMemory() {
 
 int TVPShowSimpleMessageBox(const ttstr &text, const ttstr &caption,
                             const std::vector<ttstr> &vecButtons) {
-    std::string utf8Text = text.AsStdString();
-    std::string utf8Caption = caption.AsStdString();
-
     // 确保在主线程执行UI操作
     if (![NSThread isMainThread]) {
-        spdlog::warn("TVPShowSimpleMessageBox from background thread: {} - {}",
-                     utf8Caption, utf8Text);
-        return vecButtons.empty() ? -1 : 0;
+        __block int result = -1;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = TVPShowSimpleMessageBox(text, caption, vecButtons);
+        });
+        return result;
     }
 
     // 转换文本
+    std::string utf8Text = text.AsStdString();
+    std::string utf8Caption = caption.AsStdString();
     NSString *nsText = [NSString stringWithUTF8String:utf8Text.c_str()];
     NSString *nsCaption = [NSString stringWithUTF8String:utf8Caption.c_str()];
 


### PR DESCRIPTION
## Summary
- default shell file pickers to native OS dialogs
- route shell warning/error prompts through system alerts
- surface game log warning/error/failure lines via deduplicated system alerts

## Verification
- /Applications/Godot.app/Contents/MacOS/Godot --headless --path apps/godot_app --check-only --quit