### PR TITLE
fix(render): restore Senren Banka UI rendering

### DIFF
--- a/bridge/godot_extension/src/aether_kiri_godot.cpp
+++ b/bridge/godot_extension/src/aether_kiri_godot.cpp
@@ -1040,8 +1040,10 @@ bool DeferredGodotGpuDrainEnabled() {
         // transitions on Metal.  Execute those operations immediately by
         // default; the old batched behavior remains available for profiling
         // with AETHERKIRI_GODOT_DEFER_GPU_DRAIN=1.
-        return value != nullptr && value[0] != '\0' &&
-               std::strcmp(value, "0") != 0;
+        if (value == nullptr || value[0] == '\0') {
+            return TVP_GODOT_DEFER_GPU_DRAIN_DEFAULT;
+        }
+        return std::strcmp(value, "0") != 0;
     }();
     return enabled;
 }

--- a/cpp/core/visual/LayerCompletionCoordinates.h
+++ b/cpp/core/visual/LayerCompletionCoordinates.h
@@ -1,0 +1,30 @@
+#ifndef LayerCompletionCoordinatesH
+#define LayerCompletionCoordinatesH
+
+namespace TVPLayerInternal {
+
+struct GpuCompletionCoordinates {
+    int destinationX;
+    int destinationY;
+    int parentLeft;
+    int parentTop;
+    int parentRight;
+    int parentBottom;
+};
+
+inline GpuCompletionCoordinates ResolveGpuCompletionCoordinates(
+    int updateLeft, int updateTop, int updateRight, int updateBottom,
+    int layerLeft, int layerTop, bool localDestination) {
+    const int parentLeft = updateLeft + layerLeft;
+    const int parentTop = updateTop + layerTop;
+    return {localDestination ? updateLeft : parentLeft,
+            localDestination ? updateTop : parentTop,
+            parentLeft,
+            parentTop,
+            updateRight + layerLeft,
+            updateBottom + layerTop};
+}
+
+} // namespace TVPLayerInternal
+
+#endif

--- a/cpp/core/visual/LayerIntf.cpp
+++ b/cpp/core/visual/LayerIntf.cpp
@@ -61,6 +61,8 @@
 #include "RenderManager.h"
 #include "godot/GodotRenderManager.h"
 #include "FontImpl.h"
