### PR TITLE
fix: center startup logos and retain settled title frame

### DIFF
--- a/cpp/plugins/motionplayer/PlayerInternal.h
+++ b/cpp/plugins/motionplayer/PlayerInternal.h
@@ -112,6 +112,39 @@ namespace internal {
                 clipRect[3] >= canvasHeight;
         }
 
+        inline bool
+        startupLogoUsesCenteredOrigin(const std::array<float, 4> &bounds,
+                                      int canvasWidth, int canvasHeight) {
+            if(canvasWidth <= 0 || canvasHeight <= 0 ||
+               !std::all_of(bounds.begin(), bounds.end(),
+                            [](float value) { return std::isfinite(value); })) {
+                return false;
+            }
+
+            const float width = bounds[2] - bounds[0];
+            const float height = bounds[3] - bounds[1];
+            if(width <= 0.0f || height <= 0.0f) {
+                return false;
+            }
+
+            const bool crossesOrigin = bounds[0] < 0.0f && bounds[1] < 0.0f &&
+                bounds[2] > 0.0f && bounds[3] > 0.0f;
+            if(!crossesOrigin) {
+                return false;
+            }
+
+            const float canvasWidthF = static_cast<float>(canvasWidth);
+            const float canvasHeightF = static_cast<float>(canvasHeight);
+            const float centerX = (bounds[0] + bounds[2]) * 0.5f;
+            const float centerY = (bounds[1] + bounds[3]) * 0.5f;
+            const float centeredToleranceX =
+                std::min(canvasWidthF * 0.1f, width * 0.2f + 1e-3f);
+            const float centeredToleranceY =
+                std::min(canvasHeightF * 0.1f, height * 0.2f + 1e-3f);
+            return std::fabs(centerX) <= centeredToleranceX &&
+                std::fabs(centerY) <= centeredToleranceY;
+        }
+
         inline bool isFullCanvasCompositeRenderRoot(
             bool groupOnly,
             bool hasRenderParent,

--- a/cpp/plugins/motionplayer/PlayerInternal.h
+++ b/cpp/plugins/motionplayer/PlayerInternal.h
@@ -166,6 +166,61 @@ namespace internal {
                 motionPath.find("m2logo.mtn") != std::string::npos;
         }
 
+        inline bool startupLogoMotionUsesStableBackdropReference(
+            std::string motionPath) {
+            std::transform(motionPath.begin(), motionPath.end(),
+                           motionPath.begin(),
+                           [](unsigned char ch) {
+                               return static_cast<char>(std::tolower(ch));
+                           });
+            return motionPath.find("m2logo.mtn") != std::string::npos;
+        }
+
+        inline bool startupLogoStableBackdropSource(
+            const std::string &motionPath,
+            std::string sourceKey) {
+            if(!startupLogoMotionUsesStableBackdropReference(motionPath)) {
+                return false;
+            }
+            std::transform(sourceKey.begin(), sourceKey.end(),
+                           sourceKey.begin(),
+                           [](unsigned char ch) {
+                               return static_cast<char>(std::tolower(ch));
+                           });
+            return sourceKey == "src/logo/icon50" ||
+                sourceKey.find("/logo/icon/icon50") != std::string::npos;
+        }
+
+        inline bool startupLogoPresentationScaleAppliesToSource(
+            const std::string &motionPath,
+            const std::string &sourceKey) {
+            return !startupLogoMotionUsesStableBackdropReference(motionPath) ||
+                startupLogoStableBackdropSource(motionPath, sourceKey);
+        }
+
+        inline std::array<float, 2> startupLogoPresentationScale(
+            std::string motionPath,
+            float canvasWidth,
+            float canvasHeight,
+            float referenceWidth,
+            float referenceHeight) {
+            if(!std::isfinite(canvasWidth) || !std::isfinite(canvasHeight) ||
+               !std::isfinite(referenceWidth) ||
+               !std::isfinite(referenceHeight) ||
+               canvasWidth <= 0.0f || canvasHeight <= 0.0f ||
+               referenceWidth <= 0.0f || referenceHeight <= 0.0f) {
+                return { 1.0f, 1.0f };
+            }
+
+            const float scaleX = canvasWidth / referenceWidth;
+            const float scaleY = canvasHeight / referenceHeight;
+            if(startupLogoMotionUsesStableBackdropReference(motionPath)) {
+                const float coveredScale = std::max(scaleX, scaleY);
+                return { coveredScale, coveredScale };
+            }
+            return { scaleX, scaleY };
+        }
+
         inline bool shouldCaptureYuzuTitlePresentationHoldFrame(
             bool hadHeldFrame,
             bool finalFrameRendered,
@@ -183,6 +238,17 @@ namespace internal {
             bool hasStableComposition,
             bool hasActiveTransientLogo) {
             return hasStableComposition && !hasActiveTransientLogo;
+        }
+
+        inline bool yuzuTitlePresentationHoldFrameIsResident(
+            bool exactLayer,
+            bool layerVisible,
+            bool parentVisible,
+            bool hasImage,
+            bool hasMainImage,
+            int opacity) {
+            return exactLayer && layerVisible && parentVisible && hasImage &&
+                hasMainImage && opacity > 0;
         }
 
         inline bool isFullCanvasCompositeRenderRoot(
@@ -3252,6 +3318,46 @@ namespace internal {
         // with pre-computed positions for the sub_6C7440 render loop.
         // Aligned to libkrkr2.so: full 2x3 affine [m11,m21,m12,m22,tx,ty]
         using Affine2x3 = std::array<double, 6>;
+
+        inline Affine2x3 startupLogoGeometryParentTransform(
+            const std::string &motionPath,
+            const Affine2x3 &parent,
+            int inheritFlags) {
+            if(!startupLogoMotionUsesStableBackdropReference(motionPath) ||
+               (inheritFlags & 0x060) == 0x060) {
+                return parent;
+            }
+
+            const double basisX =
+                std::hypot(parent[0], parent[1]);
+            const double basisY =
+                std::hypot(parent[2], parent[3]);
+            if(!std::isfinite(basisX) || !std::isfinite(basisY) ||
+               basisX <= 1.0e-9 || basisY <= 1.0e-9) {
+                return parent;
+            }
+
+            // A skewed basis cannot be separated into independent authored
+            // X/Y scales without changing its slant. M2's text parent is an
+            // orthogonal uniform-scale transform, so keep the compatibility
+            // correction deliberately narrow.
+            const double basisDot =
+                parent[0] * parent[2] + parent[1] * parent[3];
+            if(std::fabs(basisDot) > basisX * basisY * 1.0e-6) {
+                return parent;
+            }
+
+            Affine2x3 result = parent;
+            if((inheritFlags & 0x020) == 0) {
+                result[0] /= basisX;
+                result[1] /= basisX;
+            }
+            if((inheritFlags & 0x040) == 0) {
+                result[2] /= basisY;
+                result[3] /= basisY;
+            }
+            return result;
+        }
 
         // Compose: result = parent * Translate(lx, ly)
         inline Affine2x3 affineTranslate(const Affine2x3 &p, double lx, double ly) {

--- a/cpp/plugins/motionplayer/PlayerInternal.h
+++ b/cpp/plugins/motionplayer/PlayerInternal.h
@@ -145,6 +145,46 @@ namespace internal {
                 std::fabs(centerY) <= centeredToleranceY;
         }
 
+        inline bool startupLogoMotionUsesCenteredOrigin(
+            std::string motionPath) {
+            std::transform(motionPath.begin(), motionPath.end(),
+                           motionPath.begin(),
+                           [](unsigned char ch) {
+                               return static_cast<char>(std::tolower(ch));
+                           });
+            return motionPath.find("yuzulogo.mtn") != std::string::npos;
+        }
+
+        inline bool startupLogoMotionScalesAroundCanvasCenter(
+            std::string motionPath) {
+            std::transform(motionPath.begin(), motionPath.end(),
+                           motionPath.begin(),
+                           [](unsigned char ch) {
+                               return static_cast<char>(std::tolower(ch));
+                           });
+            return motionPath.find("yuzulogo.mtn") != std::string::npos ||
+                motionPath.find("m2logo.mtn") != std::string::npos;
+        }
+
+        inline bool shouldCaptureYuzuTitlePresentationHoldFrame(
+            bool hadHeldFrame,
+            bool finalFrameRendered,
+            bool hasOpaqueCanvasBaseFrame,
+            bool hasStableFrame,
+            bool hasOpaqueFinalOverlayFrame) {
+            if(!hadHeldFrame) {
+                return hasOpaqueCanvasBaseFrame || hasStableFrame ||
+                    hasOpaqueFinalOverlayFrame;
+            }
+            return !finalFrameRendered && hasOpaqueFinalOverlayFrame;
+        }
+
+        inline bool yuzuTitlePresentationFrameIsStable(
+            bool hasStableComposition,
+            bool hasActiveTransientLogo) {
+            return hasStableComposition && !hasActiveTransientLogo;
+        }
+
         inline bool isFullCanvasCompositeRenderRoot(
             bool groupOnly,
             bool hasRenderParent,

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -659,11 +659,11 @@ namespace {
         return value;
     }
 
-    constexpr const char *kYuzuStartupLogoMotion = "yuzulogo.mtn";
     constexpr const char *kM2StartupLogoMotion = "m2logo.mtn";
 
     bool loweredPathContainsYuzuStartupLogo(const std::string &loweredPath) {
-        return loweredPath.find(kYuzuStartupLogoMotion) != std::string::npos;
+        return motion::internal::startupLogoMotionUsesCenteredOrigin(
+            loweredPath);
     }
 
     bool loweredPathContainsM2StartupLogo(const std::string &loweredPath) {
@@ -731,8 +731,8 @@ namespace {
     }
 
     bool isYuzuStartupLogoMotion(const std::string &motionPath) {
-        const auto motion = renderDebugLowercase(motionPath);
-        return loweredPathContainsYuzuStartupLogo(motion);
+        return motion::internal::startupLogoMotionUsesCenteredOrigin(
+            motionPath);
     }
 
     bool isM2StartupLogoMotion(const std::string &motionPath) {
@@ -741,8 +741,8 @@ namespace {
     }
 
     bool isYuzuLogoPresentationMotion(const std::string &motionPath) {
-        return isM2StartupLogoMotion(motionPath) ||
-            isYuzuStartupLogoMotion(motionPath);
+        return motion::internal::startupLogoMotionScalesAroundCanvasCenter(
+            motionPath);
     }
 
     std::array<int, 4> neutralStartupLogoTint(
@@ -1163,11 +1163,18 @@ namespace {
         bool hasOpaqueBackground = false;
         bool hasOpaqueNumberedComposite = false;
         bool hasOpaqueMainOrLogo = false;
+        bool hasActiveTransientLogo = false;
         for(const auto &entry : runtime.preparedRenderItems) {
             if(!entry.drawFlag || entry.skipFlag0 || entry.skipFlag1 ||
-               entry.opacity < 240 ||
                isYuzuTitleWhiteUtilityLayer("title_bg", entry.nodeLabel,
                                             entry.sourceKey)) {
+                continue;
+            }
+            if(isYuzuTitleLogoLayer(entry.nodeLabel, entry.sourceKey) &&
+               entry.opacity > 0 && (entry.blendMode & 0x0f) != 0) {
+                hasActiveTransientLogo = true;
+            }
+            if(entry.opacity < 240) {
                 continue;
             }
             if(isYuzuTitleBackgroundLayer(entry.nodeLabel, entry.sourceKey)) {
@@ -1189,8 +1196,9 @@ namespace {
                 ++opaqueNormalPresentationItems;
             }
         }
-        return (hasOpaqueBackground && opaqueTitleCharacters >= 3 &&
-                hasOpaqueMainOrLogo) ||
+        const bool hasStableComposition =
+            (hasOpaqueBackground && opaqueTitleCharacters >= 3 &&
+             hasOpaqueMainOrLogo) ||
             // A normal title card commonly starts with its opaque background
             // and character while a white transition is still fading out.
             // That is a useful delta-composition base, but not the terminal
@@ -1198,6 +1206,8 @@ namespace {
             // signal that the card is ready to retain after the motion ends.
             (opaqueNormalPresentationItems >= 2 && hasOpaqueMainOrLogo) ||
             (hasOpaqueNumberedComposite && hasOpaqueMainOrLogo);
+        return motion::internal::yuzuTitlePresentationFrameIsStable(
+            hasStableComposition, hasActiveTransientLogo);
     }
 
     void logYuzuTitlePreparedSummary(
@@ -1740,6 +1750,11 @@ namespace {
         }
         const bool isTitleMotion = isYuzuTitlePresentationMotion(motionPath);
         const bool isLogoMotion = isYuzuLogoPresentationMotion(motionPath);
+        // Yuzu authors its startup motion around (0, 0), while M2 is already
+        // mapped into canvas space. M2 also contains centered helper geometry,
+        // so geometry alone cannot determine the motion-level convention.
+        const bool logoUsesCenteredOrigin =
+            isYuzuStartupLogoMotion(motionPath);
 
         if(isTitleMotion) {
             const bool hasSyntheticIntroLayer = std::any_of(
@@ -1855,12 +1870,13 @@ namespace {
             }
         }
 
-        // Startup logos may arrive either in their legacy centered coordinate
-        // system or already transformed into canvas coordinates. Infer the
-        // convention from prepared geometry instead of always adding half a
-        // canvas, which moves canvas-space logos off the bottom-right edge.
+        // Confirm that Yuzu still has centered authored geometry before
+        // translating it. Never promote M2's centered helper geometry to a
+        // motion-level decision: its full-canvas backdrop is already mapped
+        // to canvas space and another half-canvas translation clips the logo.
         bool usesCenteredPresentationOrigin =
-            isLogoMotion && runtime.yuzuPresentationCenteredOriginConfirmed;
+            logoUsesCenteredOrigin &&
+            runtime.yuzuPresentationCenteredOriginConfirmed;
         float centeredPresentationTranslateX =
             static_cast<float>(canvasWidth) * 0.5f;
         float centeredPresentationTranslateY =
@@ -1995,8 +2011,11 @@ namespace {
                     return;
                 }
                 if(isLogoMotion) {
-                    if(motion::internal::startupLogoUsesCenteredOrigin(
-                           referenceBox, canvasWidth, canvasHeight)) {
+                    const bool needsCanvasCenterTranslation =
+                        logoUsesCenteredOrigin &&
+                        motion::internal::startupLogoUsesCenteredOrigin(
+                            referenceBox, canvasWidth, canvasHeight);
+                    if(needsCanvasCenterTranslation) {
                         usesCenteredPresentationOrigin = true;
                         centeredOriginFromReference = true;
                         runtime.yuzuPresentationCenteredOriginConfirmed = true;
@@ -2288,8 +2307,13 @@ namespace {
             return;
         }
 
+        // Both startup logo motions are positioned around the canvas center
+        // before presentation scaling. Yuzu may additionally need its
+        // centered authored origin translated first; M2 must not be
+        // translated, but still needs to scale around the canvas center.
         const bool scaleAroundCanvasCenter =
-            isLogoMotion && usesCenteredPresentationOrigin;
+            motion::internal::startupLogoMotionScalesAroundCanvasCenter(
+                motionPath);
         const float scaleOriginX =
             scaleAroundCanvasCenter ? static_cast<float>(canvasWidth) * 0.5f
                                     : 0.0f;
@@ -11918,11 +11942,13 @@ namespace motion {
                 findYuzuTitlePresentationHoldFrame(
                     finalNativeLayer, motionPath) != nullptr;
             const bool shouldCaptureTitleFrame =
-                (!hadHeldFrame &&
-                 (yuzuTitleHasOpaqueCanvasBaseFrame ||
-                  yuzuTitleHasStableFrame)) ||
-                (hadHeldFrame && !_runtime->yuzuTitleFinalFrameRendered &&
-                 yuzuTitleHasOpaqueFinalOverlayFrame);
+                motion::internal::
+                    shouldCaptureYuzuTitlePresentationHoldFrame(
+                        hadHeldFrame,
+                        _runtime->yuzuTitleFinalFrameRendered,
+                        yuzuTitleHasOpaqueCanvasBaseFrame,
+                        yuzuTitleHasStableFrame,
+                        yuzuTitleHasOpaqueFinalOverlayFrame);
             if(shouldCaptureTitleFrame) {
                 capturedYuzuTitleFrame =
                     captureYuzuTitlePresentationHoldFrame(
@@ -11932,7 +11958,7 @@ namespace motion {
             }
             if(capturedYuzuTitleFrame &&
                (yuzuTitleHasStableFrame ||
-                (hadHeldFrame && yuzuTitleHasOpaqueFinalOverlayFrame))) {
+                yuzuTitleHasOpaqueFinalOverlayFrame)) {
                 _runtime->yuzuTitleFinalFrameRendered = true;
             }
         }

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -2214,6 +2214,39 @@ namespace {
         float refHeight = 0.0f;
         float refArea = 0.0f;
         int refOpacity = -1;
+        const bool useStableBackdropReference =
+            isLogoMotion &&
+            motion::internal::startupLogoMotionUsesStableBackdropReference(
+                motionPath);
+        if(useStableBackdropReference) {
+            for(const auto &entry : runtime.preparedRenderItems) {
+                if(!entry.drawFlag || entry.skipFlag0 || entry.skipFlag1 ||
+                   !motion::internal::startupLogoStableBackdropSource(
+                       motionPath, entry.sourceKey)) {
+                    continue;
+                }
+                auto referenceBox = boundsFromRenderCorners(entry.corners);
+                if(!validRenderPaintBox(referenceBox) &&
+                   entry.hasViewport && validRenderPaintBox(entry.viewport)) {
+                    referenceBox = entry.viewport;
+                }
+                if(!validRenderPaintBox(referenceBox) &&
+                   validRenderPaintBox(entry.paintBox)) {
+                    referenceBox = entry.paintBox;
+                }
+                if(!validRenderPaintBox(referenceBox)) {
+                    continue;
+                }
+                const float width = referenceBox[2] - referenceBox[0];
+                const float height = referenceBox[3] - referenceBox[1];
+                const float area = width * height;
+                if(area > refArea) {
+                    refArea = area;
+                    refWidth = width;
+                    refHeight = height;
+                }
+            }
+        }
         auto considerReference =
             [&](const motion::detail::PlayerRuntime::PreparedRenderItem &entry,
                 int referenceKind) {
@@ -2274,13 +2307,18 @@ namespace {
 
         // A title background represents the design stage. A named position
         // node is only local content and must never determine canvas scale.
-        if(isTitleMotion) {
-            for(const auto &entry : runtime.preparedRenderItems) {
-                considerReference(entry, 1);
-            }
-        } else {
-            for(const auto &entry : runtime.preparedRenderItems) {
-                considerReference(entry, 0);
+        // M2's backdrop is presentation fill geometry. Its sibling content
+        // already carries the authored animation scale and must not inherit
+        // the backdrop's canvas-cover scale.
+        if(refWidth <= 0.0f || refHeight <= 0.0f) {
+            if(isTitleMotion) {
+                for(const auto &entry : runtime.preparedRenderItems) {
+                    considerReference(entry, 1);
+                }
+            } else {
+                for(const auto &entry : runtime.preparedRenderItems) {
+                    considerReference(entry, 0);
+                }
             }
         }
         if(refWidth <= 0.0f || refHeight <= 0.0f) {
@@ -2292,8 +2330,15 @@ namespace {
             return;
         }
 
-        const float scaleX = static_cast<float>(canvasWidth) / refWidth;
-        const float scaleY = static_cast<float>(canvasHeight) / refHeight;
+        const auto presentationScale =
+            motion::internal::startupLogoPresentationScale(
+                motionPath,
+                static_cast<float>(canvasWidth),
+                static_cast<float>(canvasHeight),
+                refWidth,
+                refHeight);
+        const float scaleX = presentationScale[0];
+        const float scaleY = presentationScale[1];
         if(LOGGER && shouldDebugTitleRender(motionPath) &&
            markRenderDebugLogged("yuzu-presentation-scale-candidate:" +
                                  motionPath)) {
@@ -2309,8 +2354,9 @@ namespace {
 
         // Both startup logo motions are positioned around the canvas center
         // before presentation scaling. Yuzu may additionally need its
-        // centered authored origin translated first; M2 must not be
-        // translated, but still needs to scale around the canvas center.
+        // centered authored origin translated first. M2 keeps its authored
+        // content size while uniformly covering the canvas with only its
+        // solid backdrop.
         const bool scaleAroundCanvasCenter =
             motion::internal::startupLogoMotionScalesAroundCanvasCenter(
                 motionPath);
@@ -2339,6 +2385,11 @@ namespace {
         };
 
         for(auto &entry : runtime.preparedRenderItems) {
+            if(!motion::internal::
+                   startupLogoPresentationScaleAppliesToSource(
+                       motionPath, entry.sourceKey)) {
+                continue;
+            }
             const bool scaleGeometry =
                 shouldScaleBox(boundsFromRenderCorners(entry.corners));
             if(scaleGeometry) {
@@ -4110,6 +4161,26 @@ namespace {
             }
         }
         return best;
+    }
+
+    bool yuzuTitlePresentationHoldFrameIsResident(
+        tTJSNI_BaseLayer *layer,
+        const std::string &motionPath) {
+        if(!layer) {
+            return false;
+        }
+        const auto &cache = yuzuTitlePresentationHoldCache();
+        const auto exact = cache.find(layer);
+        const bool exactLayer =
+            exact != cache.end() && exact->second.bitmap &&
+            exact->second.motion == motionPath;
+        return motion::internal::yuzuTitlePresentationHoldFrameIsResident(
+            exactLayer,
+            layer->GetVisible(),
+            layer->GetParentVisible(),
+            layer->GetHasImage(),
+            layer->GetMainImage() != nullptr,
+            layer->GetOpacity());
     }
 
     bool restoreYuzuTitlePresentationHoldFrame(
@@ -11418,14 +11489,20 @@ namespace motion {
             yuzuTitlePresentation &&
             hasYuzuTitleOpaqueFinalOverlayFrame(*_runtime);
         if(yuzuTitlePresentation && !yuzuTitleHasRenderableFrame) {
+            const bool residentHeldFrame =
+                _runtime->yuzuTitleFinalFrameRendered &&
+                yuzuTitlePresentationHoldFrameIsResident(
+                    finalNativeLayer, motionPath);
             const bool restoredHeldFrame =
+                !residentHeldFrame &&
                 restoreYuzuTitlePresentationHoldFrame(
                     finalNativeLayer, motionPath, canvasWidth, canvasHeight);
             if(LOGGER && shouldDebugTitleRender(motionPath) &&
                markRenderDebugLogged("presentation-skip-empty:" + motionPath)) {
                 LOGGER->info(
-                    "motion presentation skip empty title frame: motion={} restored={} target=[{}]",
-                    motionPath, restoredHeldFrame ? 1 : 0,
+                    "motion presentation skip empty title frame: motion={} resident={} restored={} target=[{}]",
+                    motionPath, residentHeldFrame ? 1 : 0,
+                    restoredHeldFrame ? 1 : 0,
                     describeLayerForDebug(finalNativeLayer));
             }
             _runtime->clearPresentationRenderReuse();
@@ -11437,14 +11514,19 @@ namespace motion {
         if(yuzuTitlePresentation &&
            _runtime->yuzuTitleFinalFrameRendered &&
            !yuzuTitleHasOpaqueCanvasBaseFrame) {
+            const bool residentHeldFrame =
+                yuzuTitlePresentationHoldFrameIsResident(
+                    finalNativeLayer, motionPath);
             const bool restoredHeldFrame =
+                !residentHeldFrame &&
                 restoreYuzuTitlePresentationHoldFrame(
                     finalNativeLayer, motionPath, canvasWidth, canvasHeight);
             if(LOGGER && shouldDebugTitleRender(motionPath) &&
                markRenderDebugLogged("presentation-skip-tail:" + motionPath)) {
                 LOGGER->info(
-                    "motion presentation skip title tail frame: motion={} restored={} target=[{}]",
-                    motionPath, restoredHeldFrame ? 1 : 0,
+                    "motion presentation skip title tail frame: motion={} resident={} restored={} target=[{}]",
+                    motionPath, residentHeldFrame ? 1 : 0,
+                    restoredHeldFrame ? 1 : 0,
                     describeLayerForDebug(finalNativeLayer));
             }
             _runtime->clearPresentationRenderReuse();

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -1855,7 +1855,12 @@ namespace {
             }
         }
 
-        bool usesCenteredPresentationOrigin = isLogoMotion;
+        // Startup logos may arrive either in their legacy centered coordinate
+        // system or already transformed into canvas coordinates. Infer the
+        // convention from prepared geometry instead of always adding half a
+        // canvas, which moves canvas-space logos off the bottom-right edge.
+        bool usesCenteredPresentationOrigin =
+            isLogoMotion && runtime.yuzuPresentationCenteredOriginConfirmed;
         float centeredPresentationTranslateX =
             static_cast<float>(canvasWidth) * 0.5f;
         float centeredPresentationTranslateY =
@@ -1927,7 +1932,11 @@ namespace {
         auto considerCenteredOrigin =
             [&](const motion::detail::PlayerRuntime::PreparedRenderItem &entry,
                 int referenceKind) {
-                if(!entry.drawFlag || entry.opacity <= 0 ||
+                // Logo origin is a motion-level convention. Inspect prepared
+                // stage geometry even before it fades in, then keep a positive
+                // centered-origin decision stable for later animated frames.
+                if(!entry.drawFlag || entry.skipFlag0 || entry.skipFlag1 ||
+                   (!isLogoMotion && entry.opacity <= 0) ||
                    isYuzuTitleWhiteUtilityLayer(motionPath, entry.nodeLabel,
                                                 entry.sourceKey)) {
                     return;
@@ -1983,6 +1992,19 @@ namespace {
                     referenceBox = entry.paintBox;
                 }
                 if(!validRenderPaintBox(referenceBox)) {
+                    return;
+                }
+                if(isLogoMotion) {
+                    if(motion::internal::startupLogoUsesCenteredOrigin(
+                           referenceBox, canvasWidth, canvasHeight)) {
+                        usesCenteredPresentationOrigin = true;
+                        centeredOriginFromReference = true;
+                        runtime.yuzuPresentationCenteredOriginConfirmed = true;
+                        runtime.yuzuPresentationTranslateX =
+                            centeredPresentationTranslateX;
+                        runtime.yuzuPresentationTranslateY =
+                            centeredPresentationTranslateY;
+                    }
                     return;
                 }
                 const float width = referenceBox[2] - referenceBox[0];

--- a/cpp/plugins/motionplayer/PlayerUpdateLayers.cpp
+++ b/cpp/plugins/motionplayer/PlayerUpdateLayers.cpp
@@ -1000,13 +1000,37 @@ namespace motion {
                     if (flags & 0x080) node.accumulated.slantX += rootNode.accumulated.slantX;
                     if (flags & 0x100) node.accumulated.slantY += rootNode.accumulated.slantY;
 
-                    // Phase D: Matrix multiply parent × local (0x6BBA24)
+                    // Phase D: Matrix multiply parent × local (0x6BBA24).
+                    // M2's glyph nodes intentionally omit both scale bits:
+                    // their positions follow the 2x parent transform, but
+                    // their image geometry stays at its authored size. The
+                    // position was already transformed above, so remove only
+                    // the omitted orthogonal scale from the geometry matrix.
+                    Affine2x3 parentGeometryAffine = {
+                        parent.accumulated.m11,
+                        parent.accumulated.m21,
+                        parent.accumulated.m12,
+                        parent.accumulated.m22,
+                        0.0,
+                        0.0
+                    };
+                    parentGeometryAffine =
+                        startupLogoGeometryParentTransform(
+                            motionPath, parentGeometryAffine, flags);
                     const double lm11 = localAffine[0], lm21 = localAffine[1];
                     const double lm12 = localAffine[2], lm22 = localAffine[3];
-                    node.accumulated.m11 = parent.accumulated.m11 * lm11 + parent.accumulated.m12 * lm21;
-                    node.accumulated.m21 = parent.accumulated.m21 * lm11 + parent.accumulated.m22 * lm21;
-                    node.accumulated.m12 = parent.accumulated.m11 * lm12 + parent.accumulated.m12 * lm22;
-                    node.accumulated.m22 = parent.accumulated.m21 * lm12 + parent.accumulated.m22 * lm22;
+                    node.accumulated.m11 =
+                        parentGeometryAffine[0] * lm11 +
+                        parentGeometryAffine[2] * lm21;
+                    node.accumulated.m21 =
+                        parentGeometryAffine[1] * lm11 +
+                        parentGeometryAffine[3] * lm21;
+                    node.accumulated.m12 =
+                        parentGeometryAffine[0] * lm12 +
+                        parentGeometryAffine[2] * lm22;
+                    node.accumulated.m22 =
+                        parentGeometryAffine[1] * lm12 +
+                        parentGeometryAffine[3] * lm22;
                 }
             }
         }

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -170,6 +170,8 @@ TEST_CASE("motion presentation excludes structural binder layers") {
 }
 
 TEST_CASE("startup logo presentation preserves its authored origin") {
+    using motion::internal::startupLogoMotionScalesAroundCanvasCenter;
+    using motion::internal::startupLogoMotionUsesCenteredOrigin;
     using motion::internal::startupLogoUsesCenteredOrigin;
 
     constexpr int canvasWidth = 1920;
@@ -192,6 +194,53 @@ TEST_CASE("startup logo presentation preserves its authored origin") {
         { -1.0f, -1.0f, 3.0f, 3.0f }, canvasWidth, canvasHeight));
     CHECK_FALSE(startupLogoUsesCenteredOrigin({ 0.0f, 0.0f, 960.0f, 540.0f },
                                               canvasWidth, canvasHeight));
+
+    const std::array<float, 4> centeredLogoBounds{
+        -960.0f, -540.0f, 960.0f, 540.0f
+    };
+    CHECK(startupLogoMotionUsesCenteredOrigin("motion/yuzulogo.mtn"));
+    CHECK(startupLogoMotionUsesCenteredOrigin("MOTION/YUZULOGO.MTN"));
+    CHECK_FALSE(startupLogoMotionUsesCenteredOrigin("motion/m2logo.mtn"));
+    CHECK(startupLogoMotionScalesAroundCanvasCenter(
+        "motion/yuzulogo.mtn"));
+    CHECK(startupLogoMotionScalesAroundCanvasCenter(
+        "MOTION/M2LOGO.MTN"));
+    CHECK_FALSE(startupLogoMotionScalesAroundCanvasCenter(
+        "motion/title_bg.mtn"));
+    CHECK((startupLogoMotionUsesCenteredOrigin("motion/yuzulogo.mtn") &&
+           startupLogoUsesCenteredOrigin(
+               centeredLogoBounds, canvasWidth, canvasHeight)));
+    CHECK_FALSE((startupLogoMotionUsesCenteredOrigin("motion/m2logo.mtn") &&
+                 startupLogoUsesCenteredOrigin(
+                     centeredLogoBounds, canvasWidth, canvasHeight)));
+    CHECK_FALSE(startupLogoUsesCenteredOrigin(
+        { 0.0f, -8.0f, 1920.0f, 1072.0f },
+        canvasWidth, canvasHeight));
+}
+
+TEST_CASE("title presentation holds its settled overlay") {
+    using motion::internal::shouldCaptureYuzuTitlePresentationHoldFrame;
+    using motion::internal::yuzuTitlePresentationFrameIsStable;
+
+    CHECK(shouldCaptureYuzuTitlePresentationHoldFrame(
+        false, false, true, false, false));
+    CHECK(shouldCaptureYuzuTitlePresentationHoldFrame(
+        false, false, false, true, false));
+    CHECK(shouldCaptureYuzuTitlePresentationHoldFrame(
+        false, false, false, false, true));
+    CHECK_FALSE(shouldCaptureYuzuTitlePresentationHoldFrame(
+        false, false, false, false, false));
+
+    CHECK(shouldCaptureYuzuTitlePresentationHoldFrame(
+        true, false, false, false, true));
+    CHECK_FALSE(shouldCaptureYuzuTitlePresentationHoldFrame(
+        true, true, false, false, true));
+    CHECK_FALSE(shouldCaptureYuzuTitlePresentationHoldFrame(
+        true, false, true, true, false));
+
+    CHECK(yuzuTitlePresentationFrameIsStable(true, false));
+    CHECK_FALSE(yuzuTitlePresentationFrameIsStable(true, true));
+    CHECK_FALSE(yuzuTitlePresentationFrameIsStable(false, false));
 }
 
 TEST_CASE("motionplayer identifies full-canvas split composition planes") {

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -169,6 +169,31 @@ TEST_CASE("motion presentation excludes structural binder layers") {
         motion::internal::presentationLayerTypeCanReceivePixels(ltAlpha));
 }
 
+TEST_CASE("startup logo presentation preserves its authored origin") {
+    using motion::internal::startupLogoUsesCenteredOrigin;
+
+    constexpr int canvasWidth = 1920;
+    constexpr int canvasHeight = 1080;
+
+    CHECK(startupLogoUsesCenteredOrigin({ -960.0f, -540.0f, 960.0f, 540.0f },
+                                        canvasWidth, canvasHeight));
+    CHECK(startupLogoUsesCenteredOrigin({ -300.0f, -120.0f, 300.0f, 120.0f },
+                                        canvasWidth, canvasHeight));
+    CHECK(startupLogoUsesCenteredOrigin({ -768.0f, -432.0f, 768.0f, 432.0f },
+                                        canvasWidth, canvasHeight));
+
+    CHECK_FALSE(startupLogoUsesCenteredOrigin({ 0.0f, 0.0f, 1920.0f, 1080.0f },
+                                              canvasWidth, canvasHeight));
+    CHECK_FALSE(startupLogoUsesCenteredOrigin(
+        { -1.0f, -1.0f, 1919.0f, 1079.0f }, canvasWidth, canvasHeight));
+    CHECK_FALSE(startupLogoUsesCenteredOrigin(
+        { -8.0f, -4.0f, 192.0f, 96.0f }, canvasWidth, canvasHeight));
+    CHECK_FALSE(startupLogoUsesCenteredOrigin(
+        { -1.0f, -1.0f, 3.0f, 3.0f }, canvasWidth, canvasHeight));
+    CHECK_FALSE(startupLogoUsesCenteredOrigin({ 0.0f, 0.0f, 960.0f, 540.0f },
+                                              canvasWidth, canvasHeight));
+}
+
 TEST_CASE("motionplayer identifies full-canvas split composition planes") {
     const std::array<int, 4> canvasRect{0, 0, 1280, 720};
     const std::array<int, 4> partialRect{20, 0, 1280, 720};

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -171,7 +171,11 @@ TEST_CASE("motion presentation excludes structural binder layers") {
 
 TEST_CASE("startup logo presentation preserves its authored origin") {
     using motion::internal::startupLogoMotionScalesAroundCanvasCenter;
+    using motion::internal::startupLogoMotionUsesStableBackdropReference;
     using motion::internal::startupLogoMotionUsesCenteredOrigin;
+    using motion::internal::startupLogoPresentationScaleAppliesToSource;
+    using motion::internal::startupLogoPresentationScale;
+    using motion::internal::startupLogoStableBackdropSource;
     using motion::internal::startupLogoUsesCenteredOrigin;
 
     constexpr int canvasWidth = 1920;
@@ -207,6 +211,66 @@ TEST_CASE("startup logo presentation preserves its authored origin") {
         "MOTION/M2LOGO.MTN"));
     CHECK_FALSE(startupLogoMotionScalesAroundCanvasCenter(
         "motion/title_bg.mtn"));
+    CHECK(startupLogoMotionUsesStableBackdropReference(
+        "motion/m2logo.mtn"));
+    CHECK(startupLogoMotionUsesStableBackdropReference(
+        "MOTION/M2LOGO.MTN"));
+    CHECK_FALSE(startupLogoMotionUsesStableBackdropReference(
+        "motion/yuzulogo.mtn"));
+    CHECK(startupLogoStableBackdropSource(
+        "motion/m2logo.mtn", "src/logo/icon50"));
+    CHECK_FALSE(startupLogoStableBackdropSource(
+        "motion/m2logo.mtn", "src/logo/main"));
+    CHECK_FALSE(startupLogoStableBackdropSource(
+        "motion/yuzulogo.mtn", "src/logo/icon50"));
+    CHECK(startupLogoPresentationScaleAppliesToSource(
+        "motion/m2logo.mtn", "src/logo/icon50"));
+    CHECK_FALSE(startupLogoPresentationScaleAppliesToSource(
+        "motion/m2logo.mtn", "src/logo/main"));
+    CHECK(startupLogoPresentationScaleAppliesToSource(
+        "motion/yuzulogo.mtn", "src/yuzu/yuzu_mi"));
+    const auto m2Scale = startupLogoPresentationScale(
+        "motion/m2logo.mtn", 1920.0f, 1080.0f, 960.0f, 544.0f);
+    CHECK(m2Scale[0] == Catch::Approx(2.0f));
+    CHECK(m2Scale[1] == Catch::Approx(2.0f));
+    const auto yuzuScale = startupLogoPresentationScale(
+        "motion/yuzulogo.mtn", 1920.0f, 1080.0f, 960.0f, 360.0f);
+    CHECK(yuzuScale[0] == Catch::Approx(2.0f));
+    CHECK(yuzuScale[1] == Catch::Approx(3.0f));
+
+    const motion::internal::Affine2x3 doubledParent{
+        2.0, 0.0, 0.0, 2.0, 120.0, 80.0
+    };
+    const auto independentM2Glyph =
+        motion::internal::startupLogoGeometryParentTransform(
+            "motion/m2logo.mtn", doubledParent, 0x19c);
+    CHECK(independentM2Glyph[0] == Catch::Approx(1.0));
+    CHECK(independentM2Glyph[1] == Catch::Approx(0.0));
+    CHECK(independentM2Glyph[2] == Catch::Approx(0.0));
+    CHECK(independentM2Glyph[3] == Catch::Approx(1.0));
+    CHECK(independentM2Glyph[4] == Catch::Approx(120.0));
+    CHECK(independentM2Glyph[5] == Catch::Approx(80.0));
+
+    const auto inheritedM2Glyph =
+        motion::internal::startupLogoGeometryParentTransform(
+            "motion/m2logo.mtn", doubledParent, 0x1fc);
+    CHECK(inheritedM2Glyph == doubledParent);
+    const auto untouchedYuzuGlyph =
+        motion::internal::startupLogoGeometryParentTransform(
+            "motion/yuzulogo.mtn", doubledParent, 0x19c);
+    CHECK(untouchedYuzuGlyph == doubledParent);
+
+    const motion::internal::Affine2x3 rotatedParent{
+        0.0, 2.0, -3.0, 0.0, 0.0, 0.0
+    };
+    const auto independentRotatedM2Glyph =
+        motion::internal::startupLogoGeometryParentTransform(
+            "motion/m2logo.mtn", rotatedParent, 0x19c);
+    CHECK(independentRotatedM2Glyph[0] == Catch::Approx(0.0));
+    CHECK(independentRotatedM2Glyph[1] == Catch::Approx(1.0));
+    CHECK(independentRotatedM2Glyph[2] == Catch::Approx(-1.0));
+    CHECK(independentRotatedM2Glyph[3] == Catch::Approx(0.0));
+
     CHECK((startupLogoMotionUsesCenteredOrigin("motion/yuzulogo.mtn") &&
            startupLogoUsesCenteredOrigin(
                centeredLogoBounds, canvasWidth, canvasHeight)));
@@ -220,6 +284,7 @@ TEST_CASE("startup logo presentation preserves its authored origin") {
 
 TEST_CASE("title presentation holds its settled overlay") {
     using motion::internal::shouldCaptureYuzuTitlePresentationHoldFrame;
+    using motion::internal::yuzuTitlePresentationHoldFrameIsResident;
     using motion::internal::yuzuTitlePresentationFrameIsStable;
 
     CHECK(shouldCaptureYuzuTitlePresentationHoldFrame(
@@ -241,6 +306,19 @@ TEST_CASE("title presentation holds its settled overlay") {
     CHECK(yuzuTitlePresentationFrameIsStable(true, false));
     CHECK_FALSE(yuzuTitlePresentationFrameIsStable(true, true));
     CHECK_FALSE(yuzuTitlePresentationFrameIsStable(false, false));
+
+    CHECK(yuzuTitlePresentationHoldFrameIsResident(
+        true, true, true, true, true, 255));
+    CHECK_FALSE(yuzuTitlePresentationHoldFrameIsResident(
+        false, true, true, true, true, 255));
+    CHECK_FALSE(yuzuTitlePresentationHoldFrameIsResident(
+        true, false, true, true, true, 255));
+    CHECK_FALSE(yuzuTitlePresentationHoldFrameIsResident(
+        true, true, true, false, true, 255));
+    CHECK_FALSE(yuzuTitlePresentationHoldFrameIsResident(
+        true, true, true, true, false, 255));
+    CHECK_FALSE(yuzuTitlePresentationHoldFrameIsResident(
+        true, true, true, true, true, 0));
 }
 
 TEST_CASE("motionplayer identifies full-canvas split composition planes") {


### PR DESCRIPTION
## Summary

- treat YUZUSOFT's startup motion as centered-origin while preserving M2 Cheeseware's canvas-space origin
- use M2's stable backdrop as the canvas-fill reference without scaling its animated content
- respect M2 glyph scale-inheritance masks so `CheeseWare` keeps its authored letter widths and spacing
- retain the already-resident settled title frame instead of clearing and copying it again after the animation
- add regression coverage for presentation scaling, glyph geometry, and title hold-frame residency

## Root cause

YUZUSOFT and M2 use different authored coordinate conventions. Applying one motion-level half-canvas translation to both moved M2 to the bottom-right, while scaling M2 around `(0, 0)` produced the same visible offset even after the translation was removed.

M2 also separates its presentation backdrop from its animated content. Using a transient content quad as the scale reference changed the apparent logo size, and the partial-inherit matrix path reapplied the parent's 2x scale to glyph nodes whose `inheritMask` explicitly excludes scale. The result was 2x-wide letters laid out at the authored spacing, so `CheeseWare` overlapped.

The title flash was separate: once the settled frame had been captured on the same visible layer, the tail-skip path still cleared and copied that bitmap back onto the layer. That redundant clear/copy could expose a blank intermediate GPU frame.

## Impact

YUZUSOFT remains centered, M2 is centered at its authored size with readable text, and the main-menu title keeps its settled frame without a post-animation flash.

## Validation

- `git diff --check`
- macOS debug native targets built successfully: `motionplayer-dll`, `engine_api`
- full `motionplayer-dll` suite: 61 test cases, 805 assertions, all passed
- real-game verification with the supplied `lllj` fixture:
  - [x] YUZUSOFT logo remains centered
  - [x] M2 Cheeseware logo is visible, centered, and its glyphs render at their original 59/47/47/44 px widths instead of 2x
  - [x] title handoff reports `resident=1 restored=0`, avoiding the redundant final-frame rewrite

Fixes #54
