### PR TITLE
fix(tjs2): load structured ns0 dictionary data

### DIFF
--- a/.agents/skills/fix-aetherkiri-game-compatibility/SKILL.md
+++ b/.agents/skills/fix-aetherkiri-game-compatibility/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: fix-aetherkiri-game-compatibility
+description: Diagnose, implement, validate, commit, and document end-to-end compatibility fixes for KiriKiri games running in AetherKiri. Use when a game fails to import or start, loses backgrounds or character layers, crashes after extended play or save/load, stalls in a native-plugin-dependent mode, renders a black frame, has path or script compatibility failures, or needs coordinated changes across the public AetherKiri repository and private AetherInternal package followed by local builds and verified-games updates.
+---
+
+# Fix AetherKiri Game Compatibility
+
+Carry a game from a reproducible failure to a verified minimal fix. Preserve the public/private package boundary, validate the actual affected flow, and leave a reviewable commit chain.
+
+## Establish scope and repository state
+
+1. Identify the public AetherKiri worktree, its current branch and remotes, and the checked-out `packages/AetherInternal` revision.
+2. Read repository instructions and inspect `git status` in both repositories before changing anything.
+3. Preserve unrelated tracked changes and untracked local helpers. Never commit game packages, saves, logs, generated builds, proprietary SDK files, credentials, or local paths.
+4. Pull or fetch the requested upstream state before reproduction when the user asks to test the latest code. Create a dedicated compatibility branch unless the user identifies an existing branch.
+5. Record the exact original game title separately from localized folder names, translation labels, or test-directory aliases.
+
+Do not treat a deliberately missing or modified save, an unrelated popup, or a stale process as the target failure. Follow the user's stated boundary.
+
+## Reproduce with evidence
+
+1. Launch through the normal AetherKiri game-selection interface unless the user explicitly requests direct auto-start.
+2. Capture the newest KiriKiri/AetherKiri log and correlate it with the visible symptom. Use focused diagnostic environment variables only when existing evidence is insufficient.
+3. Reduce the failure to the first unsupported boundary, for example:
+   - path normalization or archive lookup;
+   - TJS parsing, dispatch, member calls, or dictionary loading;
+   - plugin registration or native module behavior;
+   - layer creation, texture upload, compositing, or presentation;
+   - save serialization, encoding, ownership, or lifetime;
+   - input-method composition and committed-text delivery.
+4. Distinguish startup success from gameplay success. A title page proves only the startup path; it does not verify save/load, prolonged play, galleries, movies, character rendering, or plugin-driven RPG scenes.
+5. Prefer narrow tracing that exposes names, types, arguments, transitions, and failure codes. Avoid permanent high-volume logging unless it is independently useful and appropriately gated.
+
+For an existing diagnostic ZIP, use `$unpack-investigate-artifacts` rather than recollecting evidence.
+
+## Determine implementation ownership
+
+Inspect the code that owns the missing behavior before editing:
+
+- Put general engine behavior, public interfaces, diagnostics, portable fallbacks, registration hooks, and build integration in AetherKiri.
+- Put non-public native-plugin compatibility implementations and private extension sources in AetherInternal.
+- Keep game-specific filenames, constants, and script workarounds out of shared engine paths unless evidence proves they represent a reusable engine contract.
+- Reuse existing implementations and ABI boundaries before adding a parallel subsystem.
+- Do not alter `.github/workflows` merely to compensate for an incomplete local checkout or missing private package. Preserve a working remote build contract.
+
+If both repositories must change, make the public side tolerate the package being absent when that is an established project requirement. Do not silently degrade a build that is expected to include Internal.
+
+## Implement the minimum complete fix
+
+1. Trace the failing call from script-visible behavior through plugin/engine boundaries to rendering or state output.
+2. Implement every operation required by the smallest real game flow, including lifecycle and error behavior. A stub returning success is not a fix when downstream state remains absent.
+3. Match existing data structures, ownership rules, encodings, and platform abstractions.
+4. Keep Win32 window management out of portable plugin emulation when AetherKiri already owns the window and presentation path.
+5. Route drawing through AetherKiri's existing renderer and texture/compositing facilities. Verify alpha, ordering, transforms, clipping, invalidation, resize, and frame presentation as applicable.
+6. Preserve full Unicode input. Buffer IME pre-edit/composition state outside the KiriKiri layer and send only committed text; support Chinese, Japanese, and other composed input without leaking transient punctuation or candidates.
+7. Add focused tests for stable public contracts where practical. Use a real authorized game flow for behavior that cannot be represented faithfully by a unit test.
+
+Do not broaden the patch into unrelated cleanup.
+
+## Coordinate public and private commits
+
+When AetherInternal changes:
+
+1. Build and inspect the Internal change in its own repository.
+2. Commit and push the Internal implementation first.
+3. Update the public repository's `packages/AetherInternal` gitlink to that reachable commit.
+4. Commit public interfaces, loader behavior, tests, and the gitlink together only when they form one coherent compatibility step.
+5. Confirm the public checkout can resolve the pinned private revision in the intended authenticated workflow.
+
+Commit files in the repository that owns them. Use the user-specified author identity. Stage explicit paths, inspect the staged diff, and keep local helpers and generated artifacts out of every commit.
+
+## Validate the repaired flow
+
+Run validation in increasing scope:
+
+1. Run focused tests or compile the changed targets.
+2. Configure a fresh local build with AetherInternal enabled and confirm configuration reports the private package as enabled.
+3. Build the complete requested application target, not only a library.
+4. Confirm the expected Internal and public sources actually compiled or linked.
+5. Start the normal application and import/select the authorized local game.
+6. Reproduce the formerly failing boundary and continue beyond it.
+7. Exercise the relevant regression surface: background and character rendering, repeated save/load after extended runtime, input, audio, scene changes, return-to-title behavior, or native-plugin-dependent RPG rendering.
+8. Inspect logs for script errors, bridge failures, missing module registrations, crashes, deadlocks, and repeated warnings.
+
+Do not claim success from compilation alone. For a render fix, require a presented non-black frame with the expected layers. For an RPG/native-plugin fix, enter the RPG scene and verify its map, character, HUD, and input rather than relying on story-mode startup.
+
+When a remote workflow supplies private content, keep its existing interface intact and verify local behavior through the same package contract. Change workflows only when the workflow itself is the demonstrated failure and the user authorizes that scope.
+
+## Document support and finish
+
+After the user confirms the game works:
+
+1. Update both `doc/verified_games.md` and `doc/verified_games.zh-CN.md`.
+2. Use the official original game title. Do not publish the local folder name.
+3. Record only platforms and build profiles actually tested, such as `Windows x64 debug app`.
+4. Describe only flows that were exercised. Use smoke verification for startup/basic-input coverage and flow verification only for explicitly tested in-game flows.
+5. Credit the verifier and keep machine-local game paths out of the documents.
+6. Update both document dates and keep the English and Chinese rows equivalent.
+7. Run whitespace checks, inspect the final diff, and confirm workflow files and unrelated files remain unchanged.
+8. Commit the documentation on the compatibility branch with explicit file staging.
+
+Report the branch, public and private commit IDs, build result, exact verified flow, support-list title/platform, and anything intentionally left uncommitted. Push only when the user requests it or the active task already includes publishing.

