### PR TITLE
fix: restore compatible character layers

### DIFF
--- a/cpp/core/base/ScriptMgnIntf.cpp
+++ b/cpp/core/base/ScriptMgnIntf.cpp
@@ -740,6 +740,91 @@ void TVPExecuteStorage(const ttstr &name, tTJSVariant *result,
 #include <filesystem>
 #include <tjsByteCodeLoader.h>
 
+bool TVPPatchWorldRestoreFaceVisibility(ttstr &script) {
+    using ScriptString = std::basic_string<tjs_char>;
+    const auto missing = ScriptString::npos;
+    ScriptString source(script.c_str(), script.GetLen());
+
+    const ScriptString functionMarker(TJS_W("function _updateAll("));
+    const auto functionPos = source.find(functionMarker);
+    if(functionPos == missing)
+        return false;
+
+    auto functionEnd = source.find(TJS_W("\n\tfunction "),
+                                   functionPos + functionMarker.size());
+    if(functionEnd == missing)
+        functionEnd = source.size();
+
+    if(source.find(TJS_W("__akRestoreFaceVisible"), functionPos) < functionEnd)
+        return false;
+
+    const ScriptString dataMarker(
+        TJS_W("\t\t\tvar data = allData.data;"));
+    const ScriptString captureMarker(
+        TJS_W("\t\t\t\t\t\tcreate.add(info);"));
+    const ScriptString clearMarker(TJS_W("\t\t\tenvClear(leave);"));
+
+    const auto findUniqueInFunction =
+        [&](const ScriptString &marker) -> ScriptString::size_type {
+        const auto first = source.find(marker, functionPos);
+        if(first == missing || first >= functionEnd)
+            return missing;
+        const auto next = source.find(marker, first + marker.size());
+        if(next != missing && next < functionEnd)
+            return missing;
+        return first;
+    };
+
+    const auto dataPos = findUniqueInFunction(dataMarker);
+    const auto capturePos = findUniqueInFunction(captureMarker);
+    const auto clearPos = findUniqueInFunction(clearMarker);
+    if(dataPos == missing || capturePos == missing || clearPos == missing ||
+       !(dataPos < capturePos && capturePos < clearPos))
+        return false;
+
+    const auto lineEndingAfter =
+        [&](ScriptString::size_type position,
+            const ScriptString &marker) -> ScriptString {
+        const auto after = position + marker.size();
+        if(after + 1 < source.size() && source[after] == TJS_W('\r') &&
+           source[after + 1] == TJS_W('\n'))
+            return ScriptString(TJS_W("\r\n"));
+        if(after < source.size() && source[after] == TJS_W('\n'))
+            return ScriptString(TJS_W("\n"));
+        return {};
+    };
+
+    const ScriptString dataEol = lineEndingAfter(dataPos, dataMarker);
+    const ScriptString captureEol =
+        lineEndingAfter(capturePos, captureMarker);
+    const ScriptString clearEol = lineEndingAfter(clearPos, clearMarker);
+    if(dataEol.empty() || captureEol.empty() || clearEol.empty())
+        return false;
+
+    // Insert from the bottom up so the validated source offsets remain valid.
+    source.insert(clearPos + clearMarker.size() + clearEol.size(),
+                  ScriptString(
+                      TJS_W("\t\t\tif (__akRestoreFaceVisible && typeof "
+                            "this.removeIgnore != \"undefined\") { try { "
+                            "this.removeIgnore(\"face\"); } catch("
+                            "__akFaceIgnoreE) {} }")) +
+                      clearEol);
+    source.insert(capturePos + captureMarker.size() + captureEol.size(),
+                  ScriptString(
+                      TJS_W("\t\t\t\t\t\ttry { if (info[0] == \"face\" && "
+                            "info[2] !== void && (info[2].showmode & 1)) "
+                            "__akRestoreFaceVisible = true; } catch("
+                            "__akFaceRestoreE) {}")) +
+                      captureEol);
+    source.insert(dataPos + dataMarker.size() + dataEol.size(),
+                  ScriptString(
+                      TJS_W("\t\t\tvar __akRestoreFaceVisible = false;")) +
+                      dataEol);
+
+    script = ttstr(source);
+    return true;
+}
+
 static void TVPApplyScriptCompatibilityPatches(const ttstr &shortname,
                                                ttstr &buffer) {
     const ttstr lower = shortname.AsLowerCase();
@@ -1426,35 +1511,17 @@ static void TVPApplyScriptCompatibilityPatches(const ttstr &shortname,
                   "\t\tsyncMsgVisibleFromKag();\r\n"
                   "\t\tScripts.foreach(envlayerList, function(id,obj) {\r\n"),
             false);
-        patched.Replace(
-            TJS_W("\tfunction _updateAll(allData, snap=false, restore=true) {\r\n"
-                  "\t\tif (allData !== void) {\r\n"
-                  "\t\t\tvar data = allData.data;\r\n"
-                  "\t\t\tvar leave = %[];\r\n"
-                  "\t\t\tvar create = [];\r\n"),
-            TJS_W("\tfunction _updateAll(allData, snap=false, restore=true) {\r\n"
-                  "\t\tif (allData !== void) {\r\n"
-                  "\t\t\tvar data = allData.data;\r\n"
-                  "\t\t\tvar __akRestoreFaceVisible = false;\r\n"
-                  "\t\t\tvar leave = %[];\r\n"
-                  "\t\t\tvar create = [];\r\n"),
-            false);
-        patched.Replace(
-            TJS_W("\t\t\t\t\t\tcreate.add(info);\r\n"
-                  "\t\t\t\t\t\tvar name = info[0];\r\n"),
-            TJS_W("\t\t\t\t\t\tcreate.add(info);\r\n"
-                  "\t\t\t\t\t\ttry { if (info[0] == \"face\" && info[2] !== void && (info[2].showmode & 1)) __akRestoreFaceVisible = true; } catch(__akFaceRestoreE) {}\r\n"
-                  "\t\t\t\t\t\tvar name = info[0];\r\n"),
-            false);
-        patched.Replace(
-            TJS_W("\t\t\t// 生成するものと同種のもの以外は破棄\r\n"
-                  "\t\t\tenvClear(leave);\r\n"
-                  "\t\t\t// オブジェクト生成\r\n"),
-            TJS_W("\t\t\t// 生成するものと同種のもの以外は破棄\r\n"
-                  "\t\t\tenvClear(leave);\r\n"
-                  "\t\t\tif (__akRestoreFaceVisible && typeof this.removeIgnore != \"undefined\") { try { this.removeIgnore(\"face\"); } catch(__akFaceIgnoreE) {} }\r\n"
-                  "\t\t\t// オブジェクト生成\r\n"),
-            false);
+        const bool patchedFaceRestore =
+            TVPPatchWorldRestoreFaceVisibility(patched);
+        if(!patchedFaceRestore &&
+           patched.IndexOf(TJS_W("function _updateAll(")) >= 0 &&
+           (patched.IndexOf(TJS_W("var data = allData.data;")) >= 0 ||
+            patched.IndexOf(TJS_W("create.add(info);")) >= 0 ||
+            patched.IndexOf(TJS_W("envClear(leave);")) >= 0)) {
+            spdlog::warn(
+                "Skipped atomic World._updateAll face-visibility patch: "
+                "required anchors were incomplete or ambiguous");
+        }
         if(patched != buffer) {
             buffer = patched;
             spdlog::info("Applied compatibility patch for world msgwin visibility restore");
@@ -2137,6 +2204,34 @@ static void TVPExecuteTextScriptWithRecovery(const ttstr &script,
     }
 }
 
+const tjs_char *TVPGetD3DStandSourcePatchScript() {
+    return TJS_W(
+        "(function() {\r\n"
+        "\tif (typeof global.D3DAffineLayer == \"undefined\") return;\r\n"
+        "\tif (typeof global.__aetherKiriD3DStandOrigLoadImages != \"undefined\") return;\r\n"
+        "\tglobal.__aetherKiriD3DStandOrigLoadImages = &global.D3DAffineLayer.loadImages;\r\n"
+        "\tglobal.D3DAffineLayer.loadImages = function(filename, colorKey=clNone, options=void, redraw=false) {\r\n"
+        "\t\tvar sourceInfo = findAffineSource(filename, options);\r\n"
+        "\t\tvar sourceClass = sourceInfo.sourceClass;\r\n"
+        "\t\tvar storage = sourceInfo.storage;\r\n"
+        "\t\tvar ext = sourceInfo.ext;\r\n"
+        "\t\tif (ext != \".STAND\" && ext != \".EVENT\") return (global.__aetherKiriD3DStandOrigLoadImages incontextof this)(filename, colorKey, options, redraw);\r\n"
+        "\t\tif (sourceClass === void) return (global.__aetherKiriD3DStandOrigLoadImages incontextof this)(filename, colorKey, options, redraw);\r\n"
+        "\t\tif (this._image.filename != filename ||\r\n"
+        "\t\t\t(this._image instanceof \"D3DAffineSourcePicture\" && redraw) ||\r\n"
+        "\t\t\t(this._image instanceof \"D3DAffineSourceImage\" && ((sourceClass === void && !redraw) || this._image._sourceClass !== sourceClass))\r\n"
+        "\t\t\t) {\r\n"
+        "\t\t\tinvalidate this._image;\r\n"
+        "\t\t\tthis._image = new D3DAffineSourceImage(this, sourceClass);\r\n"
+        "\t\t\tthis._image.filename = filename;\r\n"
+        "\t\t\tthis._image.loadImages(storage, colorKey, options);\r\n"
+        "\t\t\tif (options !== void) this._image.setOptions(options);\r\n"
+        "\t\t\tthis.calcAffine();\r\n"
+        "\t\t}\r\n"
+        "\t};\r\n"
+        "})();\r\n");
+}
+
 static void TVPApplyPostScriptCompatibilityPatches(const ttstr &shortname) {
     const ttstr lower = shortname.AsLowerCase();
     const bool patchWorld = lower == TJS_W("world.tjs");
@@ -2233,31 +2328,7 @@ static void TVPApplyPostScriptCompatibilityPatches(const ttstr &shortname) {
 
     if(patchD3DLayer) try {
         TVPExecuteScript(
-            TJS_W(
-                "(function() {\r\n"
-                "\tif (typeof global.D3DAffineLayer == \"undefined\") return;\r\n"
-                "\tif (typeof global.__aetherKiriD3DStandOrigLoadImages != \"undefined\") return;\r\n"
-                "\tglobal.__aetherKiriD3DStandOrigLoadImages = &global.D3DAffineLayer.loadImages;\r\n"
-                "\tglobal.D3DAffineLayer.loadImages = function(filename, colorKey=clNone, options=void, redraw=false) {\r\n"
-                "\t\tvar sourceInfo = findAffineSource(filename, options);\r\n"
-                "\t\tvar sourceClass = sourceInfo.sourceClass;\r\n"
-                "\t\tvar storage = sourceInfo.storage;\r\n"
-                "\t\tvar ext = sourceInfo.ext;\r\n"
-                "\t\tif (ext != \".STAND\" && ext != \".EVENT\") return (global.__aetherKiriD3DStandOrigLoadImages incontextof this)(filename, colorKey, options, redraw);\r\n"
-                "\t\tif (sourceClass === void) return (global.__aetherKiriD3DStandOrigLoadImages incontextof this)(filename, colorKey, options, redraw);\r\n"
-                "\t\tif (this._image.filename != filename ||\r\n"
-                "\t\t\t(this._image instanceof \"D3DAffineSourcePicture\" && redraw) ||\r\n"
-                "\t\t\t(this._image instanceof \"D3DAffineSourceImage\" && ((sourceClass === void && !redraw) || this._image._sourceClass !== sourceClass))\r\n"
-                "\t\t\t) {\r\n"
-                "\t\t\tinvalidate this._image;\r\n"
-                "\t\t\tthis._image = new D3DAffineSourceImage(this, sourceClass);\r\n"
-                "\t\t\tthis._image.filename = filename;\r\n"
-                "\t\t\tthis._image.loadImages(storage, colorKey, options);\r\n"
-                "\t\t\tif (options !== void) this._image.setOptions(options);\r\n"
-                "\t\t\tthis.calcUpdate();\r\n"
-                "\t\t}\r\n"
-                "\t};\r\n"
-                "})();\r\n"),
+            TVPGetD3DStandSourcePatchScript(),
             TJS_W("AetherKiriD3DStandSourcePatch"), 0, (tTJSVariant *)nullptr);
         spdlog::info(
             "Applied compatibility hook for D3DAffineLayer stand source routing");

--- a/cpp/core/base/ScriptMgnIntf.h
+++ b/cpp/core/base/ScriptMgnIntf.h
@@ -84,10 +84,15 @@ extern const tjs_char *TVPGetPatchWindowPrerequisitesScript();
 extern const tjs_char *TVPGetKagLoadContractGuardScript();
 extern const tjs_char *TVPGetPatchRuntimeRegistryExpression();
 extern const tjs_char *TVPGetPatchRuntimeInstanceRecoveryScript();
+extern const tjs_char *TVPGetD3DStandSourcePatchScript();
 extern bool TVPMergeObjectMembers(iTJSDispatch2 *destination,
                                   iTJSDispatch2 *source);
 extern bool TVPMergeMissingObjectMembers(iTJSDispatch2 *destination,
                                          iTJSDispatch2 *source);
+
+// Adds the face-visibility snapshot repair to compatible World._updateAll
+// implementations. The three dependent insertions are applied atomically.
+extern bool TVPPatchWorldRestoreFaceVisibility(ttstr &script);
 
 extern void TVPArmKagNoTransWaitRepair();
 

--- a/cpp/core/base/impl/StorageImpl.cpp
+++ b/cpp/core/base/impl/StorageImpl.cpp
@@ -680,6 +680,34 @@ bool TVPCheckExistentLocalFolder(const ttstr &name) {
 }
 //---------------------------------------------------------------------------
 
+ttstr TVPGetNativeProjectDirectory(const ttstr &nativeProjectPath) {
+    ttstr path(nativeProjectPath);
+    while(path.GetLen() > 1 &&
+          (path.GetLastChar() == TJS_W('/') ||
+           path.GetLastChar() == TJS_W('\\'))) {
+        path = path.SubString(0, path.GetLen() - 1);
+    }
+    if(!TVPCheckExistentLocalFile(path))
+        return path;
+
+    const tjs_char *text = path.c_str();
+    tjs_int separator = path.GetLen() - 1;
+    while(separator >= 0 && text[separator] != TJS_W('/') &&
+          text[separator] != TJS_W('\\')) {
+        separator--;
+    }
+    if(separator < 0)
+        return TJS_W(".");
+    if(separator == 0)
+        return path.SubString(0, 1);
+#if defined(_WIN32)
+    if(separator == 2 && text[1] == TJS_W(':'))
+        return path.SubString(0, 3);
+#endif
+    return path.SubString(0, separator);
+}
+//---------------------------------------------------------------------------
+
 tTVPArchive *TVPOpenZIPArchive(const ttstr &name, tTJSBinaryStream *st,
                                bool normalizeFileName);
 

--- a/cpp/core/base/impl/StorageImpl.h
+++ b/cpp/core/base/impl/StorageImpl.h
@@ -68,6 +68,9 @@ TJS_EXP_FUNC_DEF(bool, TVPCheckExistentLocalFolder, (const ttstr &name));
 TJS_EXP_FUNC_DEF(bool, TVPCheckExistentLocalFile, (const ttstr &name));
 /* name must be an OS's NATIVE file name */
 
+TJS_EXP_FUNC_DEF(ttstr, TVPGetNativeProjectDirectory,
+                 (const ttstr &nativeProjectPath));
+
 TJS_EXP_FUNC_DEF(bool, TVPCreateFolders, (const ttstr &folder));
 /* make folders recursively, like mkdir -p. folder must be OS NATIVE
  * folder name

--- a/cpp/core/base/impl/SysInitImpl.cpp
+++ b/cpp/core/base/impl/SysInitImpl.cpp
@@ -150,6 +150,20 @@ static tjs_uint64 TVPTotalPhysMemory = 0;
 
 static void TVPInitProgramArgumentsAndDataPath(bool stop_after_datapath_got);
 
+bool TVPIsProjectStorageFile(const ttstr &normalizedProjectPath,
+                             const ttstr &nativeProjectPath) {
+    if(TVPIsExistentStorageNoSearchNoNormalize(normalizedProjectPath))
+        return true;
+
+    // Normalized storage names intentionally fold ASCII case. On a
+    // case-sensitive filesystem (notably an iOS app container), that can make
+    // the initial existence probe miss a valid archive before file media has
+    // recovered the native component casing. The host-provided path still has
+    // the exact on-disk spelling, so use it as a file-only fallback.
+    return !nativeProjectPath.IsEmpty() &&
+        TVPCheckExistentLocalFile(nativeProjectPath);
+}
+
 void TVPBeforeSystemInit() {
     // RegisterDllLoadHook();
     //  register DLL delayed import hook to support _inmm.dll
@@ -161,7 +175,7 @@ void TVPBeforeSystemInit() {
     if(TVPGetCommandLine(TJS_W("-arcdelim"), &v))
         TVPArchiveDelimiter = ttstr(v)[0];
 
-    if(TVPIsExistentStorageNoSearchNoNormalize(TVPProjectDir)) {
+    if(TVPIsProjectStorageFile(TVPProjectDir, TVPNativeProjectDir)) {
         TVPProjectDir += TVPArchiveDelimiter;
         // A bound XP3 executable is both the highest-priority project
         // archive and a launcher living beside the original game's data

--- a/cpp/core/base/impl/SysInitImpl.h
+++ b/cpp/core/base/impl/SysInitImpl.h
@@ -21,6 +21,9 @@ extern ttstr TVPNativeDataPath;
 
 extern bool TVPProjectDirSelected;
 
+extern bool TVPIsProjectStorageFile(const ttstr &normalizedProjectPath,
+                                    const ttstr &nativeProjectPath);
+
 extern void TVPEnsureDataPathDirectory();
 
 extern bool TVPExecuteUserConfig();

--- a/cpp/core/environ/stubs/ui_stubs.cpp
+++ b/cpp/core/environ/stubs/ui_stubs.cpp
@@ -37,6 +37,7 @@
 #include "Application.h"
 #include "RenderManager.h"
 #include "GodotRenderManager.h"
+#include "StorageImpl.h"
 #if defined(KRKR_ENABLE_GPU_BRIDGE)
 #include "krkr_egl_context.h"
 #include <GLES3/gl3.h>
@@ -1469,10 +1470,9 @@ static std::vector<std::string> s_appHomeDirs;
 const std::vector<std::string> &TVPGetApplicationHomeDirectory() {
     if (s_appHomeDirs.empty()) {
         if (!TVPNativeProjectDir.IsEmpty()) {
-            std::string dir = TVPNativeProjectDir.AsNarrowStdString();
-            while (!dir.empty() && dir.back() == '/')
-                dir.pop_back();
-            s_appHomeDirs.push_back(dir);
+            const ttstr dir =
+                TVPGetNativeProjectDirectory(TVPNativeProjectDir);
+            s_appHomeDirs.push_back(dir.AsNarrowStdString());
         } else {
 #if defined(__EMSCRIPTEN__)
             s_appHomeDirs.push_back("/userfs");

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(motionplayer-dll
     godot-texture.cpp
     krkrgles-aliases.cpp
     kag-load-contract.cpp
+    script-compatibility.cpp
 )
 
 set(_KRKR2PLUGIN_LINK_ITEM "$<LINK_LIBRARY:WHOLE_ARCHIVE,krkr2plugin>")

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(motionplayer-dll
     krkrgles-aliases.cpp
     kag-load-contract.cpp
     script-compatibility.cpp
+    project-storage.cpp
 )
 
 set(_KRKR2PLUGIN_LINK_ITEM "$<LINK_LIBRARY:WHOLE_ARCHIVE,krkr2plugin>")

--- a/tests/unit-tests/plugins/project-storage.cpp
+++ b/tests/unit-tests/plugins/project-storage.cpp
@@ -1,0 +1,51 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "tjsCommHead.h"
+#include "SysInitImpl.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+class TemporaryProjectPath {
+public:
+    TemporaryProjectPath() {
+        const auto unique = std::chrono::steady_clock::now()
+                                .time_since_epoch()
+                                .count();
+        path = std::filesystem::temp_directory_path() /
+               ("AetherKiri-Project-" + std::to_string(unique) + ".xp3");
+    }
+
+    ~TemporaryProjectPath() {
+        std::error_code error;
+        std::filesystem::remove(path, error);
+    }
+
+    std::filesystem::path path;
+};
+
+} // namespace
+
+TEST_CASE("project archive detection falls back to the exact native path") {
+    TemporaryProjectPath project;
+    {
+        std::ofstream output(project.path, std::ios::binary);
+        REQUIRE(output.good());
+        output << "XP3";
+    }
+
+    CHECK(TVPIsProjectStorageFile(
+        TJS_W(""), ttstr(project.path.string())));
+
+    std::error_code error;
+    std::filesystem::remove(project.path, error);
+    REQUIRE_FALSE(error);
+    REQUIRE(std::filesystem::create_directory(project.path));
+
+    CHECK_FALSE(TVPIsProjectStorageFile(
+        TJS_W(""), ttstr(project.path.string())));
+}

--- a/tests/unit-tests/plugins/project-storage.cpp
+++ b/tests/unit-tests/plugins/project-storage.cpp
@@ -2,6 +2,7 @@
 
 #include "tjsCommHead.h"
 #include "SysInitImpl.h"
+#include "StorageImpl.h"
 
 #include <chrono>
 #include <filesystem>
@@ -40,6 +41,8 @@ TEST_CASE("project archive detection falls back to the exact native path") {
 
     CHECK(TVPIsProjectStorageFile(
         TJS_W(""), ttstr(project.path.string())));
+    CHECK(TVPGetNativeProjectDirectory(ttstr(project.path.string())) ==
+          ttstr(project.path.parent_path().string()));
 
     std::error_code error;
     std::filesystem::remove(project.path, error);
@@ -48,4 +51,6 @@ TEST_CASE("project archive detection falls back to the exact native path") {
 
     CHECK_FALSE(TVPIsProjectStorageFile(
         TJS_W(""), ttstr(project.path.string())));
+    CHECK(TVPGetNativeProjectDirectory(ttstr(project.path.string())) ==
+          ttstr(project.path.string()));
 }

--- a/tests/unit-tests/plugins/script-compatibility.cpp
+++ b/tests/unit-tests/plugins/script-compatibility.cpp
@@ -1,0 +1,161 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ScriptMgnIntf.h"
+#include "tjs.h"
+
+#include <string>
+
+namespace {
+
+using ScriptString = std::basic_string<tjs_char>;
+
+class ScriptEngineOwner {
+public:
+    ScriptEngineOwner() : engine_(new tTJS()) {}
+    ~ScriptEngineOwner() { engine_->Release(); }
+
+    tTJS *operator->() const { return engine_; }
+
+private:
+    tTJS *engine_;
+};
+
+tjs_int evaluateInteger(tTJS *engine, const tjs_char *expression) {
+    tTJSVariant result;
+    engine->EvalExpression(expression, &result);
+    return result.AsInteger();
+}
+
+std::size_t countOccurrences(const ttstr &script, const tjs_char *marker) {
+    const ScriptString source(script.c_str(), script.GetLen());
+    const ScriptString needle(marker);
+    std::size_t count = 0;
+    std::size_t position = 0;
+    while((position = source.find(needle, position)) != ScriptString::npos) {
+        ++count;
+        position += needle.size();
+    }
+    return count;
+}
+
+} // namespace
+
+TEST_CASE("World face restore patch supports two-argument updateAll") {
+    ttstr script(TJS_W(
+        "\tfunction _updateAll(allData, snap=false) {\r\n"
+        "\t\tif (allData !== void) {\r\n"
+        "\t\t\tvar base = envTransMode ? 1 : 0;\r\n"
+        "\t\t\tvar data = allData.data;\r\n"
+        "\t\t\tvar leave = %[];\r\n"
+        "\t\t\tvar create = [];\r\n"
+        "\t\t\tfor (var i = 0; i < data.count; i++) {\r\n"
+        "\t\t\t\tvar info = data[i];\r\n"
+        "\t\t\t\tif (info !== void) {\r\n"
+        "\t\t\t\t\t\tcreate.add(info);\r\n"
+        "\t\t\t\t\t\tvar name = info[0];\r\n"
+        "\t\t\t\t}\r\n"
+        "\t\t\t}\r\n"
+        "\t\t\t// 生成するものと同種のもの以外は破棄\r\n"
+        "\t\t\tenvClear(leave);\r\n"
+        "\t\t\t// オブジェクト生成\r\n"
+        "\t\t}\r\n"
+        "\t}\r\n"));
+
+    REQUIRE(TVPPatchWorldRestoreFaceVisibility(script));
+    CHECK(countOccurrences(script, TJS_W("__akRestoreFaceVisible")) == 3);
+    CHECK(script.IndexOf(TJS_W("var base = envTransMode ? 1 : 0;")) >= 0);
+
+    const auto declaration =
+        script.IndexOf(TJS_W("var __akRestoreFaceVisible = false;"));
+    const auto capture =
+        script.IndexOf(TJS_W("__akRestoreFaceVisible = true;"));
+    const auto restore =
+        script.IndexOf(TJS_W("if (__akRestoreFaceVisible &&"));
+    REQUIRE(declaration >= 0);
+    REQUIRE(capture >= 0);
+    REQUIRE(restore >= 0);
+    CHECK(declaration < capture);
+    CHECK(capture < restore);
+}
+
+TEST_CASE("World face restore patch supports three-argument LF scripts") {
+    ttstr script(TJS_W(
+        "\tfunction _updateAll(allData, snap=false, restore=true) {\n"
+        "\t\tif (allData !== void) {\n"
+        "\t\t\tvar data = allData.data;\n"
+        "\t\t\tvar leave = %[];\n"
+        "\t\t\tvar create = [];\n"
+        "\t\t\t\t\t\tcreate.add(info);\n"
+        "\t\t\t\t\t\tvar name = info[0];\n"
+        "\t\t\tenvClear(leave);\n"
+        "\t\t}\n"
+        "\t}\n"));
+
+    REQUIRE(TVPPatchWorldRestoreFaceVisibility(script));
+    CHECK(countOccurrences(script, TJS_W("__akRestoreFaceVisible")) == 3);
+    CHECK(script.IndexOf(TJS_W("\r\n")) < 0);
+}
+
+TEST_CASE("World face restore patch is atomic when an anchor is missing") {
+    ttstr script(TJS_W(
+        "\tfunction _updateAll(allData, snap=false) {\r\n"
+        "\t\tif (allData !== void) {\r\n"
+        "\t\t\tvar data = allData.data;\r\n"
+        "\t\t\t\t\t\tcreate.add(info);\r\n"
+        "\t\t}\r\n"
+        "\t}\r\n"));
+    const ttstr original(script);
+
+    CHECK_FALSE(TVPPatchWorldRestoreFaceVisibility(script));
+    CHECK(script == original);
+    CHECK(script.IndexOf(TJS_W("__akRestoreFaceVisible")) < 0);
+}
+
+TEST_CASE("D3D stand source patch uses the layer affine contract") {
+    ScriptEngineOwner engine;
+    engine->ExecScript(TJS_W(
+        "var clNone = 0;\n"
+        "class D3DAffineSourcePicture {\n"
+        "  var filename = \"old\";\n"
+        "}\n"
+        "class D3DAffineSourceImage {\n"
+        "  var filename = \"\";\n"
+        "  var loaded = 0;\n"
+        "  var optionsSet = 0;\n"
+        "  function D3DAffineSourceImage(owner, sourceClass) {}\n"
+        "  function loadImages(storage, colorKey, options) {\n"
+        "    if(storage == \"hero.pbd\") loaded = 1;\n"
+        "  }\n"
+        "  function setOptions(options) { optionsSet = 1; }\n"
+        "}\n"
+        "class D3DAffineLayer {\n"
+        "  var _image;\n"
+        "  var originalCalls = 0;\n"
+        "  var affineCalls = 0;\n"
+        "  function D3DAffineLayer() {\n"
+        "    _image = new D3DAffineSourcePicture();\n"
+        "  }\n"
+        "  function loadImages(filename, colorKey=clNone, options=void, redraw=false) {\n"
+        "    originalCalls++;\n"
+        "  }\n"
+        "  function calcAffine() { affineCalls++; }\n"
+        "}\n"
+        "function findAffineSource(filename, options) {\n"
+        "  return %[sourceClass: D3DAffineSourceImage,\n"
+        "           storage: \"hero.pbd\", ext: \".STAND\"];\n"
+        "}\n"));
+
+    REQUIRE_NOTHROW(engine->ExecScript(TVPGetD3DStandSourcePatchScript()));
+    REQUIRE_NOTHROW(engine->ExecScript(TJS_W(
+        "var standLayer = new D3DAffineLayer();\n"
+        "standLayer.loadImages(\"hero.stand\", clNone, %[dress: \"default\"]);\n")));
+
+    CHECK(evaluateInteger(engine.operator->(),
+                          TJS_W("standLayer.originalCalls")) == 0);
+    CHECK(evaluateInteger(engine.operator->(),
+                          TJS_W("standLayer.affineCalls")) == 1);
+    CHECK(evaluateInteger(engine.operator->(),
+                          TJS_W("standLayer._image.loaded")) == 1);
+    CHECK(evaluateInteger(engine.operator->(),
+                          TJS_W("standLayer._image.optionsSet")) == 1);
+}


### PR DESCRIPTION
## Summary

- make the World face-visibility restore patch atomic and support both two- and three-argument updateAll implementations
- use the D3DAffineLayer affine recalculation contract when routing .stand and .event sources
- add focused patch-shape and functional TJS regression tests

## Validation

- verified the reported scenes in 恋花绽放樱飞时 and 金辉恋曲四重奏 -Golden Time- with the macOS Godot frontend
- full motionplayer-dll suite passed: 85 test cases, 1031 assertions
- focused compatibility suite passed after rebasing: 4 test cases, 20 assertions
- ScriptMgnIntf.cpp compiled successfully against the latest main
- the complete local relink after rebasing is deferred to CI because this worktree reuses an older FFmpeg vcpkg cache than the latest main expects

Fixes #45