+#include "LayerCompletionCoordinates.h"
+#include "PimgCompositeBounds.h"
 #include "../../plugins/psbfile/PSBMedia.h"
 
 extern "C" bool AetherKiriMotionRestoreCenteredPresentationLayer(
@@ -2233,29 +2235,30 @@ static bool TVPLayerLoadPimgComposite(tTJSNI_BaseLayer *layer,
         selected.push_back(found->second);
     }
 
-    int canvasWidth = 0;
-    int canvasHeight = 0;
+    std::vector<TVPLayerInternal::PimgLayerRect> selectedRects;
+    selectedRects.reserve(selected.size());
     for(const auto *entry : selected) {
-        canvasWidth =
-            std::max(canvasWidth, entry->info.left + entry->info.width);
-        canvasHeight =
-            std::max(canvasHeight, entry->info.top + entry->info.height);
-    }
-    if(canvasWidth <= 0 || canvasHeight <= 0) {
-        for(const auto &entry : entries) {
-            canvasWidth =
-                std::max(canvasWidth, entry.info.left + entry.info.width);
-            canvasHeight =
-                std::max(canvasHeight, entry.info.top + entry.info.height);
-        }
-    }
-    if(canvasWidth <= 0 || canvasHeight <= 0) {
-        return false;
+        selectedRects.push_back({entry->info.left, entry->info.top,
+                                 entry->info.width, entry->info.height});
     }
 
-    tTVPBaseBitmap canvas(static_cast<tjs_uint>(canvasWidth),
-                          static_cast<tjs_uint>(canvasHeight), 32);
-    canvas.Fill(tTVPRect(0, 0, canvasWidth, canvasHeight), 0);
+    TVPLayerInternal::PimgCompositeBounds bounds{};
+    if(!TVPLayerInternal::ComputePimgCompositeBounds(selectedRects, bounds)) {
+        std::vector<TVPLayerInternal::PimgLayerRect> fallbackRects;
+        fallbackRects.reserve(entries.size());
+        for(const auto &entry : entries) {
+            fallbackRects.push_back({entry.info.left, entry.info.top,
+                                     entry.info.width, entry.info.height});
+        }
+        if(!TVPLayerInternal::ComputePimgCompositeBounds(fallbackRects,
+                                                         bounds)) {
+            return false;
+        }
+    }
+
+    tTVPBaseBitmap canvas(static_cast<tjs_uint>(bounds.width),
+                          static_cast<tjs_uint>(bounds.height), 32);
+    canvas.Fill(tTVPRect(0, 0, bounds.width, bounds.height), 0);
 
     bool wroteAnyLayer = false;
     iTJSDispatch2 *compositeMeta = nullptr;
@@ -2287,8 +2290,8 @@ static bool TVPLayerLoadPimgComposite(tTJSNI_BaseLayer *layer,
                 std::max(0, std::min(255, info.opacity));
             const tTVPBBBltMethod method =
                 !wroteAnyLayer && opacity == 255 ? bmCopy : bmAlphaOnAlpha;
-            canvas.Blt(info.left, info.top, &source, sourceRect, method, opacity,
-                       false);
+            canvas.Blt(info.left - bounds.left, info.top - bounds.top, &source,
+                       sourceRect, method, opacity, false);
             wroteAnyLayer = true;
         }
 
@@ -2301,9 +2304,9 @@ static bool TVPLayerLoadPimgComposite(tTJSNI_BaseLayer *layer,
 
         layer->AssignMainImageWithUpdate(&canvas);
         spdlog::debug(
-            "Layer.loadImages PIMG composite storage={} archive={} seton={} size={}x{} layers={}",
-            storage.AsStdString(), archive, setonText, canvasWidth, canvasHeight,
-            selected.size());
+            "Layer.loadImages PIMG composite storage={} archive={} seton={} origin={},{} size={}x{} layers={}",
+            storage.AsStdString(), archive, setonText, bounds.left, bounds.top,
+            bounds.width, bounds.height, selected.size());
     } catch(...) {
         if(compositeMeta) {
             compositeMeta->Release();
@@ -10936,15 +10939,24 @@ void tTJSNI_BaseLayer::InternalComplete2(tTVPComplexRect &updateregion,
 
 //---------------------------------------------------------------------------
 void tTJSNI_BaseLayer::InternalComplete2_GPU(tTVPRect updateregion,
-                                             tTVPDrawable *drawable) {
+                                             tTVPDrawable *drawable,
+                                             bool localDestination) {
     if(Manager)
         Manager->QueryUpdateExcludeRect();
-    updateregion.add_offsets(Rect.left, Rect.top);
-    // Draw_GPU's x/y parameters are the destination position corresponding
-    // to r.left/r.top. Passing (0, 0) is only correct for a full-window rect;
-    // for a dirty rect it moves that strip to the top-left and produces a
-    // visibly torn frame after every click.
-    Draw_GPU(drawable, updateregion.left, updateregion.top,
+    const auto coordinates =
+        TVPLayerInternal::ResolveGpuCompletionCoordinates(
+            updateregion.left, updateregion.top, updateregion.right,
+            updateregion.bottom, Rect.left, Rect.top, localDestination);
+    updateregion.left = coordinates.parentLeft;
+    updateregion.top = coordinates.parentTop;
+    updateregion.right = coordinates.parentRight;
+    updateregion.bottom = coordinates.parentBottom;
+    // Draw_GPU receives its rectangle in the layer's parent coordinates.
+    // A window destination uses those same coordinates. Complete(), however,
+    // renders into a layer-local cache bitmap, so its destination must retain
+    // the unshifted local position even though the source rectangle is shifted
+    // for intersection with this layer's Rect.
+    Draw_GPU(drawable, coordinates.destinationX, coordinates.destinationY,
              updateregion, false);
 }
 
@@ -10958,7 +10970,7 @@ void tTJSNI_BaseLayer::InternalComplete(tTVPComplexRect &updateregion,
     InCompletion = true;
 
     if(IsGPU()) {
-        InternalComplete2_GPU(updateregion.GetBound(), drawable);
+        InternalComplete2_GPU(updateregion.GetBound(), drawable, true);
     } else {
         InternalComplete2(updateregion, drawable);
     }
@@ -10991,11 +11003,11 @@ void tTJSNI_BaseLayer::CompleteForWindow(tTVPDrawable *drawable) {
                     // can alternate between old and new character contents.
                     InternalComplete2_GPU(
                         TVPConsumeFullGpuCompletionRequest() ? Rect : dirty,
-                        drawable);
+                        drawable, false);
                     updateRegion.Clear();
                 }
             } else {
-                InternalComplete2_GPU(Rect, drawable);
+                InternalComplete2_GPU(Rect, drawable, false);
             }
         } else {
             InternalComplete2(Manager->GetUpdateRegionForCompletion(),

--- a/cpp/core/visual/LayerIntf.h
+++ b/cpp/core/visual/LayerIntf.h
@@ -1060,7 +1060,8 @@ private:
 
     void InternalComplete2(tTVPComplexRect &updateregion,
                            tTVPDrawable *drawable);
-    void InternalComplete2_GPU(tTVPRect updateregion, tTVPDrawable *drawable);
+    void InternalComplete2_GPU(tTVPRect updateregion, tTVPDrawable *drawable,
+                               bool localDestination);
     void InternalComplete(tTVPComplexRect &updateregion,
                           tTVPDrawable *drawable);
     void CompleteForWindow(tTVPDrawable *drawable);

--- a/cpp/core/visual/PimgCompositeBounds.h
+++ b/cpp/core/visual/PimgCompositeBounds.h
@@ -1,0 +1,74 @@
+#ifndef PimgCompositeBoundsH
+#define PimgCompositeBoundsH
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+namespace TVPLayerInternal {
+
+struct PimgLayerRect {
+    int left;
+    int top;
+    int width;
+    int height;
+};
+
+struct PimgCompositeBounds {
+    int left;
+    int top;
+    int width;
+    int height;
+};
+
+inline bool ComputePimgCompositeBounds(
+    const std::vector<PimgLayerRect> &layers, PimgCompositeBounds &bounds) {
+    bool found = false;
+    long long minLeft = 0;
+    long long minTop = 0;
+    long long maxRight = 0;
+    long long maxBottom = 0;
+
+    for(const auto &layer : layers) {
+        if(layer.width <= 0 || layer.height <= 0) {
+            continue;
+        }
+
+        const long long left = layer.left;
+        const long long top = layer.top;
+        const long long right = left + layer.width;
+        const long long bottom = top + layer.height;
+        if(!found) {
+            minLeft = left;
+            minTop = top;
+            maxRight = right;
+            maxBottom = bottom;
+            found = true;
+        } else {
+            minLeft = std::min(minLeft, left);
+            minTop = std::min(minTop, top);
+            maxRight = std::max(maxRight, right);
+            maxBottom = std::max(maxBottom, bottom);
+        }
+    }
+
+    if(!found) {
+        return false;
+    }
+
+    const long long width = maxRight - minLeft;
+    const long long height = maxBottom - minTop;
+    if(width <= 0 || height <= 0 ||
+       width > std::numeric_limits<int>::max() ||
+       height > std::numeric_limits<int>::max()) {
+        return false;
+    }
+
+    bounds = {static_cast<int>(minLeft), static_cast<int>(minTop),
+              static_cast<int>(width), static_cast<int>(height)};
+    return true;
+}
+
+} // namespace TVPLayerInternal
+
+#endif

--- a/cpp/core/visual/godot/GodotGpuBridge.h
+++ b/cpp/core/visual/godot/GodotGpuBridge.h
@@ -6,6 +6,10 @@
 struct tTVPRect;
 struct tTVPPointD;
 
+// Texture synchronization on the producer side and queue execution in the
+// Godot bridge must agree on the unset environment-variable behavior.
+constexpr bool TVP_GODOT_DEFER_GPU_DRAIN_DEFAULT = false;
+
 struct TVPGodotGpuBridgeCallbacks {
     uint64_t (*create_rgba)(uint32_t width, uint32_t height,
                             const void *pixels, uint32_t stride_bytes);

--- a/cpp/core/visual/godot/GodotRenderManager.cpp
+++ b/cpp/core/visual/godot/GodotRenderManager.cpp
@@ -118,7 +118,10 @@ bool TraceGpuFallback() {
 bool DeferredGodotGpuDrainEnabled() {
     static const bool enabled = []() {
         const char *value = std::getenv("AETHERKIRI_GODOT_DEFER_GPU_DRAIN");
-        return value == nullptr || value[0] == '\0' || std::strcmp(value, "0") != 0;
+        if (value == nullptr || value[0] == '\0') {
+            return TVP_GODOT_DEFER_GPU_DRAIN_DEFAULT;
+        }
+        return std::strcmp(value, "0") != 0;
     }();
     return enabled;
 }

--- a/cpp/plugins/psbfile/PSBMedia.cpp
+++ b/cpp/plugins/psbfile/PSBMedia.cpp
@@ -21,6 +21,30 @@
 namespace PSB {
 #define LOGGER spdlog::get("plugin")
 
+    bool detail::IsSupportedImageHeader(const std::vector<uint8_t> &data) {
+        if(data.size() >= 8 && data[0] == 0x89 && data[1] == 0x50 &&
+           data[2] == 0x4e && data[3] == 0x47) {
+            return true;
+        }
+        if(data.size() >= 15 &&
+           memcmp(data.data(), "RIFF", 4) == 0 &&
+           memcmp(data.data() + 8, "WEBPVP8", 7) == 0) {
+            return true;
+        }
+        if(data.size() >= 2 && data[0] == 'B' && data[1] == 'M') {
+            return true;
+        }
+        if(data.size() >= 3 && data[0] == 0xff && data[1] == 0xd8 &&
+           data[2] == 0xff) {
+            return true;
+        }
+        if(data.size() >= 3 && data[0] == 'T' && data[1] == 'L' &&
+           data[2] == 'G') {
+            return true;
+        }
+        return false;
+    }
+
     namespace {
         size_t CalcEntryFootprint(const PSBMedia::CacheEntry &entry) {
             size_t total = entry.resource ? entry.resource->data.size() : 0;
@@ -127,25 +151,6 @@ namespace PSB {
                     path.pop_back();
                 }
             }
-        }
-
-        bool IsSupportedImageHeader(const std::vector<uint8_t> &data) {
-            if(data.size() >= 8 && data[0] == 0x89 && data[1] == 0x50 &&
-               data[2] == 0x4e && data[3] == 0x47) {
-                return true;
-            }
-            if(data.size() >= 2 && data[0] == 'B' && data[1] == 'M') {
-                return true;
-            }
-            if(data.size() >= 3 && data[0] == 0xff && data[1] == 0xd8 &&
-               data[2] == 0xff) {
-                return true;
-            }
-            if(data.size() >= 3 && data[0] == 'T' && data[1] == 'L' &&
-               data[2] == 'G') {
-                return true;
-            }
-            return false;
         }
 
         uint16_t ReadLE16(const uint8_t *src) {
@@ -1271,7 +1276,8 @@ namespace PSB {
                 imageInfo.palette.size(), static_cast<int>(imageInfo.compress),
                 res->data.size(), header);
         }
-        if(!convertedImage && hasImageInfo && !IsSupportedImageHeader(res->data)) {
+        if(!convertedImage && hasImageInfo &&
+           !detail::IsSupportedImageHeader(res->data)) {
             convertedImage = BuildBmpFromRaw(imageInfo, res);
             if(LOGGER && IsDebugPSBKey(resolvedKey)) {
                 LOGGER->info(

--- a/cpp/plugins/psbfile/PSBMedia.h
+++ b/cpp/plugins/psbfile/PSBMedia.h
@@ -13,6 +13,10 @@
 #include "resources/ImageMetadata.h"
 
 namespace PSB {
+    namespace detail {
+        bool IsSupportedImageHeader(const std::vector<uint8_t> &data);
+    }
+
     struct PSBMediaCacheStats {
         size_t entryCount = 0;
         size_t entryLimit = 0;

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -4,6 +4,7 @@ project(TestPlugins LANGUAGES CXX)
 add_executable(motionplayer-dll
     main.cpp
     motionplayer-dll.cpp
+    psb-media.cpp
     registry.cpp
     kbad-data-pack.cpp
     textrender-timing.cpp

--- a/tests/unit-tests/plugins/godot-texture.cpp
+++ b/tests/unit-tests/plugins/godot-texture.cpp
@@ -22,9 +22,15 @@ struct TriangleDrawCall {
     uint32_t blend_mode = 0;
 };
 
+enum class GpuCall {
+    Flush,
+    Blend,
+};
+
 TriangleDrawCall g_triangle_draw_call;
 int g_blend_rect_calls = 0;
 uint64_t g_next_texture_handle = 1;
+std::vector<GpuCall> g_gpu_calls;
 
 uint64_t CreateTestTexture(uint32_t, uint32_t, const void *, uint32_t) {
     return g_next_texture_handle++;
@@ -60,7 +66,13 @@ bool DrawTestTriangles(uint64_t dst, uint64_t src, uint32_t triangle_count,
 
 bool BlendTestRect(uint64_t, uint64_t, const tTVPRect *, const tTVPRect *,
                    uint32_t, int, uint32_t) {
+    g_gpu_calls.push_back(GpuCall::Blend);
     ++g_blend_rect_calls;
+    return true;
+}
+
+bool FlushTestGpu() {
+    g_gpu_calls.push_back(GpuCall::Flush);
     return true;
 }
 
@@ -70,12 +82,14 @@ public:
         g_triangle_draw_call = {};
         g_blend_rect_calls = 0;
         g_next_texture_handle = 1;
+        g_gpu_calls.clear();
         TVPGodotGpuBridgeCallbacks callbacks{};
         callbacks.create_rgba = CreateTestTexture;
         callbacks.release_texture = ReleaseTestTexture;
         callbacks.draw_triangles = DrawTestTriangles;
         callbacks.blend_rect = BlendTestRect;
         callbacks.read_rgba = ReadTestGrayTexture;
+        callbacks.flush = FlushTestGpu;
         TVPGodotGpuBridgeRegister(&callbacks);
     }
 
@@ -114,6 +128,31 @@ TEST_CASE("Godot nearest scaled alpha uses the software sampler") {
         method, &dst, &dst, tTVPRect(0, 0, 256, 256),
         tRenderTexRectArray(&source_element, 1));
     CHECK(g_blend_rect_calls == 1);
+}
+
+TEST_CASE("Godot immediate GPU drain flushes pending alpha sources") {
+    TestGpuBridge bridge;
+    std::vector<std::uint8_t> pixels(256u * 256u * 4u, 0xffu);
+    GodotTexture2D src(pixels.data(), 256 * 4, 256, 256,
+                       TVPTextureFormat::RGBA);
+    GodotTexture2D dst(pixels.data(), 256 * 4, 256, 256,
+                       TVPTextureFormat::RGBA);
+    REQUIRE(src.EnsureGpuHandle());
+    REQUIRE(dst.EnsureGpuHandle());
+    src.MarkGpuDirty();
+
+    GodotRenderManager manager;
+    iTVPRenderMethod *method = manager.GetRenderMethod("AlphaBlend_d");
+    tRenderTexRectArray::Element source_element(
+        &src, tTVPRect(0, 0, 256, 256));
+
+    manager.OperateRect(
+        method, &dst, &dst, tTVPRect(0, 0, 256, 256),
+        tRenderTexRectArray(&source_element, 1));
+
+    REQUIRE(g_gpu_calls.size() == 2);
+    CHECK(g_gpu_calls[0] == GpuCall::Flush);
+    CHECK(g_gpu_calls[1] == GpuCall::Blend);
 }
 
 TEST_CASE("Godot textures expose Gray province pixels") {

--- a/tests/unit-tests/plugins/psb-media.cpp
+++ b/tests/unit-tests/plugins/psb-media.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <vector>
+
+#include "LayerCompletionCoordinates.h"
+#include "PimgCompositeBounds.h"
+#include "psbfile/PSBMedia.h"
+
+namespace {
+    std::vector<uint8_t> makeWebPHeader(const size_t encodedSize) {
+        std::vector<uint8_t> encoded(encodedSize, 0xa5);
+        REQUIRE(encoded.size() >= 15);
+        memcpy(encoded.data(), "RIFF", 4);
+        memcpy(encoded.data() + 8, "WEBPVP8", 7);
+        return encoded;
+    }
+}
+
+TEST_CASE("PSB media preserves small WebP images before raw-pixel fallback") {
+    SECTION("quick-menu previous-choice normal state") {
+        const auto encoded = makeWebPHeader(24 * 25);
+        CHECK(PSB::detail::IsSupportedImageHeader(encoded));
+    }
+
+    SECTION("chapter-number separator") {
+        const auto encoded = makeWebPHeader(112);
+        CHECK(encoded.size() > 9 * 3 * 4);
+        CHECK(PSB::detail::IsSupportedImageHeader(encoded));
+    }
+}
+
+TEST_CASE("PIMG composites normalize selected layers to their own bounds") {
+    using TVPLayerInternal::ComputePimgCompositeBounds;
+    using TVPLayerInternal::PimgCompositeBounds;
+
+    SECTION("chapter ribbon") {
+        PimgCompositeBounds bounds{};
+        REQUIRE(ComputePimgCompositeBounds({{0, 55, 415, 88}}, bounds));
+        CHECK(bounds.left == 0);
+        CHECK(bounds.top == 55);
+        CHECK(bounds.width == 415);
+        CHECK(bounds.height == 88);
+        CHECK(55 - bounds.top == 0);
+    }
+
+    SECTION("chapter label") {
+        PimgCompositeBounds bounds{};
+        REQUIRE(ComputePimgCompositeBounds({{60, 80, 197, 31}}, bounds));
+        CHECK(bounds.left == 60);
+        CHECK(bounds.top == 80);
+        CHECK(bounds.width == 197);
+        CHECK(bounds.height == 31);
+        CHECK(60 - bounds.left == 0);
+        CHECK(80 - bounds.top == 0);
+    }
+
+    SECTION("multiple selected layers retain relative placement") {
+        PimgCompositeBounds bounds{};
+        REQUIRE(ComputePimgCompositeBounds(
+            {{60, 80, 197, 31}, {269, 80, 19, 31}}, bounds));
+        CHECK(bounds.left == 60);
+        CHECK(bounds.top == 80);
+        CHECK(bounds.width == 228);
+        CHECK(bounds.height == 31);
+        CHECK(269 - bounds.left == 209);
+    }
+}
+
+TEST_CASE("GPU offscreen completion keeps a layer-local destination") {
+    using TVPLayerInternal::ResolveGpuCompletionCoordinates;
+
+    SECTION("chapter layer cache") {
+        const auto coordinates = ResolveGpuCompletionCoordinates(
+            0, 0, 420, 88, 0, 55, true);
+        CHECK(coordinates.parentLeft == 0);
+        CHECK(coordinates.parentTop == 55);
+        CHECK(coordinates.parentRight == 420);
+        CHECK(coordinates.parentBottom == 143);
+        CHECK(coordinates.destinationX == 0);
+        CHECK(coordinates.destinationY == 0);
+    }
+
+    SECTION("window completion retains parent coordinates") {
+        const auto coordinates = ResolveGpuCompletionCoordinates(
+            0, 0, 420, 88, 0, 55, false);
+        CHECK(coordinates.parentTop == 55);
+        CHECK(coordinates.parentBottom == 143);
+        CHECK(coordinates.destinationX == 0);
+        CHECK(coordinates.destinationY == 55);
+    }
+
+    SECTION("dirty offscreen region retains its local offset") {
+        const auto coordinates = ResolveGpuCompletionCoordinates(
+            12, 7, 100, 40, 30, 55, true);
+        CHECK(coordinates.parentLeft == 42);
+        CHECK(coordinates.parentTop == 62);
+        CHECK(coordinates.destinationX == 12);
+        CHECK(coordinates.destinationY == 7);
+    }
+}


### PR DESCRIPTION
## Summary

- Synchronize the engine and Godot bridge GPU-drain default so pending alpha sources are flushed before dependent blends.
- Preserve encoded WebP payloads in PSB media and normalize selected PIMG layers to their local composite bounds.
- Keep offscreen GPU completion destinations layer-local while retaining parent/window coordinates for presentation.
- Restore the previous-choice normal-state icon and the complete chapter label in Senren Banka.

The `TextRenderBase.renderOver` progression fix is already on `main` via #80, so this PR does not duplicate that change or update the AetherInternal gitlink.

## Validation

- `./build.sh macos release --jobs=8` with the current AetherInternal `main` pin
- Targeted Catch2 coverage: 43 assertions across 4 test cases
  - immediate GPU drain ordering
  - small WebP preservation
  - PIMG composite-bound normalization
  - layer-local vs. window GPU completion coordinates
- End-to-end macOS validation on the same fix set: title → START → story; the chapter label and previous-choice icon render correctly, and story progression continues.
- `git diff --check origin/main...HEAD`

This branch contains no game assets, local game paths, or AetherInternal source changes.