--- a/.agents/skills/fix-aetherkiri-game-compatibility/agents/openai.yaml
+++ b/.agents/skills/fix-aetherkiri-game-compatibility/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AetherKiri Game Compatibility Fix"
+  short_description: "Diagnose, implement, validate, and record game fixes"
+  default_prompt: "Use $fix-aetherkiri-game-compatibility to diagnose and complete this AetherKiri game compatibility fix end to end."

--- a/.agents/skills/submit-aetherkiri-cross-repo-prs/SKILL.md
+++ b/.agents/skills/submit-aetherkiri-cross-repo-prs/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: submit-aetherkiri-cross-repo-prs
+description: Prepare, validate, push, open, monitor, and merge paired pull requests across the public AetherKiri repository and private AetherInternal package without publishing private source or unrelated history. Use when a change spans public engine hooks and private plugin implementations, when a public gitlink must pin an unmerged Internal commit for trusted CI, when GitHub Actions must build the combined product, or when reviewing cross-repository PR security, workflow failures, merge order, and cleanup.
+---
+
+# Submit AetherKiri Cross-Repo PRs
+
+Create minimal, reviewable public and private PRs while preserving the AetherInternal confidentiality boundary. Treat successful compilation and confidentiality as separate requirements.
+
+## Establish the trust boundary
+
+Confirm all of the following before pushing:
+
+- AetherKiri is public and `packages/AetherInternal` is a private git submodule.
+- Private implementation, tests that disclose algorithms, reverse-engineering notes, and proprietary assets remain in AetherInternal.
+- Public changes contain only generic interfaces, portable fallback behavior, package integration, non-sensitive tests, documentation, and the gitlink.
+- The public branch is created inside `AetherKiri/AetherKiri` when combined CI requires repository secrets. Fork and Dependabot PRs do not receive `AETHERSECRET` and must build public fallbacks.
+- The workflow uses `pull_request`, not `pull_request_target`, to execute PR code.
+
+Do not equate a private checkout with zero disclosure. A public gitlink reveals the private commit SHA. Public Actions logs can reveal private paths, symbol names, warnings, or compiler error excerpts. Uploaded application artifacts contain compiled Internal code and can be reverse engineered. Never claim absolute secrecy when public CI builds private code.
+
+## Audit public workflow exposure
+
+Before relying on combined CI, inspect `.github/workflows` on the PR base and branch:
+
+1. Confirm trusted same-repository PRs enable Internal and supply only the read-only deploy key required for submodule checkout.
+2. Confirm untrusted/fork PRs disable recursive private submodules and select public fallbacks.
+3. Keep `persist-credentials: false` and repository permissions at `contents: read` unless a reviewed job requires more.
+4. Confirm no step prints secrets, SSH configuration, private diffs, source contents, environment dumps, or generated compile databases.
+5. Review every artifact upload. Public app artifacts include private compiled behavior even when source stays private. Upload them only when that distribution is intentional.
+6. Keep caches from untrusted PRs read-only and never cache credentials or private source trees into a public artifact.
+
+If private source confidentiality is stricter than public build-log exposure allows, run the full build in AetherInternal and report a status to public instead of compiling Internal in public Actions.
+
+## Create clean branches
+
+Use independent worktrees based on the latest remote default branches. Do not open a PR from a long-lived branch containing removed, reverted, or previously private history.
+
+1. Fetch both remotes and inspect open PRs.
+2. Create the Internal branch from the latest `AetherInternal/origin/main`.
+3. Create the public branch from the latest `AetherKiri/origin/main`.
+4. Reapply only the commits required for the current fix. Preserve author identity.
+5. Scan the public diff for game files, local paths, private class names, algorithms, proprietary SDK references, secrets, and unrelated historical commits.
+6. Leave local launchers, logs, saves, builds, and game packages untracked.
+
+Use `$fix-aetherkiri-game-compatibility` to determine public/private implementation ownership and validate the game behavior before submission.
+
+## Submit Internal first
+
+1. Commit the private implementation in AetherInternal.
+2. Rebase or merge the latest private `origin/main` before publishing.
+3. Push the private branch.
+4. Obtain the full commit ID from Git; never type or extrapolate it from a short prefix:
+
+```bash
+git rev-parse HEAD
+git ls-remote origin refs/heads/BRANCH
+```
+
+Require both commands to report the same 40-character SHA.
+
+5. Open the Internal PR against `main` and record its URL.
+6. Keep the remote branch until the public PR has merged or its gitlink points to an Internal `main` commit.
+
+An Internal commit does not need to be merged for trusted public CI to test it. It must be reachable from an advertised private remote ref and readable by the workflow deploy key.
+
+## Prepare the public PR
+
+1. Add only generic engine hooks and public behavior required by the private extension.
+2. Pin `packages/AetherInternal` to the verified full Internal SHA. Prefer checking out the submodule commit and staging it; if using `git update-index --cacheinfo`, paste the output of `git rev-parse`, then verify:
+
+```bash
+git ls-tree HEAD packages/AetherInternal
+git ls-remote INTERNAL_URL refs/heads/INTERNAL_BRANCH
+```
+
+The two SHAs must match exactly.
+
+3. Do not copy private implementation into a public fallback merely to make CI pass.
+4. Add public tests and compatibility documentation without private fixtures or local paths.
+5. Run `git diff --check`, inspect every public file, and confirm `.github/workflows` is unchanged unless workflow behavior is explicitly part of the reviewed fix.
+6. Push the same-repository public branch and open the PR against `main`.
+7. Link the Internal PR from the public PR and the public PR from the Internal PR. Describe contracts and behavior, not private implementation details.
+
+## Monitor combined CI
+
+Watch the new run for the exact public head SHA. Ignore superseded runs.
+
+1. Confirm `Checkout Repository` succeeds.
+2. Confirm `Verify AetherInternal package` succeeds and reports the expected gitlink.
+3. Confirm configuration explicitly enables AetherInternal.
+4. Confirm requested platform builds and focused tests run.
+5. Review public logs before sharing them. Move detailed private compiler diagnostics to the private PR when they disclose implementation.
+6. Check uploaded artifacts against the intended distribution policy.
+
+An immediate `not our ref` failure means the gitlink is wrong, the commit was not pushed, the branch was deleted, or the deploy key cannot read it. Compare full SHAs before changing workflows.
+
+If public `main` advances and the PR becomes conflicting, merge or rebase the latest base. Resolve a submodule conflict only after proving ancestry:
+
+```bash
+git -C INTERNAL_REPO merge-base --is-ancestor BASE_INTERNAL_SHA PR_INTERNAL_SHA
+```
+
+Retain the PR Internal SHA when it descends from the new base pin. Re-run diff and workflow checks after resolving.
+
+## Merge safely
+
+Prefer this order:
+
+1. Merge the Internal PR.
+2. Determine the commit now reachable from Internal `main`.
+3. If Internal was squash-merged or rebased, update the public gitlink to the new resulting SHA and rerun CI.
+4. Merge the public PR only after its gitlink is permanently reachable.
+5. Delete feature branches only after both default branches and CI no longer depend on them.
+
+Public may technically merge while pinning an unmerged private branch commit, and `main` workflow can build it while that ref remains available. Do not use this as the normal merge order because deleting or rewriting the private branch would break every fresh checkout of public `main`.
+
+## Report completion
+
+Report both PR URLs, exact head SHAs, public gitlink SHA, mergeability, CI status, intended artifact exposure, and merge order. State explicitly that private source is not present in the public diff, while acknowledging any public build-log and binary-artifact exposure.

