### PR TITLE
fix: stabilize L3J title transitions

### DIFF
--- a/bridge/engine_api/src/engine_api.cpp
+++ b/bridge/engine_api/src/engine_api.cpp
@@ -1,5 +1,6 @@
 #include "legacy_engine_api_rename.h"
 #include "engine_api.h"
+#include "engine_input_queue_gate.h"
 
 #if defined(ENGINE_API_USE_KRKR2_RUNTIME)
 
@@ -172,6 +173,8 @@ struct engine_handle_s {
   // Input event queue
   struct InputState {
     std::deque<engine_input_event_t> pending_events;
+    aetherkiri::engine_api::PrimaryClickQueueGate primary_click_gate;
+    size_t coalesced_events = 0;
     std::unordered_set<intptr_t> active_pointer_ids;
     bool native_mouse_callbacks_disabled = false;
   } input;
@@ -1213,6 +1216,8 @@ void MarkRuntimeOpenedForHost(engine_handle_t handle,
     impl->frame.ready = false;
     impl->input.active_pointer_ids.clear();
     impl->input.pending_events.clear();
+    impl->input.primary_click_gate.reset();
+    impl->input.coalesced_events = 0;
     impl->state = ToStateValue(EngineState::kOpened);
     ClearHandleErrorLocked(impl);
   }
@@ -2448,9 +2453,12 @@ engine_result_t engine_tick(engine_handle_t handle, uint32_t delta_ms) {
 
   const auto tick_start = std::chrono::steady_clock::now();
   size_t dispatched_inputs = 0;
+  const size_t coalesced_inputs = impl->input.coalesced_events;
+  impl->input.coalesced_events = 0;
   while (!impl->input.pending_events.empty()) {
     const engine_input_event_t queued_event = impl->input.pending_events.front();
     impl->input.pending_events.pop_front();
+    impl->input.primary_click_gate.on_dequeued(queued_event);
     dispatched_inputs += 1;
 
     const char* dispatch_error = nullptr;
@@ -2661,14 +2669,14 @@ engine_result_t engine_tick(engine_handle_t handle, uint32_t delta_ms) {
     }
     spdlog::warn(
         "engine_tick_spike tick={} total_us={} input_us={} app_us={} "
-        "draw_us={} recycle_us={} capture_us={} inputs={} renderer={} "
-        "frame_backend={} suppressed={}",
+        "draw_us={} recycle_us={} capture_us={} inputs={} coalesced_inputs={} "
+        "renderer={} frame_backend={} suppressed={}",
         static_cast<unsigned long long>(impl->tick_count), total_us,
         DurationUs(tick_start, after_input),
         DurationUs(after_input, after_application_run),
         DurationUs(after_application_run, after_draw_scene),
         DurationUs(after_draw_scene, after_recycle),
-        DurationUs(after_recycle, tick_end), dispatched_inputs,
+        DurationUs(after_recycle, tick_end), dispatched_inputs, coalesced_inputs,
         impl->render.renderer, frame_backend,
         static_cast<unsigned long long>(suppressed_slow_frames));
     std::ostringstream fields;
@@ -2679,6 +2687,7 @@ engine_result_t engine_tick(engine_handle_t handle, uint32_t delta_ms) {
            << ",\"recycle_us\":" << DurationUs(after_draw_scene, after_recycle)
            << ",\"capture_us\":" << DurationUs(after_recycle, tick_end)
            << ",\"inputs\":" << dispatched_inputs
+           << ",\"coalesced_inputs\":" << coalesced_inputs
            << ",\"suppressed\":" << suppressed_slow_frames
            << ",\"renderer\":\"" << JsonEscape(impl->render.renderer)
            << "\",\"frame_backend\":\"" << JsonEscape(frame_backend) << "\"}";
@@ -2825,6 +2834,8 @@ engine_result_t engine_pause(engine_handle_t handle) {
   Application->OnDeactivate();
   impl->input.active_pointer_ids.clear();
   impl->input.pending_events.clear();
+  impl->input.primary_click_gate.reset();
+  impl->input.coalesced_events = 0;
   if (auto* loop = EngineLoop::GetInstance(); loop != nullptr) {
     loop->ResetPointerState();
   }
@@ -3721,9 +3732,18 @@ engine_result_t engine_send_input(engine_handle_t handle,
     }
   }
 
+  if (!impl->input.primary_click_gate.should_enqueue(*event)) {
+    impl->input.coalesced_events += 1;
+    ClearHandleErrorLocked(impl);
+    SetThreadError(nullptr);
+    return ENGINE_RESULT_OK;
+  }
+
   impl->input.pending_events.push_back(*event);
   constexpr size_t kMaxQueuedInputs = 512;
   if (impl->input.pending_events.size() > kMaxQueuedInputs) {
+    impl->input.primary_click_gate.on_dequeued(
+        impl->input.pending_events.front());
     impl->input.pending_events.pop_front();
   }
 

--- a/bridge/engine_api/src/engine_input_queue_gate.h
+++ b/bridge/engine_api/src/engine_input_queue_gate.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_set>
+
+#include "engine_api.h"
+
+namespace aetherkiri::engine_api {
+
+// A click can synchronously run an expensive KAG transition. Once a complete
+// primary click is queued for the next engine tick, coalesce further primary
+// gestures instead of replaying stale clicks after the transition finishes.
+class PrimaryClickQueueGate {
+ public:
+  bool should_enqueue(const engine_input_event_t& event) {
+    const bool primary_pointer = event.button == 0;
+    if (primary_pointer &&
+        event.type == ENGINE_INPUT_EVENT_POINTER_DOWN &&
+        primary_release_pending_) {
+      suppressed_pointer_ids_.insert(event.pointer_id);
+      return false;
+    }
+
+    if (primary_pointer &&
+        event.type == ENGINE_INPUT_EVENT_POINTER_MOVE &&
+        suppressed_pointer_ids_.count(event.pointer_id) != 0) {
+      return false;
+    }
+
+    if (primary_pointer && event.type == ENGINE_INPUT_EVENT_POINTER_UP) {
+      if (suppressed_pointer_ids_.erase(event.pointer_id) != 0) {
+        return false;
+      }
+      primary_release_pending_ = true;
+    }
+    return true;
+  }
+
+  void on_dequeued(const engine_input_event_t& event) {
+    if (event.type == ENGINE_INPUT_EVENT_POINTER_UP && event.button == 0) {
+      primary_release_pending_ = false;
+    }
+  }
+
+  void reset() {
+    primary_release_pending_ = false;
+    suppressed_pointer_ids_.clear();
+  }
+
+ private:
+  bool primary_release_pending_ = false;
+  std::unordered_set<int32_t> suppressed_pointer_ids_;
+};
+
+}  // namespace aetherkiri::engine_api

--- a/cpp/core/visual/LayerIntf.cpp
+++ b/cpp/core/visual/LayerIntf.cpp
@@ -249,47 +249,50 @@ static tTJSNI_BaseLayer *TVPResolveExchangedKagAssignmentTarget(
         return known_stale ? candidate : nullptr;
     }
 
-    if(!known_stale) {
-        bool visible_page_has_content_layer = false;
-        for(tjs_uint child_index = 0;
-            child_index < visible_page->GetCount(); ++child_index) {
-            auto *candidate = visible_page->GetChildren(
-                static_cast<tjs_int>(child_index));
-            if(candidate && candidate->GetVisible() &&
-               candidate->GetParentVisible() &&
-               candidate->GetWidth() >= target->GetWidth() / 2 &&
-               candidate->GetHeight() >= target->GetHeight() / 2) {
-                visible_page_has_content_layer = true;
-                break;
-            }
+    bool visible_page_has_content_layer = false;
+    for(tjs_uint child_index = 0;
+        child_index < visible_page->GetCount(); ++child_index) {
+        auto *candidate = visible_page->GetChildren(
+            static_cast<tjs_int>(child_index));
+        if(candidate && candidate->GetVisible() &&
+           candidate->GetParentVisible() &&
+           candidate->GetWidth() >= target->GetWidth() / 2 &&
+           candidate->GetHeight() >= target->GetHeight() / 2) {
+            visible_page_has_content_layer = true;
+            break;
         }
-        if(visible_page_has_content_layer ||
-           hidden_page->DebugIsInTransition() ||
-           visible_page->DebugIsInTransition()) {
-            std::lock_guard<std::mutex> lock(
-                TVPExchangedKagPageMutex);
-            TVPHiddenKagAssignmentStreaks.erase(target);
-            return nullptr;
-        }
+    }
+    if(visible_page_has_content_layer ||
+       hidden_page->DebugIsInTransition() ||
+       visible_page->DebugIsInTransition()) {
+        std::lock_guard<std::mutex> lock(
+            TVPExchangedKagPageMutex);
+        TVPHiddenKagAssignmentStreaks.erase(target);
+        return nullptr;
+    }
 
-        const auto now = std::chrono::steady_clock::now();
-        bool persistent_hidden_target = false;
-        {
-            std::lock_guard<std::mutex> lock(
-                TVPExchangedKagPageMutex);
-            auto &streak =
-                TVPHiddenKagAssignmentStreaks[target];
-            if(streak.count == 0 ||
-               now - streak.last >
-                   std::chrono::milliseconds(250)) {
-                streak.count = 0;
-            }
-            streak.last = now;
-            persistent_hidden_target = ++streak.count >= 12;
+    // A page can already be marked stale when the script creates a brand-new
+    // layer on it for the next transition.  Moving that layer on its first
+    // AssignImages() leaks the incoming frame onto the visible page for one
+    // present.  Require persistence from the target itself before treating it
+    // as an orphan left behind by a completed page exchange.
+    const auto now = std::chrono::steady_clock::now();
+    bool persistent_hidden_target = false;
+    {
+        std::lock_guard<std::mutex> lock(
+            TVPExchangedKagPageMutex);
+        auto &streak =
+            TVPHiddenKagAssignmentStreaks[target];
+        if(streak.count == 0 ||
+           now - streak.last >
+               std::chrono::milliseconds(250)) {
+            streak.count = 0;
         }
-        if(!persistent_hidden_target) {
-            return nullptr;
-        }
+        streak.last = now;
+        persistent_hidden_target = ++streak.count >= 12;
+    }
+    if(!persistent_hidden_target) {
+        return nullptr;
     }
     // The page exchange can leave a continuously animated KAG layer attached
     // to the now-hidden page while the visible page contains only message and

--- a/cpp/plugins/motionplayer/Player.h
+++ b/cpp/plugins/motionplayer/Player.h
@@ -80,6 +80,7 @@ namespace motion {
 
     class Player {
         friend class ::aetherinternal::EmoteRuntimeExtension;
+        friend struct PlayerTestAccess;
 
     public:
         explicit Player(ResourceManager rm = ResourceManager{});

--- a/cpp/plugins/motionplayer/PlayerCore.cpp
+++ b/cpp/plugins/motionplayer/PlayerCore.cpp
@@ -626,6 +626,7 @@ namespace motion {
 
         _autoProgressLastTick = 0;
         _autoProgressHasLastTick = false;
+        _manualProgressLastTick = 0;
         if(!_autoProgressRegistered) {
             registerAutoProgressPlayer(this);
             _autoProgressRegistered = true;
@@ -729,8 +730,14 @@ namespace motion {
 
     void Player::noteManualProgress() {
         _manualProgressLastTick = TVPGetTickCount();
-        _autoProgressLastTick = _manualProgressLastTick;
-        _autoProgressHasLastTick = true;
+        // A script-owned Motion.Player clock and the continuous callback must
+        // never advance the same clip.  The old 120 ms grace period let the
+        // automatic clock take over during a slow render, then the script's
+        // next wall-clock delta counted that same interval again.  That made
+        // title animations jump for one frame whenever loading exceeded the
+        // grace period.  A later play() call can explicitly opt the player
+        // back into automatic progression via enableAutoProgress().
+        disableAutoProgress();
     }
 
     std::string Player::beginEndedTimelineRenderHold() {
@@ -999,6 +1006,21 @@ namespace motion {
             if(!playing) {
                 disableAutoProgress();
             }
+            releaseDispatch();
+            return;
+        }
+
+        // Title motions are driven from AffineSourceMotion::_drawAffine.
+        // Their Player can be created and played while the incoming page is
+        // still hidden, before its first progress(0) draw. Keep frame zero
+        // until the script takes ownership so the animation and page
+        // transition begin from the same authored state; noteManualProgress()
+        // then unregisters this fallback clock entirely.
+        if(_manualProgressLastTick == 0 && _runtime->activeMotion &&
+           isYuzuTitlePresentationMotionPath(
+               _runtime->activeMotion->path)) {
+            _autoProgressLastTick = tick;
+            _autoProgressHasLastTick = true;
             releaseDispatch();
             return;
         }

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -95,20 +95,23 @@ namespace {
         const std::string &compressName,
         int width,
         int height,
-        const PSB::PSBResource &resource,
-        std::unordered_map<
-            const PSB::PSBResource *,
-            std::pair<std::uint64_t, std::uint64_t>> &fingerprintCache) {
-        auto fingerprintIt = fingerprintCache.find(&resource);
-        if(fingerprintIt == fingerprintCache.end()) {
-            std::uint64_t first = 1469598103934665603ull;
-            std::uint64_t second = 0x517cc1b727220a95ull;
-            appendMotionSourceFingerprint(first, second, resource.data);
-            fingerprintIt = fingerprintCache.emplace(
-                &resource, std::make_pair(first, second)).first;
+        const PSB::PSBResource &resource) {
+        std::pair<std::uint64_t, std::uint64_t> fingerprint;
+        {
+            std::lock_guard lock(snapshot.sourceFingerprintMutex);
+            auto fingerprintIt =
+                snapshot.sourceFingerprints.find(&resource);
+            if(fingerprintIt == snapshot.sourceFingerprints.end()) {
+                std::uint64_t first = 1469598103934665603ull;
+                std::uint64_t second = 0x517cc1b727220a95ull;
+                appendMotionSourceFingerprint(first, second, resource.data);
+                fingerprintIt = snapshot.sourceFingerprints.emplace(
+                    &resource, std::make_pair(first, second)).first;
+            }
+            fingerprint = fingerprintIt->second;
         }
-        auto first = fingerprintIt->second.first;
-        auto second = fingerprintIt->second.second;
+        auto first = fingerprint.first;
+        auto second = fingerprint.second;
 
         std::size_t paletteBytes = 0;
         if(resourcePath.size() > 6 &&
@@ -8884,9 +8887,7 @@ namespace motion {
                     ? decodedHeight : height;
                 sharedBitmapKey = makeSharedMotionSourceBitmapKey(
                     *sourceMotion, resourcePath, compressName,
-                    bitmapWidth, bitmapHeight,
-                    *resourceMetadata,
-                    _runtime->motionSourceResourceFingerprintCache);
+                    bitmapWidth, bitmapHeight, *resourceMetadata);
                 srcBmp = findSharedMotionSourceBitmap(sharedBitmapKey);
                 if(profileEnabled) {
                     if(srcBmp) {
@@ -9152,7 +9153,13 @@ namespace motion {
                 return nullptr;
             }
 
-            const bool sourceIsAlphaOnlyMask = bitmapLooksAlphaOnlyMask(*srcBmp);
+            auto &sourceTraits =
+                _runtime->motionSourceBitmapTraits[sourceIdentity];
+            if(!sourceTraits.alphaOnlyKnown) {
+                sourceTraits.alphaOnly = bitmapLooksAlphaOnlyMask(*srcBmp);
+                sourceTraits.alphaOnlyKnown = true;
+            }
+            const bool sourceIsAlphaOnlyMask = sourceTraits.alphaOnly;
             const bool colorsCarryTint =
                 !packedColorsAreDefault(command.packedColors[0],
                                         command.packedColors[1],
@@ -9169,12 +9176,19 @@ namespace motion {
                 isYuzuLogoTextMaskSource(motionPath, command.sourceKey);
             const bool yuzuLogoCompositeSource =
                 isYuzuLogoCompositeSource(motionPath, command.sourceKey);
+            if(yuzuLogoTextSource && !sourceTraits.whiteMaskKnown) {
+                sourceTraits.whiteMask = bitmapLooksWhiteMask(*srcBmp);
+                sourceTraits.whiteMaskKnown = true;
+            }
+            if(yuzuLogoTextSource && !sourceTraits.hasWhitePixelsKnown) {
+                sourceTraits.hasWhitePixels =
+                    bitmapHasWhiteMaskPixels(*srcBmp);
+                sourceTraits.hasWhitePixelsKnown = true;
+            }
             const bool tintDefaultLogoTextMask =
-                yuzuLogoTextSource &&
-                bitmapLooksWhiteMask(*srcBmp);
+                yuzuLogoTextSource && sourceTraits.whiteMask;
             const bool tintDefaultLogoWhitePixels =
-                yuzuLogoTextSource &&
-                bitmapHasWhiteMaskPixels(*srcBmp);
+                yuzuLogoTextSource && sourceTraits.hasWhitePixels;
             const bool tintOnlyWhitePixels =
                 tintDefaultLogoWhitePixels && !sourceIsAlphaOnlyMask;
             const bool tintDefaultNeutralMask =

--- a/cpp/plugins/motionplayer/ResourceManager.cpp
+++ b/cpp/plugins/motionplayer/ResourceManager.cpp
@@ -185,16 +185,53 @@ namespace {
         return lastLoaded;
     }
 
-    tTJSVariant &recentMotionModule() {
-        static tTJSVariant module;
-        return module;
+    struct RecentMotionModule {
+        tTJSVariant module;
+        std::string placedPath;
+        tjs_int decryptSeed = 0;
+    };
+
+    std::string placedMotionPath(const ttstr &path) {
+        if(path.IsEmpty()) {
+            return {};
+        }
+        const auto placed = TVPGetPlacedPath(path);
+        return lowercase(
+            placed.IsEmpty() ? path.AsStdString() : placed.AsStdString());
+    }
+
+    RecentMotionModule &recentMotionModule() {
+        static RecentMotionModule recent;
+        return recent;
     }
 
     void rememberRecentMotionModule(const tTJSVariant &loaded) {
-        if(loaded.Type() == tvtObject &&
-           motion::detail::lookupModuleSnapshot(loaded)) {
-            recentMotionModule() = loaded;
+        if(loaded.Type() != tvtObject) {
+            return;
         }
+        const auto snapshot = motion::detail::lookupModuleSnapshot(loaded);
+        if(!snapshot || snapshot->path.empty()) {
+            return;
+        }
+        auto &recent = recentMotionModule();
+        recent.module = loaded;
+        recent.placedPath = placedMotionPath(
+            motion::detail::widen(snapshot->path));
+        recent.decryptSeed =
+            motion::ResourceManager::getEmotePSBDecryptSeed();
+    }
+
+    tTJSVariant reuseExactRecentMotionModule(
+        const ttstr &path, const tjs_int decryptSeed) {
+        const auto &recent = recentMotionModule();
+        if(recent.module.Type() != tvtObject ||
+           recent.decryptSeed != decryptSeed ||
+           recent.placedPath.empty() ||
+           recent.placedPath != placedMotionPath(path) ||
+           !motion::detail::lookupModuleSnapshot(recent.module)) {
+            return {};
+        }
+        return recent.module;
     }
 
     std::uint16_t readU16LE(const std::uint8_t *data) {
@@ -436,6 +473,17 @@ tTJSVariant motion::ResourceManager::load(ttstr path) const {
         return cached;
     }
 
+    // Some KAG layer types construct two independent resource managers for
+    // the same motion during one scene transition. Reuse the most recently
+    // parsed immutable snapshot when both the resolved storage path and
+    // decrypt seed match; otherwise a large PSB is synchronously parsed twice
+    // on the application thread.
+    if(const auto recent = reuseExactRecentMotionModule(path, _decryptSeed);
+       recent.Type() == tvtObject) {
+        rememberLoadedModule(path, recent);
+        return recent;
+    }
+
     const auto alias = _state
         ? fallbackSplitEmoteModule(_state->lastLoadedModule, path)
         : tTJSVariant{};
@@ -445,7 +493,7 @@ tTJSVariant motion::ResourceManager::load(ttstr path) const {
     }
 
     const auto recentAlias = fallbackSplitEmoteModule(
-        recentMotionModule(), path);
+        recentMotionModule().module, path);
     if(recentAlias.Type() != tvtVoid) {
         rememberLoadedModule(path, recentAlias);
         return recentAlias;

--- a/cpp/plugins/motionplayer/RuntimeSupport.h
+++ b/cpp/plugins/motionplayer/RuntimeSupport.h
@@ -11,6 +11,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -223,6 +224,13 @@ namespace motion::detail {
         std::shared_ptr<const PSB::PSBDictionary> root;
         std::unordered_map<std::string, std::shared_ptr<const PSB::PSBResource>>
             resourcesByPath;
+        // Immutable PSB resources are shared by every Player bound to this
+        // snapshot. Fingerprinting a multi-megabyte embedded image once per
+        // Player made animated title scenes repeatedly rescan the same bytes.
+        mutable std::mutex sourceFingerprintMutex;
+        mutable std::unordered_map<
+            const PSB::PSBResource *,
+            std::pair<std::uint64_t, std::uint64_t>> sourceFingerprints;
         tTJSVariant moduleValue;
         std::vector<std::string> mainTimelineLabels;
         std::vector<std::string> diffTimelineLabels;
@@ -331,15 +339,18 @@ namespace motion::detail {
         // bitmap so prepared/tinted variants use the same coordinates.
         std::unordered_map<std::string, std::array<int, 4>>
             motionSourceBitmapRects;
-        // E-mote atlases are shared by many icon sources. Building the
-        // cross-player bitmap-cache key fingerprints the complete atlas
-        // bytes, so remember that content fingerprint for this runtime
-        // instead of rescanning the same multi-megabyte resource once per
-        // icon. The cache is cleared whenever the active motion changes,
-        // keeping the resource-pointer identity bounded by its snapshot.
-        std::unordered_map<const PSB::PSBResource *,
-                           std::pair<std::uint64_t, std::uint64_t>>
-            motionSourceResourceFingerprintCache;
+        struct MotionSourceBitmapTraits {
+            bool alphaOnlyKnown = false;
+            bool alphaOnly = false;
+            bool whiteMaskKnown = false;
+            bool whiteMask = false;
+            bool hasWhitePixelsKnown = false;
+            bool hasWhitePixels = false;
+        };
+        // Source classification samples immutable pixels. Cache the result so
+        // color animation does not resample the same bitmap for every tint.
+        std::unordered_map<std::string, MotionSourceBitmapTraits>
+            motionSourceBitmapTraits;
         struct MotionSourceMetadata {
             int width = 0;
             int height = 0;
@@ -654,7 +665,7 @@ namespace motion::detail {
         void clearMotionBitmapCaches() {
             motionSourceBitmapCache.clear();
             motionSourceBitmapRects.clear();
-            motionSourceResourceFingerprintCache.clear();
+            motionSourceBitmapTraits.clear();
             motionSourceMetadataCache.clear();
             motionPreparedBitmapCache.clear();
             motionPreparedMaterializedKeysBySource.clear();

--- a/doc/verified_games.md
+++ b/doc/verified_games.md
@@ -2,7 +2,7 @@
 
 [简体中文](verified_games.zh-CN.md)
 
-Last updated: 2026-08-06
+Last updated: 2026-08-07
 
 This document tracks games that have been manually smoke-tested with
 AetherKiri. It is a compatibility notebook, not a guarantee that every route,
@@ -44,7 +44,7 @@ movie, plugin path, or save state in a title has been exhaustively validated.
 | サノバウィッチ | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 千恋＊万花 | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 天使☆騒々 RE-BOOT! | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue flow, scene/text rendering, gallery rendering and animation smoke, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
-| ライムライト・レモネードジャム | Windows x64 debug app; macOS release app; iOS/iPadOS release app build on iPad | Startup, title animation and menu rendering, continue/load flow, scene/text rendering, gallery navigation/compositing, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer), [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
+| ライムライト・レモネードジャム | Windows x64 debug app; macOS debug and release apps; iOS/iPadOS release app build on iPad | Startup, flicker-free logo-to-title transition, stable title animation and menu rendering, continue/load flow, scene/text rendering, gallery navigation/compositing, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer), [@KYoiRyi](https://github.com/KYoiRyi), [@MadCcc](https://github.com/MadCcc) | Local game files are not committed. |
 | ワガママハイスペック | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, music selection/playback, lock-screen audio recovery, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | ワガママハイスペック OC | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, continue/load flow, scene/text rendering, music playback, lock-screen audio recovery, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 淫母マンション～ママは、性処理肉便器～ | macOS release app; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, scene/text rendering, audio playback, and basic input | Smoke verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |

--- a/doc/verified_games.zh-CN.md
+++ b/doc/verified_games.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](verified_games.md)
 
-最后更新：2026-08-06
+最后更新：2026-08-07
 
 本文档记录已经用 AetherKiri 手动 smoke test 或 flow test 过的游戏。它是兼容性记录，
 不代表每条路线、每个视频、每个插件路径或每个存档状态都已经完整验证。
@@ -43,7 +43,7 @@
 | サノバウィッチ | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 千恋＊万花 | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 天使☆騒々 RE-BOOT! | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续游戏流程、场景/文字渲染、画廊渲染与动画冒烟、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
-| ライムライト・レモネードジャム | Windows x64 debug app；macOS release app；iOS/iPadOS iPad release app build | 启动、标题动画与菜单渲染、继续/读档流程、场景/文字渲染、画廊导航与图像合成、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer)、[@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
+| ライムライト・レモネードジャム | Windows x64 debug app；macOS debug 和 release app；iOS/iPadOS iPad release app build | 启动、无闪帧的 Logo 到标题页切换、稳定的标题动画与菜单渲染、继续/读档流程、场景/文字渲染、画廊导航与图像合成、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer)、[@KYoiRyi](https://github.com/KYoiRyi)、[@MadCcc](https://github.com/MadCcc) | 本地游戏文件不提交到仓库。 |
 | ワガママハイスペック | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音乐选择与播放、锁屏恢复音频和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | ワガママハイスペック OC | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、继续/读档流程、场景/文字渲染、音乐播放、锁屏恢复音频和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 淫母マンション～ママは、性処理肉便器～ | macOS release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、场景/文字渲染、音频播放和基础输入 | 冒烟验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "engine_api.h"
+#include "engine_input_queue_gate.h"
 #include "engine_runtime_provider.h"
 
 namespace {
@@ -196,6 +197,42 @@ const engine_runtime_provider_v1_t kArtemisGateProvider = [] {
 }();
 
 }  // namespace
+
+TEST_CASE("primary click queue gate coalesces clicks before the next tick") {
+  aetherkiri::engine_api::PrimaryClickQueueGate gate;
+  engine_input_event_t event{};
+  event.struct_size = sizeof(event);
+  event.button = 0;
+  event.pointer_id = 7;
+
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  REQUIRE(gate.should_enqueue(event));
+  const engine_input_event_t queued_release = event;
+
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_MOVE;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+
+  gate.on_dequeued(queued_release);
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+}
+
+TEST_CASE("primary click queue gate preserves secondary pointer releases") {
+  aetherkiri::engine_api::PrimaryClickQueueGate gate;
+  engine_input_event_t event{};
+  event.struct_size = sizeof(event);
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  event.button = 1;
+
+  REQUIRE(gate.should_enqueue(event));
+}
 
 TEST_CASE("Artemis runtime is compiled but beta-gated in product builds") {
   const engine_result_t registration =

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -53,6 +53,14 @@ namespace motion::detail {
         bool allowArmNeon);
 }
 
+namespace motion {
+    struct PlayerTestAccess {
+        static void enableAutoProgress(Player &player, iTJSDispatch2 *dispatch) {
+            player.enableAutoProgress(dispatch);
+        }
+    };
+}
+
 #if defined(AETHERKIRI_EXPECT_INTERNAL_EMOTE)
 namespace {
     const bool kPrivateMotionRuntimeRegistered = [] {
@@ -830,6 +838,20 @@ namespace {
 
 } // namespace
 
+TEST_CASE("manual Motion.Player progress owns the playback clock") {
+    motion::Player player;
+    auto *dispatch = new tTJSDispatch();
+    motion::PlayerTestAccess::enableAutoProgress(player, dispatch);
+    CHECK(player.getAutoProgressDispatchForCompat() == dispatch);
+
+    // Even an initial zero-delta refresh means that the script owns this
+    // player's wall clock.  Leaving the continuous callback registered here
+    // double-counts a slow frame when the next script delta arrives.
+    player.frameProgressManually(0.0);
+    CHECK(player.getAutoProgressDispatchForCompat() == nullptr);
+    dispatch->Release();
+}
+
 TEST_CASE("storage resolves logical E-mote PSBs to DirectX exports") {
     ensurePluginRuntime();
     TemporaryAutoPath autoPath;
@@ -1477,6 +1499,21 @@ TEST_CASE("resource manager owns snapshots only while their module is cached") {
     manager.unload(ttstr(TJS_W("memory-lifetime.mtn")));
     REQUIRE(releasedSnapshot.expired());
     REQUIRE(manager.uniqueCachedModuleCount() == 0);
+}
+
+TEST_CASE("resource managers reuse the most recent exact motion module") {
+    setEmoteSeed();
+
+    motion::ResourceManager first;
+    const auto firstModule = first.load(motionFixturePath());
+    REQUIRE(firstModule.Type() == tvtObject);
+
+    motion::ResourceManager second;
+    const auto secondModule = second.load(motionFixturePath());
+    REQUIRE(secondModule.Type() == tvtObject);
+    REQUIRE(secondModule.AsObjectNoAddRef() ==
+            firstModule.AsObjectNoAddRef());
+    REQUIRE(second.uniqueCachedModuleCount() == 1);
 }
 
 TEST_CASE("emoteplayer timeline state and todo stubs") {


### PR DESCRIPTION
## Summary

- make script-driven `Motion.Player.progress()` own the playback clock, preventing the continuous engine callback from counting the same slow frame twice
- keep newly created incoming title layers on the hidden KAG page until the target itself proves persistent, preventing a one-frame title-background leak before the real fade-in
- reuse an exact recently parsed motion module and cache immutable source fingerprints/bitmap traits to reduce main-thread stalls during title startup
- coalesce additional primary click gestures after a complete click is already queued, so rapid taps are not replayed after an expensive transition
- update the verified-games records for the confirmed macOS and iPad flow

## Root cause

The title issue had multiple contributing boundaries:

1. A slow render could exceed the old 120 ms manual-progress grace period. Continuous auto-progress would then advance the clip, and the next script delta advanced the same wall-clock interval again, producing a visible title jump.
2. Independent resource managers could synchronously parse the same large PSB twice, while repeated fingerprint and pixel-trait scans added more work to title frames.
3. KAG page-exchange recovery inherited the parent page's stale state. A brand-new incoming title layer was therefore treated as an orphan on its first `AssignImages()` and briefly reparented onto the visible page.
4. Rapid primary taps accumulated while the transition was busy and were dispatched afterward, making the menu feel stuck or delayed.

The KAG recovery path now requires target-specific persistence before rerouting a hidden-page layer. Normal transitions remain governed by page visibility, and exact motion reuse is limited to the same resolved storage path and decrypt seed.

## Scope

This PR addresses the title-animation jitter, the pre-menu one-frame flash, and rapid-click backlog reported in #93. It intentionally does not claim that every separate symptom listed in that issue (such as the settings-page crash) is resolved.

Refs #93

## Validation

- macOS arm64 debug app target rebuilt successfully with `AETHERKIRI_ENABLE_INTERNAL=ON`
- MotionPlayer tests: 135 test cases / 1,554 assertions passed
- engine API diagnostics: 12 test cases / 214 assertions passed
- frame-by-frame macOS capture verified the sequence remains logo fade -> white frames -> continuous title fade, with no premature full-title frame
- iOS/iPadOS release app built, installed, and exercised on an iPad mini (A17 Pro); the reporter confirmed both the title animation and the flash before the main menu are fixed
- private source, game archives, extracted assets, and diagnostic exports are not included
