### PR TITLE
fix: prevent top-aligned layer text clipping

### DIFF
--- a/cpp/core/visual/FontBaseline.h
+++ b/cpp/core/visual/FontBaseline.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 namespace krkr::font {
 
@@ -41,6 +42,24 @@ inline int ClampTextOriginToClipTop(int originY, int glyphTop,
                                    int outlineWidth, int clipTop) {
     const int inkTop = originY + glyphTop - std::max(0, outlineWidth);
     return inkTop < clipTop ? originY + (clipTop - inkTop) : originY;
+}
+
+// A blurred shadow grows by shadowWidth in every direction and is then moved
+// by the requested shadow offset.  Return only the extra space needed above
+// the unshadowed glyph; shadows that are moved far enough down need no extra
+// top padding.
+inline int ComputeTextShadowTopPadding(int shadowLevel, int shadowWidth,
+                                       int shadowOffsetY) {
+    if(shadowLevel == 0)
+        return 0;
+
+    const std::int64_t width = std::max<std::int64_t>(
+        -static_cast<std::int64_t>(shadowWidth),
+        static_cast<std::int64_t>(shadowWidth));
+    const std::int64_t padding =
+        std::max<std::int64_t>(0, width - shadowOffsetY);
+    return static_cast<int>(std::min<std::int64_t>(
+        padding, std::numeric_limits<int>::max()));
 }
 
 } // namespace krkr::font

--- a/cpp/core/visual/LayerIntf.cpp
+++ b/cpp/core/visual/LayerIntf.cpp
@@ -12367,27 +12367,57 @@ tTJSNC_Layer::tTJSNC_Layer() : tTJSNativeClass(TJS_W("Layer")) {
                                 /*var. type*/ tTJSNI_Layer);
         if(numparams < 4)
             return TJS_E_BADPARAMCOUNT;
-        _this->DrawText(
-            *param[0], *param[1], *param[2],
-            static_cast<tjs_uint32>((tjs_int64)*param[3]),
+
+        const tjs_int x = *param[0];
+        tjs_int y = *param[1];
+        const tjs_uint32 color =
+            static_cast<tjs_uint32>((tjs_int64)*param[3]);
+        const tjs_int opacity =
             (numparams >= 5 && param[4]->Type() != tvtVoid) ? (tjs_int)*param[4]
-                                                            : (tjs_int)255,
+                                                            : (tjs_int)255;
+        const bool antialiased =
             (numparams >= 6 && param[5]->Type() != tvtVoid)
                 ? param[5]->operator bool()
-                : true,
+                : true;
+        const tjs_int shadowLevel =
             (numparams >= 7 && param[6]->Type() != tvtVoid) ? (tjs_int)*param[6]
-                                                            : 0,
+                                                            : 0;
+        const tjs_uint32 shadowColor =
             (numparams >= 8 && param[7]->Type() != tvtVoid)
                 ? static_cast<tjs_uint32>((tjs_int64)*param[7])
-                : 0,
+                : 0;
+        const tjs_int shadowWidth =
             (numparams >= 9 && param[8]->Type() != tvtVoid) ? (tjs_int)*param[8]
-                                                            : 0,
+                                                            : 0;
+        const tjs_int shadowOffsetX =
             (numparams >= 10 && param[9]->Type() != tvtVoid)
                 ? (tjs_int)*param[9]
-                : 0,
+                : 0;
+        const tjs_int shadowOffsetY =
             (numparams >= 11 && param[10]->Type() != tvtVoid)
                 ? (tjs_int)*param[10]
-                : 0);
+                : 0;
+
+        // Some games draw a top-aligned name into a small transparent layer.
+        // Replacement fonts can have ink above the logical line box, so keep
+        // the glyph and its shadow inside the active clip just like the
+        // vertical-gradient text path below does.
+        try {
+            tTVPRect glyphBounds;
+            _this->GetFontGlyphDrawRect(*param[2], glyphBounds);
+            y = krkr::font::ClampTextOriginToClipTop(
+                y, glyphBounds.top,
+                krkr::font::ComputeTextShadowTopPadding(
+                    shadowLevel, shadowWidth, shadowOffsetY),
+                _this->GetClipTop());
+        } catch(...) {
+            // Bounds measurement is best-effort. Preserve the original draw
+            // behavior when the active font cannot report its glyph bounds.
+        }
+
+        _this->DrawText(
+            x, y, *param[2], color, opacity, antialiased, shadowLevel,
+            shadowColor, shadowWidth, shadowOffsetX, shadowOffsetY);
 
         return TJS_S_OK;
     }

--- a/tests/unit-tests/plugins/font-baseline.cpp
+++ b/tests/unit-tests/plugins/font-baseline.cpp
@@ -51,3 +51,15 @@ TEST_CASE("top-aligned text keeps negative ink and outlines inside its clip") {
     CHECK(krkr::font::ClampTextOriginToClipTop(0, 0, 1, 0) == 1);
     CHECK(krkr::font::ClampTextOriginToClipTop(8, -4, 0, 3) == 8);
 }
+
+TEST_CASE("text shadow top padding accounts for blur and vertical offset") {
+    CHECK(krkr::font::ComputeTextShadowTopPadding(0, 4, -3) == 0);
+    CHECK(krkr::font::ComputeTextShadowTopPadding(255, 0, 2) == 0);
+    CHECK(krkr::font::ComputeTextShadowTopPadding(128, 3, 1) == 2);
+    CHECK(krkr::font::ComputeTextShadowTopPadding(128, 3, -2) == 5);
+    CHECK(krkr::font::ComputeTextShadowTopPadding(128, -3, 1) == 2);
+
+    const int padding =
+        krkr::font::ComputeTextShadowTopPadding(128, 2, 1);
+    CHECK(krkr::font::ClampTextOriginToClipTop(0, -2, padding, 0) == 3);
+}


### PR DESCRIPTION
## 问题

在《管乐恋曲～The bonds of melody～》中加载第一个存档后，人物名称标题的上半部分会被裁掉。

游戏把名称绘制到一个 200×32 的透明小图层，并直接以 y=0 调用 Layer.drawText。替代字体的实际字形边界可能高于逻辑行框，因此负的字形 top 会在图层顶部被裁掉。原有保护只覆盖了渐变文字和部分插件路径，没有覆盖直接的 Layer.drawText 调用。

## 修复

- 在 Layer.drawText 入口绘制前测量实际字形边界。
- 仅当字形或阴影越过当前 clip 顶边时，按必要距离下移绘制原点。
- 将阴影宽度与垂直偏移纳入顶部边界计算。
- 字形测量失败时保持原有绘制行为，不阻断脚本。
- 增加字体顶部边界与阴影边界的单元测试。

这是通用的文本裁剪修复，不包含游戏名、脚本名或角色名特判。

## 验证

- 新增与既有字体边界测试通过。
- 完整单元测试：99/99 通过。
- macOS Debug 完整构建和签名校验通过。
- 使用正常启动流程进入游戏、选择 Continue、加载第一个存档：人物名称上沿完整，正文位置正常，未出现新增渲染错误。