--- a/.agents/skills/submit-aetherkiri-cross-repo-prs/agents/openai.yaml
+++ b/.agents/skills/submit-aetherkiri-cross-repo-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Submit AetherKiri Cross-Repo PRs"
+  short_description: "Coordinate secure public and Internal pull requests"
+  default_prompt: "Use $submit-aetherkiri-cross-repo-prs to prepare, validate, and submit paired AetherKiri and AetherInternal pull requests without exposing private source."

--- a/cpp/core/tjs2/tjs.cpp
+++ b/cpp/core/tjs2/tjs.cpp
@@ -11,6 +11,7 @@
 
 #include "tjsCommHead.h"
 
+#include <atomic>
 #include <map>
 #include <cassert>
 #include <fmt/printf.h>
@@ -35,6 +36,26 @@ extern "C" void TJS_CollectOrphanedICCs(bool force = false);
 #include "tjsRegExp.h"
 
 namespace TJS {
+    namespace {
+        std::atomic<tTJSStructuredDataPackLoader> &
+        TJSStructuredDataPackLoaderSlot() {
+            static std::atomic<tTJSStructuredDataPackLoader> loader{ nullptr };
+            return loader;
+        }
+    }
+
+    void TJSSetStructuredDataPackLoader(tTJSStructuredDataPackLoader loader) {
+        TJSStructuredDataPackLoaderSlot().store(loader,
+                                                std::memory_order_release);
+    }
+
+    bool TJSLoadStructuredDataPack(tTJSBinaryStream *stream,
+                                   tTJSVariant *result) {
+        const auto loader =
+            TJSStructuredDataPackLoaderSlot().load(std::memory_order_acquire);
+        return loader && loader(stream, result);
+    }
+
 #ifndef TJS_NO_REGEXP
 
     extern iTJSDispatch2 *TJSCreateRegExpClass();

--- a/cpp/core/tjs2/tjs.h
+++ b/cpp/core/tjs2/tjs.h
@@ -21,6 +21,8 @@
 
 namespace TJS {
 
+    class tTJSBinaryStream;
+
     //---------------------------------------------------------------------------
     // TJS version
     //---------------------------------------------------------------------------
@@ -31,6 +33,13 @@ namespace TJS {
 
     extern const char TJSCompiledDate[];
     //---------------------------------------------------------------------------
+
+    using tTJSStructuredDataPackLoader =
+        bool (*)(tTJSBinaryStream *stream, tTJSVariant *result);
+
+    void TJSSetStructuredDataPackLoader(tTJSStructuredDataPackLoader loader);
+    bool TJSLoadStructuredDataPack(tTJSBinaryStream *stream,
+                                   tTJSVariant *result);
 
     //---------------------------------------------------------------------------
     // Console output callback interface

--- a/cpp/core/tjs2/tjsDictionary.cpp
+++ b/cpp/core/tjs2/tjsDictionary.cpp
@@ -15,7 +15,77 @@
 #include "tjsArray.h"
 #include "tjsBinarySerializer.h"
 #include "tjsDebug.h"
+#include "../base/ScriptMgnIntf.h"
+#include "../base/TextStream.h"
 #include <atomic>
+#include <spdlog/spdlog.h>
+
+namespace {
+
+bool TJSDictionaryStructTraceEnabled() {
+    static const bool enabled = [] {
+        const char *value = std::getenv("AETHERKIRI_STRUCT_TRACE");
+        return value && *value && *value != '0';
+    }();
+    return enabled;
+}
+
+tjs_error TJSLoadDictionaryStructuredText(tTJSVariant *result,
+                                          const ttstr &name,
+                                          const ttstr &mode,
+                                          iTJSDispatch2 *context) {
+    iTJSTextReadStream *stream = TVPCreateTextStreamForRead(name, mode);
+    if(!stream)
+        return TJS_E_INVALIDPARAM;
+
+    ttstr buffer;
+    try {
+        stream->Read(buffer, 0);
+    } catch(...) {
+        stream->Destruct();
+        throw;
+    }
+    stream->Destruct();
+
+    if(TJSDictionaryStructTraceEnabled()) {
+        std::string prefix = buffer.AsStdString();
+        if(prefix.size() > 160)
+            prefix.resize(160);
+        for(char &ch : prefix) {
+            if(ch == '\r' || ch == '\n' || ch == '\t')
+                ch = ' ';
+        }
+        spdlog::info(
+            "Dictionary.loadStruct text-fallback file={} mode={} chars={} "
+            "prefix=\"{}\"",
+            name.AsStdString(), mode.AsStdString(),
+            static_cast<long long>(buffer.length()), prefix);
+    }
+
+    const tjs_int length = buffer.length();
+    tjs_char *top = buffer.AppendBuffer(9);
+    memmove(top + 8, top, sizeof(tjs_char) * length);
+    memcpy(top, TJS_W("(const)["), sizeof(tjs_char) * 8);
+    top[8 + length] = TJS_W(']');
+    buffer.FixLen();
+
+    tTJSVariant values;
+    TVPExecuteExpression(buffer, TVPExtractStorageName(name), 0, context,
+                         &values);
+
+    if(result) {
+        const tTJSVariantClosure closure = values.AsObjectClosureNoAddRef();
+        if(!closure.Object)
+            return TJS_E_INVALIDPARAM;
+        const tjs_error hr = closure.PropGetByNum(TJS_IGNOREPROP, 0, result,
+                                                  nullptr);
+        if(TJS_FAILED(hr))
+            return hr;
+    }
+    return TJS_S_OK;
+}
+
+} // namespace
 
 static std::atomic<int64_t> sTJSDictCreateCount{0};
 static std::atomic<int64_t> sTJSDictDestroyCount{0};
@@ -82,6 +152,10 @@ namespace TJS {
             ttstr mode;
             if(numparams >= 2 && param[1]->Type() != tvtVoid)
                 mode = *param[1];
+            iTJSDispatch2 *context = numparams >= 3 &&
+                    param[2]->Type() != tvtVoid
+                ? param[2]->AsObjectNoAddRef()
+                : nullptr;
 
             tTJSBinaryStream *stream = TJSCreateBinaryStreamForRead(name, mode);
             if(!stream)
@@ -112,6 +186,10 @@ namespace TJS {
                         }
                     }
                 }
+                if(!isbin) {
+                    stream->SetPosition(0);
+                    isbin = TJSLoadStructuredDataPack(stream, result);
+                }
             } catch(...) {
                 delete stream;
                 if(dicfree) {
@@ -124,7 +202,8 @@ namespace TJS {
             delete stream;
             if(isbin)
                 return TJS_S_OK;
-            return TJS_E_INVALIDPARAM;
+            return TJSLoadDictionaryStructuredText(result, name, mode,
+                                                   context);
         }
         TJS_END_NATIVE_STATIC_METHOD_DECL(/*func. name*/ loadStruct)
         //----------------------------------------------------------------------

--- a/cpp/plugins/tjsNs0DataPack.cpp
+++ b/cpp/plugins/tjsNs0DataPack.cpp
@@ -610,3 +610,26 @@ bool TVPLoadTjsNs0DataPack(tTJSBinaryStream *stream, tTJSVariant *result,
         *result = value;
     return true;
 }
+
+namespace {
+
+bool loadTjsNs0DataPackWithoutOuterIv(tTJSBinaryStream *stream,
+                                      tTJSVariant *result) {
+    return TVPLoadTjsNs0DataPack(stream, result);
+}
+
+} // namespace
+
+extern "C" void TVPRegisterTjsNs0DataPackLoader() {
+    TJS::TJSSetStructuredDataPackLoader(&loadTjsNs0DataPackWithoutOuterIv);
+}
+
+namespace {
+
+struct TjsNs0DataPackLoaderRegistration {
+    TjsNs0DataPackLoaderRegistration() {
+        TVPRegisterTjsNs0DataPackLoader();
+    }
+} TjsNs0DataPackLoaderRegistrationInstance;
+
+} // namespace

--- a/cpp/plugins/tjsNs0DataPack.h
+++ b/cpp/plugins/tjsNs0DataPack.h
@@ -6,3 +6,5 @@
 // signature. Returns false when the stream uses a different format.
 bool TVPLoadTjsNs0DataPack(tTJSBinaryStream *stream, tTJSVariant *result,
                            const ttstr &outerIv = ttstr());
+
+extern "C" void TVPRegisterTjsNs0DataPackLoader();

--- a/doc/verified_games.md
+++ b/doc/verified_games.md
@@ -2,7 +2,7 @@
 
 [简体中文](verified_games.zh-CN.md)
 
-Last updated: 2026-07-22
+Last updated: 2026-07-24
 
 This document tracks games that have been manually smoke-tested with
 AetherKiri. It is a compatibility notebook, not a guarantee that every route,
@@ -37,11 +37,12 @@ movie, plugin path, or save state in a title has been exhaustively validated.
 | サノバウィッチ | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 千恋＊万花 | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 天使☆騒々 RE-BOOT! | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue flow, scene/text rendering, gallery rendering and animation smoke, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
-| ライムライト・レモネードジャム | macOS release app; iOS/iPadOS release app build on iPad | Startup, title animation and menu rendering, continue/load flow, scene/text rendering, gallery navigation/compositing, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
+| ライムライト・レモネードジャム | Windows x64 debug app; macOS release app; iOS/iPadOS release app build on iPad | Startup, title animation and menu rendering, continue/load flow, scene/text rendering, gallery navigation/compositing, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer), [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
 | ワガママハイスペック | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, music selection/playback, lock-screen audio recovery, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | ワガママハイスペック OC | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, music playback, lock-screen audio recovery, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 淫母マンション～ママは、性処理肉便器～ | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, scene/text rendering, audio playback, and basic input | Smoke verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 天色＊アイルノーツ | macOS debug app | Startup, title/menu rendering, continue/load flow, background and character rendering, SD CG transition stability, scene/text rendering, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
+| GINKA | Windows x64 debug app | Import, startup, title/menu rendering, game-data loading, background and character rendering, and basic input | Smoke verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
 | NEKOPARA Vol. 1 | macOS debug app | Startup, title/menu rendering, data-load and first-save flow, scene/text rendering, E-mote character rendering and animation, rapid dialogue input, and character-layer click forwarding | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 
 ## How To Add A Game

--- a/doc/verified_games.zh-CN.md
+++ b/doc/verified_games.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](verified_games.md)
 
-最后更新：2026-07-22
+最后更新：2026-07-24
 
 本文档记录已经用 AetherKiri 手动 smoke test 或 flow test 过的游戏。它是兼容性记录，
 不代表每条路线、每个视频、每个插件路径或每个存档状态都已经完整验证。
@@ -36,11 +36,12 @@
 | サノバウィッチ | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 千恋＊万花 | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 天使☆騒々 RE-BOOT! | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续游戏流程、场景/文字渲染、画廊渲染与动画冒烟、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
-| ライムライト・レモネードジャム | macOS release app；iOS/iPadOS iPad release app build | 启动、标题动画与菜单渲染、继续/读档流程、场景/文字渲染、画廊导航与图像合成、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
+| ライムライト・レモネードジャム | Windows x64 debug app；macOS release app；iOS/iPadOS iPad release app build | 启动、标题动画与菜单渲染、继续/读档流程、场景/文字渲染、画廊导航与图像合成、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer)、[@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
 | ワガママハイスペック | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音乐选择与播放、锁屏恢复音频和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | ワガママハイスペック OC | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音乐播放、锁屏恢复音频和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 淫母マンション～ママは、性処理肉便器～ | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、场景/文字渲染、音频播放和基础输入 | 冒烟验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 天色＊アイルノーツ | macOS debug app | 启动、标题/菜单渲染、继续/读档流程、背景与角色立绘渲染、SD CG 切换稳定性、场景/文字渲染和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
+| GINKA | Windows x64 debug app | 导入、启动、标题/菜单渲染、游戏数据加载、背景与角色渲染，以及基础输入 | 冒烟验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
 | NEKOPARA Vol. 1 | macOS debug app | 启动、标题/菜单渲染、Data Load 与首个存档读取流程、场景/文字渲染、E-mote 角色立绘与动画、快速推进对话，以及立绘区域点击事件转发 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 
 ## 如何新增游戏


### PR DESCRIPTION
Summary
 * add a generic structured-data loader hook after the native Dictionary.loadStruct binary path
 * register the public ns0 fallback and pin AetherInternal's private loader integration
 * record Windows verification for GINKA and ライムライト・レモネードジャム
 * add repository skills for game-compatibility repair and secure public/Internal PR submission
The loader only accepts the TJS/?s0 signature. Other streams retain the normal structured-text fallback, and no game title, local path, or game-specific resource name is used by runtime code.
Depends on AetherKiri/AetherInternal#1.
Validation
 * Windows x64 Debug full application build with AetherInternal enabled
 * GINKA import, startup, title/menu, data loading, background/character rendering, and basic input
 * ライムライト・レモネードジャム startup, title/menu, scene rendering, and basic input
 * both repository skills pass skill-creator quick validation
The plugin test executable compiles and links, but existing duplicate DrawDeviceD2D Catch2 test names across public/Internal currently stop test discovery.
Confidentiality boundary
The public diff contains no private source. Trusted same-repository CI checks out the pinned private commit with the repository deploy key. The public gitlink exposes the Internal commit SHA, and public workflow logs plus uploaded application artifacts may expose private symbols or compiled behavior; they are not equivalent to source confidentiality.
