### PR TITLE
fix(ios): support KAG virtual keyboard input

### DIFF
--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -1214,6 +1214,11 @@ var last_forwarded_touch_down_msec := 0
 var last_forwarded_touch_up_msec := 0
 var last_forwarded_touch_move_msec_by_id := {}
 var touch_input_busy_until_msec := 0
+var game_text_input_active := false
+var game_text_input_attention_position := Vector2i(-1, -1)
+var game_text_input_reopen_requested := false
+var game_text_input_last_show_msec := 0
+var game_text_input_suspended := false
 var device_probe_enabled := false
 var follow_texture_surface_size := false
 var present_hold_frames := 0
@@ -1240,6 +1245,7 @@ const TOUCH_DRAG_MIN_INTERVAL_MS := 80
 const TOUCH_DRAG_DISTANCE_THRESHOLD := 18.0
 const TOUCH_BUSY_TICK_MS := 120.0
 const TOUCH_BUSY_SUPPRESS_MS := 0
+const VIRTUAL_KEYBOARD_REOPEN_DELAY_MS := 750
 const TOUCH_POINTER_ID_OFFSET := 100000
 const TOUCH_SECONDARY_POINTER_ID := 0
 const TOUCH_SECONDARY_TAP_WINDOW_MS := 180
@@ -7973,6 +7979,7 @@ func _process(delta: float) -> void:
                     perf_log_file.store_line(tick_error_line)
                     perf_log_file.flush()
                 game_running = false
+                _deactivate_game_text_input()
                 _sync_debug_console_state()
                 if diagnostic_session != null:
                     diagnostic_session.set_game_active(false)
@@ -7988,6 +7995,7 @@ func _process(delta: float) -> void:
                         tick_ms,
                         player.get_renderer_info(),
                     ])
+                _sync_game_text_input_state()
                 var update_start := Time.get_ticks_usec()
                 _update_frame()
                 var update_ms := float(Time.get_ticks_usec() - update_start) / 1000.0
@@ -8013,6 +8021,7 @@ func _process(delta: float) -> void:
             viewport.visible = false
             game_view.visible = false
             game_running = false
+            _deactivate_game_text_input()
             _sync_debug_console_state()
             if diagnostic_session != null:
                 diagnostic_session.set_game_active(false)
@@ -8252,6 +8261,8 @@ func _notification(what: int) -> void:
         player.destroy_engine()
 
 func _pause_game_for_lifecycle(reason: String) -> void:
+    game_text_input_suspended = true
+    _deactivate_game_text_input()
     if not _is_touch_platform():
         return
     if app_lifecycle_paused or not game_running or cached_startup_state != STARTUP_SUCCEEDED:
@@ -8270,6 +8281,7 @@ func _pause_game_for_lifecycle(reason: String) -> void:
     _log_lifecycle_line("app_paused reason=%s" % reason)
 
 func _resume_game_for_lifecycle(reason: String) -> void:
+    game_text_input_suspended = false
     if not _is_touch_platform():
         return
     if not app_lifecycle_paused:
@@ -8683,6 +8695,7 @@ func _capture_main_view(frame_stats: Dictionary) -> void:
         get_tree().quit(0 if visible > 0 else 2)
 
 func _clear_game_input_capture() -> void:
+    _deactivate_game_text_input()
     active_touch_points.clear()
     active_mouse_buttons.clear()
     suppressed_touch_points.clear()
@@ -9648,6 +9661,8 @@ func _touch_engine_pointer_id(pointer_id: int) -> int:
     return TOUCH_POINTER_ID_OFFSET + pointer_id
 
 func _send_game_pointer_event(event_type: int, pointer_id: int, x: float, y: float, delta_x: float, delta_y: float, button: int, modifiers: int = 0) -> void:
+    if _is_touch_platform() and event_type == POINTER_DOWN and button == 0:
+        game_text_input_reopen_requested = true
     var result := int(player.send_pointer_event(event_type, pointer_id, x, y, delta_x, delta_y, button, modifiers))
     if _android_input_debug_enabled():
         print("android_input fwd type=%d pid=%d x=%.1f y=%.1f dx=%.1f dy=%.1f button=%d mods=%d result=%d" % [
@@ -9785,6 +9800,139 @@ func _hold_next_present_after_input(frames: int = POST_INPUT_PRESENT_HOLD_FRAMES
 func _is_touch_platform() -> bool:
     var platform := OS.get_name()
     return platform == "iOS" or platform == "Android"
+
+func _deactivate_game_text_input() -> void:
+    if game_text_input_active:
+        if (
+            _is_touch_platform()
+            and DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD)
+        ):
+            DisplayServer.virtual_keyboard_hide()
+        elif DisplayServer.has_feature(DisplayServer.FEATURE_IME):
+            DisplayServer.window_set_ime_active(false)
+    game_text_input_active = false
+    game_text_input_attention_position = Vector2i(-1, -1)
+    game_text_input_reopen_requested = false
+
+func _show_game_virtual_keyboard(attention_position: Vector2i, state: Dictionary) -> void:
+    var existing_text := ""
+    var cursor_start := -1
+    var cursor_end := -1
+    if bool(state.get("text_available", false)):
+        existing_text = String(state.get("text", ""))
+        var text_length := existing_text.length()
+        var selection_start := clampi(
+            int(state.get("selection_start", text_length)), 0, text_length
+        )
+        var selection_end := clampi(
+            int(state.get("selection_end", selection_start)), 0, text_length
+        )
+        cursor_start = mini(selection_start, selection_end)
+        var ordered_end := maxi(selection_start, selection_end)
+        # Godot's mobile backends use -1 to distinguish a caret from a real
+        # selection; Android treats equal start/end as a selection session.
+        if ordered_end != cursor_start:
+            cursor_end = ordered_end
+    DisplayServer.virtual_keyboard_show(
+        existing_text,
+        Rect2(Vector2(attention_position), Vector2.ONE),
+        DisplayServer.KEYBOARD_TYPE_DEFAULT,
+        -1,
+        cursor_start,
+        cursor_end
+    )
+    game_text_input_last_show_msec = Time.get_ticks_msec()
+
+func _sync_game_text_input_state() -> void:
+    if game_text_input_suspended or not _can_forward_game_input():
+        _deactivate_game_text_input()
+        return
+    var state = player.get_text_input_state()
+    if not state is Dictionary or not bool(state.get("available", false)):
+        _deactivate_game_text_input()
+        return
+
+    var attention_valid := bool(state.get("attention_point_valid", false))
+    var ime_active := bool(state.get("ime_active", false))
+    var virtual_keyboard_available := (
+        _is_touch_platform()
+        and DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD)
+    )
+    var desktop_ime_available := (
+        not virtual_keyboard_available
+        and DisplayServer.has_feature(DisplayServer.FEATURE_IME)
+    )
+    # Attention marks an editable KiriKiri layer. imClose/imDisable still need
+    # a mobile soft keyboard for direct (non-composed) text entry.
+    var should_activate := attention_valid and (
+        virtual_keyboard_available or (desktop_ime_available and ime_active)
+    )
+    if not should_activate:
+        _deactivate_game_text_input()
+        return
+
+    var attention_position := game_text_input_attention_position
+    if attention_valid:
+        var surface_point := Vector2(
+            float(state.get("attention_x", 0)),
+            float(state.get("attention_y", 0))
+        )
+        var screen_point := _map_surface_point_to_screen(surface_point)
+        attention_position = Vector2i(roundi(screen_point.x), roundi(screen_point.y))
+    var attention_position_changed := (
+        attention_position != game_text_input_attention_position
+    )
+
+    if not game_text_input_active:
+        if virtual_keyboard_available:
+            _show_game_virtual_keyboard(attention_position, state)
+        elif desktop_ime_available:
+            DisplayServer.window_set_ime_active(true)
+            DisplayServer.window_set_ime_position(attention_position)
+        game_text_input_active = true
+    elif (
+        virtual_keyboard_available
+        and game_text_input_reopen_requested
+        and not DisplayServer.has_hardware_keyboard()
+        and (
+            Time.get_ticks_msec() - game_text_input_last_show_msec
+            >= VIRTUAL_KEYBOARD_REOPEN_DELAY_MS
+        )
+    ):
+        # A game-surface tap is also a caret/selection resync boundary while
+        # the keyboard is already visible.
+        _show_game_virtual_keyboard(attention_position, state)
+    elif desktop_ime_available and attention_position_changed:
+        DisplayServer.window_set_ime_position(attention_position)
+
+    game_text_input_attention_position = attention_position
+    game_text_input_reopen_requested = false
+
+func _map_surface_point_to_screen(point: Vector2) -> Vector2:
+    if viewport == null:
+        return point
+    var local_point := point
+    if viewport.texture != null:
+        var texture_size := Vector2(
+            max(1.0, float(viewport.texture.get_width())),
+            max(1.0, float(viewport.texture.get_height()))
+        )
+        var surface_size := texture_size
+        if current_surface_size.x > 0 and current_surface_size.y > 0:
+            surface_size = Vector2(current_surface_size)
+        var texture_point := Vector2(
+            point.x * texture_size.x / surface_size.x,
+            point.y * texture_size.y / surface_size.y
+        )
+        var panel_size := viewport.size
+        var scale := minf(
+            panel_size.x / texture_size.x,
+            panel_size.y / texture_size.y
+        )
+        var drawn_size := texture_size * scale
+        var offset := (panel_size - drawn_size) * 0.5
+        local_point = offset + texture_point * scale
+    return viewport.get_screen_transform() * local_point
 
 func _map_viewport_point(pos: Vector2, clamp_to_bounds: bool = false) -> Vector2:
     if viewport.texture == null:

--- a/bridge/engine_api/include/engine_api.h
+++ b/bridge/engine_api/include/engine_api.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /* ABI version: major(8bit), minor(8bit), patch(16bit). */
-#define ENGINE_API_VERSION 0x01040000u
+#define ENGINE_API_VERSION 0x01050000u
 #define ENGINE_API_MAKE_VERSION(major, minor, patch) \
   ((((uint32_t)(major)&0xFFu) << 24u) | (((uint32_t)(minor)&0xFFu) << 16u) | \
    ((uint32_t)(patch)&0xFFFFu))
@@ -197,6 +197,26 @@ typedef struct engine_input_event_t {
   uint64_t reserved_u64[2];
   void* reserved_ptr[2];
 } engine_input_event_t;
+
+/* Host-facing snapshot of the focused KiriKiri text input layer. */
+typedef struct engine_text_input_state_t {
+  uint32_t struct_size;
+  /* Non-zero when the focused layer's IME mode accepts composed input. */
+  uint32_t ime_active;
+  int32_t ime_mode;
+  /* Non-zero when the focused layer publishes an editable caret position. */
+  uint32_t attention_point_valid;
+  int32_t attention_x;
+  int32_t attention_y;
+  /* Backing text is copied separately with engine_copy_text_input_text(). */
+  uint32_t text_available;
+  uint32_t text_utf8_bytes;
+  /* Unicode scalar offsets; equal values mean there is no selection. */
+  int32_t selection_start;
+  int32_t selection_end;
+  uint64_t reserved_u64[2];
+  void* reserved_ptr[4];
+} engine_text_input_state_t;
 
 /*
  * Returns runtime API version in out_api_version.
@@ -384,6 +404,22 @@ ENGINE_API_EXPORT engine_result_t engine_get_host_native_view(
  */
 ENGINE_API_EXPORT engine_result_t engine_send_input(engine_handle_t handle,
                                                     const engine_input_event_t* event);
+
+/*
+ * Gets the current script-visible text input/IME focus state.
+ * out_state->struct_size must be initialized by caller.
+ */
+ENGINE_API_EXPORT engine_result_t engine_get_text_input_state(
+    engine_handle_t handle, engine_text_input_state_t* out_state);
+
+/*
+ * Copies the focused editor's backing text as null-terminated UTF-8.
+ * text_utf8_bytes in engine_text_input_state_t reports the full byte count,
+ * excluding the terminator. A smaller destination is safely truncated.
+ */
+ENGINE_API_EXPORT engine_result_t engine_copy_text_input_text(
+    engine_handle_t handle, char* out_buffer, uint32_t buffer_size,
+    uint32_t* out_bytes_written);
 
 /*
  * Exports the current main window menu tree as UTF-8 JSON.

--- a/bridge/engine_api/src/engine_api.cpp
+++ b/bridge/engine_api/src/engine_api.cpp
@@ -125,6 +125,17 @@ extern "C" bool TVPHostGetLatestGodotGpuFrame(uint64_t* texture,
 extern "C" void TVPHostActivateMainWindow();
 extern "C" void TVPHostSetSurfaceSize(uint32_t width, uint32_t height);
 extern "C" void TVPHostSetPreferGpuFrame(bool prefer_gpu_frame);
+extern "C" void TVPHostGetTextInputState(uint32_t* ime_active,
+                                           int32_t* ime_mode,
+                                           uint32_t* attention_point_valid,
+                                           int32_t* attention_x,
+                                           int32_t* attention_y,
+                                           uint32_t* text_available,
+                                           uint32_t* text_utf8_bytes,
+                                           int32_t* selection_start,
+                                           int32_t* selection_end);
+extern "C" uint32_t TVPHostCopyTextInputText(char* out_buffer,
+                                               uint32_t buffer_size);
 
 struct engine_handle_s {
   std::recursive_mutex mutex;
@@ -3704,6 +3715,89 @@ engine_result_t engine_send_input(engine_handle_t handle,
   return ENGINE_RESULT_OK;
 }
 
+engine_result_t engine_get_text_input_state(
+    engine_handle_t handle, engine_text_input_state_t* out_state) {
+  if (out_state == nullptr) {
+    return SetThreadErrorAndReturn(ENGINE_RESULT_INVALID_ARGUMENT,
+                                   "out_state is null");
+  }
+  if (out_state->struct_size < sizeof(engine_text_input_state_t)) {
+    return SetThreadErrorAndReturn(
+        ENGINE_RESULT_INVALID_ARGUMENT,
+        "engine_text_input_state_t.struct_size is too small");
+  }
+
+  std::lock_guard<std::recursive_mutex> registry_guard(g_registry_mutex);
+  engine_handle_s* impl = nullptr;
+  auto result = ValidateHandleLocked(handle, &impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+
+  std::lock_guard<std::recursive_mutex> guard(impl->mutex);
+  result = ValidateHandleThreadLocked(impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+  if (impl->state != ToStateValue(EngineState::kOpened) &&
+      impl->state != ToStateValue(EngineState::kPaused)) {
+    return SetHandleErrorAndReturnLocked(
+        impl, ENGINE_RESULT_INVALID_STATE,
+        "engine_open_game must succeed before engine_get_text_input_state");
+  }
+
+  engine_text_input_state_t snapshot{};
+  snapshot.struct_size = sizeof(snapshot);
+  TVPHostGetTextInputState(&snapshot.ime_active, &snapshot.ime_mode,
+                           &snapshot.attention_point_valid,
+                           &snapshot.attention_x, &snapshot.attention_y,
+                           &snapshot.text_available,
+                           &snapshot.text_utf8_bytes,
+                           &snapshot.selection_start,
+                           &snapshot.selection_end);
+  *out_state = snapshot;
+  ClearHandleErrorLocked(impl);
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_copy_text_input_text(
+    engine_handle_t handle, char* out_buffer, uint32_t buffer_size,
+    uint32_t* out_bytes_written) {
+  if (out_buffer == nullptr || buffer_size == 0 ||
+      out_bytes_written == nullptr) {
+    return SetThreadErrorAndReturn(
+        ENGINE_RESULT_INVALID_ARGUMENT,
+        "engine_copy_text_input_text requires a buffer and byte count");
+  }
+  out_buffer[0] = '\0';
+  *out_bytes_written = 0;
+
+  std::lock_guard<std::recursive_mutex> registry_guard(g_registry_mutex);
+  engine_handle_s* impl = nullptr;
+  auto result = ValidateHandleLocked(handle, &impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+
+  std::lock_guard<std::recursive_mutex> guard(impl->mutex);
+  result = ValidateHandleThreadLocked(impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+  if (impl->state != ToStateValue(EngineState::kOpened) &&
+      impl->state != ToStateValue(EngineState::kPaused)) {
+    return SetHandleErrorAndReturnLocked(
+        impl, ENGINE_RESULT_INVALID_STATE,
+        "engine_open_game must succeed before engine_copy_text_input_text");
+  }
+
+  *out_bytes_written = TVPHostCopyTextInputText(out_buffer, buffer_size);
+  ClearHandleErrorLocked(impl);
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
 engine_result_t engine_get_main_menu_json(engine_handle_t handle,
                                           char* out_buffer,
                                           uint32_t buffer_size,
@@ -5025,6 +5119,75 @@ engine_result_t engine_send_input(engine_handle_t handle,
     default:
       SetHandleErrorLocked(impl, "unsupported input event type");
       return ENGINE_RESULT_NOT_SUPPORTED;
+  }
+
+  impl->last_error.clear();
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_get_text_input_state(
+    engine_handle_t handle, engine_text_input_state_t* out_state) {
+  if (out_state == nullptr) {
+    return SetThreadErrorAndReturn(ENGINE_RESULT_INVALID_ARGUMENT,
+                                   "out_state is null");
+  }
+  if (out_state->struct_size < sizeof(engine_text_input_state_t)) {
+    return SetThreadErrorAndReturn(
+        ENGINE_RESULT_INVALID_ARGUMENT,
+        "engine_text_input_state_t.struct_size is too small");
+  }
+
+  std::lock_guard<std::recursive_mutex> registry_guard(g_registry_mutex);
+  engine_handle_s* impl = nullptr;
+  auto result = ValidateHandleLocked(handle, &impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+
+  std::lock_guard<std::recursive_mutex> guard(impl->mutex);
+  if (impl->state != ToStateValue(EngineState::kOpened) &&
+      impl->state != ToStateValue(EngineState::kPaused)) {
+    SetHandleErrorLocked(
+        impl,
+        "engine_open_game must succeed before engine_get_text_input_state");
+    return ENGINE_RESULT_INVALID_STATE;
+  }
+
+  engine_text_input_state_t snapshot{};
+  snapshot.struct_size = sizeof(snapshot);
+  *out_state = snapshot;
+  impl->last_error.clear();
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_copy_text_input_text(
+    engine_handle_t handle, char* out_buffer, uint32_t buffer_size,
+    uint32_t* out_bytes_written) {
+  if (out_buffer == nullptr || buffer_size == 0 ||
+      out_bytes_written == nullptr) {
+    return SetThreadErrorAndReturn(
+        ENGINE_RESULT_INVALID_ARGUMENT,
+        "engine_copy_text_input_text requires a buffer and byte count");
+  }
+  out_buffer[0] = '\0';
+  *out_bytes_written = 0;
+
+  std::lock_guard<std::recursive_mutex> registry_guard(g_registry_mutex);
+  engine_handle_s* impl = nullptr;
+  auto result = ValidateHandleLocked(handle, &impl);
+  if (result != ENGINE_RESULT_OK) {
+    return result;
+  }
+
+  std::lock_guard<std::recursive_mutex> guard(impl->mutex);
+  if (impl->state != ToStateValue(EngineState::kOpened) &&
+      impl->state != ToStateValue(EngineState::kPaused)) {
+    SetHandleErrorLocked(
+        impl,
+        "engine_open_game must succeed before engine_copy_text_input_text");
+    return ENGINE_RESULT_INVALID_STATE;
   }
 
   impl->last_error.clear();

--- a/bridge/godot_extension/src/aether_kiri_godot.cpp
+++ b/bridge/godot_extension/src/aether_kiri_godot.cpp
@@ -5372,6 +5372,59 @@ public:
         return result;
     }
 
+    Dictionary get_text_input_state() {
+        Dictionary state;
+        state["available"] = false;
+        state["ime_active"] = false;
+        state["ime_mode"] = 0;
+        state["attention_point_valid"] = false;
+        state["attention_x"] = 0;
+        state["attention_y"] = 0;
+        state["text_available"] = false;
+        state["text"] = String();
+        state["selection_start"] = 0;
+        state["selection_end"] = 0;
+        if (handle_ == nullptr) {
+            return state;
+        }
+
+        engine_text_input_state_t native_state{};
+        native_state.struct_size = sizeof(native_state);
+        const engine_result_t result =
+            engine_get_text_input_state(handle_, &native_state);
+        update_last_error(result);
+        if (result != ENGINE_RESULT_OK) {
+            return state;
+        }
+
+        state["available"] = true;
+        state["ime_active"] = native_state.ime_active != 0;
+        state["ime_mode"] = native_state.ime_mode;
+        state["attention_point_valid"] =
+            native_state.attention_point_valid != 0;
+        state["attention_x"] = native_state.attention_x;
+        state["attention_y"] = native_state.attention_y;
+        state["text_available"] = native_state.text_available != 0;
+        state["selection_start"] = native_state.selection_start;
+        state["selection_end"] = native_state.selection_end;
+        if (native_state.text_available != 0 &&
+            native_state.text_utf8_bytes > 0) {
+            std::vector<char> text_buffer(
+                static_cast<size_t>(native_state.text_utf8_bytes) + 1u, '\0');
+            uint32_t bytes_written = 0;
+            const engine_result_t text_result = engine_copy_text_input_text(
+                handle_, text_buffer.data(),
+                static_cast<uint32_t>(text_buffer.size()), &bytes_written);
+            update_last_error(text_result);
+            if (text_result != ENGINE_RESULT_OK) {
+                state["text_available"] = false;
+                return state;
+            }
+            state["text"] = String::utf8(text_buffer.data(), bytes_written);
+        }
+        return state;
+    }
+
     int get_startup_state() {
         if (handle_ == nullptr) {
             return ENGINE_STARTUP_STATE_IDLE;
@@ -6002,6 +6055,8 @@ protected:
         ClassDB::bind_method(D_METHOD("send_key_event", "pressed", "key_code",
                                       "modifiers", "unicode_codepoint"),
                              &AetherKiriPlayer::send_key_event);
+        ClassDB::bind_method(D_METHOD("get_text_input_state"),
+                             &AetherKiriPlayer::get_text_input_state);
         ClassDB::bind_method(D_METHOD("get_startup_state"),
                              &AetherKiriPlayer::get_startup_state);
         ClassDB::bind_method(D_METHOD("drain_startup_logs"),

--- a/cpp/core/environ/EngineLoop.cpp
+++ b/cpp/core/environ/EngineLoop.cpp
@@ -494,9 +494,22 @@ void EngineLoop::HandleTextInput(const EngineInputEvent& event) {
     auto* win = TVPMainWindow;
     if (!win) return;
 
-    if (event.unicode_codepoint > 0 && event.unicode_codepoint <= 0xFFFF) {
-        const tjs_char ch = static_cast<tjs_char>(event.unicode_codepoint);
-        TVPPostInputEvent(
-            new tTVPOnKeyPressInputEvent(win, ch));
+    const uint32_t codepoint = event.unicode_codepoint;
+    if(codepoint == 0 || codepoint > 0x10FFFF)
+        return;
+
+    // Android's Godot text bridge reports a non-BMP character as two UTF-16
+    // code units, while other hosts can report the complete Unicode scalar.
+    // Preserve either representation for KiriKiri's UTF-16 input events.
+    if(codepoint <= 0xFFFF) {
+        TVPPostInputEvent(new tTVPOnKeyPressInputEvent(
+            win, static_cast<tjs_char>(codepoint)));
+        return;
     }
+
+    const uint32_t scalar = codepoint - 0x10000;
+    const tjs_char high = static_cast<tjs_char>(0xD800 + (scalar >> 10));
+    const tjs_char low = static_cast<tjs_char>(0xDC00 + (scalar & 0x3FF));
+    TVPPostInputEvent(new tTVPOnKeyPressInputEvent(win, high));
+    TVPPostInputEvent(new tTVPOnKeyPressInputEvent(win, low));
 }

--- a/cpp/core/environ/stubs/ui_stubs.cpp
+++ b/cpp/core/environ/stubs/ui_stubs.cpp
@@ -71,6 +71,206 @@ bool g_host_prefer_gpu_frame = true;
 tTJSNI_Window *g_host_window_owner = nullptr;
 std::vector<tTJSNI_Window *> g_host_window_owners;
 
+struct HostTextInputState {
+    tTJSNI_Window *owner = nullptr;
+    tTVPImeMode ime_mode = imDisable;
+    bool ime_active = false;
+    bool attention_point_valid = false;
+    tjs_int attention_x = 0;
+    tjs_int attention_y = 0;
+    bool text_available = false;
+    std::string text_utf8;
+    int32_t selection_start = 0;
+    int32_t selection_end = 0;
+};
+
+std::mutex g_host_text_input_mutex;
+HostTextInputState g_host_text_input_state;
+
+bool IsHostTextInputModeActive(tTVPImeMode mode) {
+    return mode != imDisable && mode != imClose;
+}
+
+bool IsHighSurrogate(tjs_char value) {
+    return value >= static_cast<tjs_char>(0xd800) &&
+           value <= static_cast<tjs_char>(0xdbff);
+}
+
+bool IsLowSurrogate(tjs_char value) {
+    return value >= static_cast<tjs_char>(0xdc00) &&
+           value <= static_cast<tjs_char>(0xdfff);
+}
+
+void AppendUtf8Scalar(std::string &out, uint32_t scalar) {
+    if(scalar <= 0x7f) {
+        out.push_back(static_cast<char>(scalar));
+    } else if(scalar <= 0x7ff) {
+        out.push_back(static_cast<char>(0xc0 | (scalar >> 6)));
+        out.push_back(static_cast<char>(0x80 | (scalar & 0x3f)));
+    } else if(scalar <= 0xffff) {
+        out.push_back(static_cast<char>(0xe0 | (scalar >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((scalar >> 6) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | (scalar & 0x3f)));
+    } else {
+        out.push_back(static_cast<char>(0xf0 | (scalar >> 18)));
+        out.push_back(static_cast<char>(0x80 | ((scalar >> 12) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | ((scalar >> 6) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | (scalar & 0x3f)));
+    }
+}
+
+std::string HostTextUtf16ToUtf8(const tjs_char *text, size_t length) {
+    std::string result;
+    result.reserve(length);
+    for(size_t index = 0; index < length; ++index) {
+        uint32_t scalar = static_cast<uint32_t>(text[index]);
+        if(IsHighSurrogate(text[index])) {
+            if(index + 1 < length && IsLowSurrogate(text[index + 1])) {
+                scalar = 0x10000u +
+                         ((static_cast<uint32_t>(text[index]) - 0xd800u)
+                          << 10u) +
+                         (static_cast<uint32_t>(text[index + 1]) - 0xdc00u);
+                ++index;
+            } else {
+                scalar = 0xfffdu;
+            }
+        } else if(IsLowSurrogate(text[index])) {
+            scalar = 0xfffdu;
+        }
+        AppendUtf8Scalar(result, scalar);
+    }
+    return result;
+}
+
+int32_t HostUtf16OffsetToScalar(const tjs_char *text, size_t length,
+                                tTVInteger offset) {
+    size_t boundary = static_cast<size_t>(
+        std::clamp<tTVInteger>(offset, 0, static_cast<tTVInteger>(length)));
+    if(boundary > 0 && boundary < length &&
+       IsHighSurrogate(text[boundary - 1]) && IsLowSurrogate(text[boundary])) {
+        --boundary;
+    }
+
+    int32_t scalar_offset = 0;
+    for(size_t index = 0; index < boundary; ++scalar_offset) {
+        if(IsHighSurrogate(text[index]) && index + 1 < boundary &&
+           IsLowSurrogate(text[index + 1])) {
+            index += 2;
+        } else {
+            ++index;
+        }
+    }
+    return scalar_offset;
+}
+
+bool TryReadHostTextInputContent(iTJSDispatch2 *attention_owner,
+                                 std::string *out_text_utf8,
+                                 int32_t *out_selection_start,
+                                 int32_t *out_selection_end) {
+    if(attention_owner == nullptr || out_text_utf8 == nullptr ||
+       out_selection_start == nullptr || out_selection_end == nullptr) {
+        return false;
+    }
+
+    try {
+        tTJSVariant text_value;
+        if(TJS_FAILED(attention_owner->PropGet(
+               TJS_IGNOREPROP, TJS_W("Edit_text"), nullptr, &text_value,
+               attention_owner)) ||
+           text_value.Type() != tvtString) {
+            return false;
+        }
+
+        const ttstr text(text_value.GetString());
+        const size_t utf16_length = static_cast<size_t>(text.GetLen());
+        tTVInteger caret = static_cast<tTVInteger>(utf16_length);
+        tTVInteger anchor = caret;
+        tTJSVariant caret_value;
+        if(TJS_SUCCEEDED(attention_owner->PropGet(
+               TJS_IGNOREPROP, TJS_W("Edit_selStart"), nullptr, &caret_value,
+               attention_owner)) &&
+           (caret_value.Type() == tvtInteger || caret_value.Type() == tvtReal)) {
+            caret = caret_value.AsInteger();
+        }
+        tTJSVariant anchor_value;
+        if(TJS_SUCCEEDED(attention_owner->PropGet(
+               TJS_IGNOREPROP, TJS_W("Edit_selAnchor"), nullptr,
+               &anchor_value, attention_owner)) &&
+           (anchor_value.Type() == tvtInteger ||
+            anchor_value.Type() == tvtReal)) {
+            anchor = anchor_value.AsInteger();
+        } else {
+            anchor = caret;
+        }
+
+        *out_text_utf8 = HostTextUtf16ToUtf8(text.c_str(), utf16_length);
+        const int32_t caret_scalar =
+            HostUtf16OffsetToScalar(text.c_str(), utf16_length, caret);
+        const int32_t anchor_scalar =
+            HostUtf16OffsetToScalar(text.c_str(), utf16_length, anchor);
+        *out_selection_start = std::min(caret_scalar, anchor_scalar);
+        *out_selection_end = std::max(caret_scalar, anchor_scalar);
+        return true;
+    } catch(...) {
+        return false;
+    }
+}
+
+void AdoptHostTextInputOwnerLocked(tTJSNI_Window *owner) {
+    if(g_host_text_input_state.owner == owner)
+        return;
+    g_host_text_input_state = {};
+    g_host_text_input_state.owner = owner;
+}
+
+void SetHostTextInputMode(tTJSNI_Window *owner, tTVPImeMode mode) {
+    if(owner == nullptr)
+        return;
+    std::lock_guard<std::mutex> lock(g_host_text_input_mutex);
+    AdoptHostTextInputOwnerLocked(owner);
+    const bool ime_active = IsHostTextInputModeActive(mode);
+    if(g_host_text_input_state.owner == owner &&
+       g_host_text_input_state.ime_mode == mode &&
+       g_host_text_input_state.ime_active == ime_active) {
+        return;
+    }
+    g_host_text_input_state.owner = owner;
+    g_host_text_input_state.ime_mode = mode;
+    g_host_text_input_state.ime_active = ime_active;
+}
+
+void SetHostTextInputAttentionPoint(tTJSNI_Window *owner, bool valid,
+                                    tjs_int x = 0, tjs_int y = 0,
+                                    iTJSDispatch2 *attention_owner = nullptr) {
+    if(owner == nullptr)
+        return;
+    std::string text_utf8;
+    int32_t selection_start = 0;
+    int32_t selection_end = 0;
+    const bool text_available = valid && TryReadHostTextInputContent(
+        attention_owner, &text_utf8, &selection_start, &selection_end);
+
+    std::lock_guard<std::mutex> lock(g_host_text_input_mutex);
+    AdoptHostTextInputOwnerLocked(owner);
+    g_host_text_input_state.owner = owner;
+    g_host_text_input_state.attention_point_valid = valid;
+    g_host_text_input_state.attention_x = valid ? x : 0;
+    g_host_text_input_state.attention_y = valid ? y : 0;
+    g_host_text_input_state.text_available = text_available;
+    g_host_text_input_state.text_utf8 =
+        text_available ? std::move(text_utf8) : std::string();
+    g_host_text_input_state.selection_start =
+        text_available ? selection_start : 0;
+    g_host_text_input_state.selection_end = text_available ? selection_end : 0;
+}
+
+void ClearHostTextInputState(tTJSNI_Window *owner) {
+    std::lock_guard<std::mutex> lock(g_host_text_input_mutex);
+    if(g_host_text_input_state.owner != owner)
+        return;
+    g_host_text_input_state = {};
+}
+
 void RegisterHostWindow(tTJSNI_Window *owner) {
     if(owner == nullptr)
         return;
@@ -458,6 +658,54 @@ void ApplyDrawDeviceSurfaceRect(iTVPDrawDevice *dd, const tTVPRect &rect,
 
 }
 
+extern "C" void TVPHostGetTextInputState(uint32_t *ime_active,
+                                          int32_t *ime_mode,
+                                          uint32_t *attention_point_valid,
+                                          int32_t *attention_x,
+                                          int32_t *attention_y,
+                                          uint32_t *text_available,
+                                          uint32_t *text_utf8_bytes,
+                                          int32_t *selection_start,
+                                          int32_t *selection_end) {
+    std::lock_guard<std::mutex> lock(g_host_text_input_mutex);
+    if(ime_active)
+        *ime_active = g_host_text_input_state.ime_active ? 1u : 0u;
+    if(ime_mode)
+        *ime_mode = static_cast<int32_t>(g_host_text_input_state.ime_mode);
+    if(attention_point_valid)
+        *attention_point_valid =
+            g_host_text_input_state.attention_point_valid ? 1u : 0u;
+    if(attention_x)
+        *attention_x = static_cast<int32_t>(g_host_text_input_state.attention_x);
+    if(attention_y)
+        *attention_y = static_cast<int32_t>(g_host_text_input_state.attention_y);
+    if(text_available)
+        *text_available = g_host_text_input_state.text_available ? 1u : 0u;
+    if(text_utf8_bytes)
+        *text_utf8_bytes = static_cast<uint32_t>(
+            std::min<size_t>(g_host_text_input_state.text_utf8.size(),
+                             UINT32_MAX));
+    if(selection_start)
+        *selection_start = g_host_text_input_state.selection_start;
+    if(selection_end)
+        *selection_end = g_host_text_input_state.selection_end;
+}
+
+extern "C" uint32_t TVPHostCopyTextInputText(char *out_buffer,
+                                               uint32_t buffer_size) {
+    if(out_buffer == nullptr || buffer_size == 0)
+        return 0;
+    std::lock_guard<std::mutex> lock(g_host_text_input_mutex);
+    const uint32_t bytes = static_cast<uint32_t>(std::min<size_t>(
+        g_host_text_input_state.text_utf8.size(),
+        static_cast<size_t>(buffer_size - 1)));
+    if(bytes > 0) {
+        std::memcpy(out_buffer, g_host_text_input_state.text_utf8.data(), bytes);
+    }
+    out_buffer[bytes] = '\0';
+    return bytes;
+}
+
 void TVPHostForceDrawDeviceShow() {
     if (g_host_window_owner != nullptr) {
         g_host_window_owner->UpdateContent();
@@ -672,7 +920,15 @@ public:
     void SetHintText(const ttstr &text) override {}
 
     void SetAttentionPoint(tjs_int left, tjs_int top,
-                           const struct tTVPFont *font) override {}
+                           const struct tTVPFont *font,
+                           iTJSDispatch2 *attention_owner) override {
+        SetHostTextInputAttentionPoint(owner_, true, left, top,
+                                       attention_owner);
+    }
+
+    void DisableAttentionPoint() override {
+        SetHostTextInputAttentionPoint(owner_, false);
+    }
 
     void ZoomRectangle(tjs_int &left, tjs_int &top, tjs_int &right,
                        tjs_int &bottom) override {
@@ -1114,9 +1370,13 @@ public:
         return imDisable;
     }
 
-    void SetImeMode(tTVPImeMode mode) override {}
+    void SetImeMode(tTVPImeMode mode) override {
+        SetHostTextInputMode(owner_, mode);
+    }
 
-    void ResetImeMode() override {}
+    void ResetImeMode() override {
+        SetHostTextInputMode(owner_, imDisable);
+    }
 
     void UpdateWindow(tTVPUpdateType type) override {
         // Rendering is driven by engine_tick / engine_read_frame_rgba
@@ -1147,6 +1407,7 @@ private:
     void DetachOwner() {
         if(owner_ == nullptr)
             return;
+        ClearHostTextInputState(owner_);
         UnregisterHostWindow(owner_);
         owner_ = nullptr;
     }

--- a/cpp/core/environ/win32/TVPWindow.h
+++ b/cpp/core/environ/win32/TVPWindow.h
@@ -334,7 +334,8 @@ public:
     virtual void UpdateCursorPos(tjs_int x, tjs_int y) {}
     virtual void SetHintText(const ttstr &text) = 0;
     virtual void SetAttentionPoint(tjs_int left, tjs_int top,
-                                   const struct tTVPFont *font) = 0;
+                                   const struct tTVPFont *font,
+                                   iTJSDispatch2 *attention_owner) = 0;
     virtual void ZoomRectangle(tjs_int &left, tjs_int &top, tjs_int &right,
                                tjs_int &bottom) = 0;
     virtual void BringToFront() = 0;
@@ -436,7 +437,7 @@ public:
     // TODO
     void SetMouseCursor(tjs_int handle) {}
     void SetHintText(iTJSDispatch2 *sender, const ttstr &text) {}
-    void DisableAttentionPoint() {}
+    virtual void DisableAttentionPoint() {}
     static void GetVideoOffset(tjs_int &ofsx, tjs_int &ofsy) {
         ofsx = 0;
         ofsy = 0;

--- a/cpp/core/visual/impl/WindowImpl.cpp
+++ b/cpp/core/visual/impl/WindowImpl.cpp
@@ -1322,7 +1322,8 @@ void tTJSNI_Window::SetAttentionPoint(tTJSNI_BaseLayer *layer, tjs_int l,
             }
         }
 
-        Form->SetAttentionPoint(l, t, font);
+        Form->SetAttentionPoint(
+            l, t, font, layer ? layer->GetOwnerNoAddRef() : nullptr);
     }
 }
 //---------------------------------------------------------------------------

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -122,6 +122,55 @@ TEST_CASE("legacy startup drain remains independent") {
   REQUIRE(DrainDiagnostics(handle).find("after-open") != std::string::npos);
 }
 
+TEST_CASE("text input state validates lifecycle and ABI size") {
+  Handle handle;
+  char text[8] = {};
+  uint32_t text_bytes = 0;
+  engine_text_input_state_t state{};
+  state.struct_size = sizeof(state);
+  REQUIRE(engine_get_text_input_state(handle.value, &state) ==
+          ENGINE_RESULT_INVALID_STATE);
+  REQUIRE(engine_copy_text_input_text(handle.value, text, sizeof(text),
+                                      &text_bytes) ==
+          ENGINE_RESULT_INVALID_STATE);
+
+  engine_text_input_state_t too_small{};
+  too_small.struct_size = sizeof(too_small) - 1;
+  REQUIRE(engine_get_text_input_state(handle.value, &too_small) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_get_text_input_state(handle.value, nullptr) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_copy_text_input_text(handle.value, nullptr, sizeof(text),
+                                      &text_bytes) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_copy_text_input_text(handle.value, text, 0, &text_bytes) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_copy_text_input_text(handle.value, text, sizeof(text),
+                                      nullptr) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+
+  REQUIRE(engine_open_game(handle.value, ".", nullptr) == ENGINE_RESULT_OK);
+  state = {};
+  state.struct_size = sizeof(state);
+  REQUIRE(engine_get_text_input_state(handle.value, &state) == ENGINE_RESULT_OK);
+  REQUIRE(state.struct_size == sizeof(state));
+  REQUIRE(state.ime_active == 0);
+  REQUIRE(state.ime_mode == 0);
+  REQUIRE(state.attention_point_valid == 0);
+  REQUIRE(state.attention_x == 0);
+  REQUIRE(state.attention_y == 0);
+  REQUIRE(state.text_available == 0);
+  REQUIRE(state.text_utf8_bytes == 0);
+  REQUIRE(state.selection_start == 0);
+  REQUIRE(state.selection_end == 0);
+  text[0] = 'x';
+  text_bytes = 99;
+  REQUIRE(engine_copy_text_input_text(handle.value, text, sizeof(text),
+                                      &text_bytes) == ENGINE_RESULT_OK);
+  REQUIRE(text_bytes == 0);
+  REQUIRE(text[0] == '\0');
+}
+
 TEST_CASE("plugin debug snapshot is bounded JSON and validates buffers") {
   Handle handle;
   engine_option_t trace_option{};


### PR DESCRIPTION
## Summary

- expose focused KAG text-input state, caret position, backing text, and selection through the engine API and Godot bridge
- activate and manage the mobile virtual keyboard, seeding it with the real KAG text and selection so prefilled content remains editable
- preserve full Unicode scalar input, including non-BMP characters, and clear keyboard state across focus and app lifecycle transitions
- keep desktop IME activation and caret positioning in sync

## Root cause

The host UI layer discarded KiriKiri attention-point and IME state, so the Godot app could not know when an editable layer had focus and never opened the iOS keyboard.

The initial keyboard bridge also seeded Godot's hidden native editor with an empty string. iOS therefore knew only about newly typed characters, not the KAG field's existing content, and could not generate Backspace events for prefilled text.

## User impact

KAG edit fields in the bundled iOS demo now open the software keyboard. Existing text can be edited and deleted, and the native keyboard cursor/selection stays aligned with the KAG editor.

## Validation

- `cmake --build out/macos/debug --parallel 6`
- `ctest --test-dir out/macos/debug --output-on-failure --parallel 6` — 69/69 passed
- `godot --headless --path apps/godot_app --editor --quit` — Godot 4.7.1 script load passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./build.sh ios release --jobs=6`
- signed Release device build with Xcode 26.6
- installed and launched on iPad mini (A17 Pro), iPadOS 26.5.2
- verified the software keyboard opens, numeric input works, and prefilled Chinese text can be deleted with Backspace

<img width="1133" height="744" alt="IMG_0068" src="https://github.com/user-attachments/assets/788cec14-b431-45f0-8368-ef0bc473a189" />
<img width="1133" height="744" alt="IMG_0069" src="https://github.com/user-attachments/assets/70e55c71-65d5-4ff7-b562-71d1a2df723a" />


Fixes #60
