### PR TITLE
perf: reuse D3D E-mote frames and fix spinner direction

### DIFF
--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -56,6 +56,7 @@ const UI_ICON_DIR := "res://assets/ui/icons/"
 const ICON_SETTINGS := UI_ICON_DIR + "gear-fill.svg"
 const ICON_SAVE := UI_ICON_DIR + "save-fill.svg"
 const ICON_REFRESH := UI_ICON_DIR + "arrows-counter-clockwise-fill.svg"
+const LOADING_SPINNER_ROTATION := -TAU
 const ICON_ADD := UI_ICON_DIR + "plus-circle.svg"
 const ICON_HELP := UI_ICON_DIR + "help.svg"
 const ICON_LIBRARY := UI_ICON_DIR + "library.svg"
@@ -4190,7 +4191,11 @@ func _build_loading_panel() -> void:
     loading_labels.add_child(loading_title_label)
     if not ui_motion.reduced_motion:
         var spinner_tween := loading_spinner.create_tween().set_loops()
-        spinner_tween.tween_property(loading_spinner, "rotation", TAU, 0.85).from(0.0).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
+        # The refresh glyph depicts counter-clockwise motion. Godot's positive
+        # UI rotation is clockwise because the canvas Y axis points down.
+        spinner_tween.tween_property(
+            loading_spinner, "rotation", LOADING_SPINNER_ROTATION, 0.85
+        ).from(0.0).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
 
     if ui_log_enabled and not _mobile_runtime():
         log_view = TextEdit.new()

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -56,7 +56,8 @@ const UI_ICON_DIR := "res://assets/ui/icons/"
 const ICON_SETTINGS := UI_ICON_DIR + "gear-fill.svg"
 const ICON_SAVE := UI_ICON_DIR + "save-fill.svg"
 const ICON_REFRESH := UI_ICON_DIR + "arrows-counter-clockwise-fill.svg"
-const LOADING_SPINNER_ROTATION := -TAU
+const LOADING_SPINNER_ROTATION := TAU
+const LOADING_SPINNER_FLIP_H := true
 const ICON_ADD := UI_ICON_DIR + "plus-circle.svg"
 const ICON_HELP := UI_ICON_DIR + "help.svg"
 const ICON_LIBRARY := UI_ICON_DIR + "library.svg"
@@ -4174,6 +4175,7 @@ func _build_loading_panel() -> void:
     loading_spinner.position = Vector2(12, 12)
     loading_spinner.size = Vector2(20, 20)
     loading_spinner.pivot_offset = Vector2(10, 10)
+    loading_spinner.flip_h = LOADING_SPINNER_FLIP_H
     spinner_holder.add_child(loading_spinner)
 
     var loading_labels := VBoxContainer.new()
@@ -4191,8 +4193,8 @@ func _build_loading_panel() -> void:
     loading_labels.add_child(loading_title_label)
     if not ui_motion.reduced_motion:
         var spinner_tween := loading_spinner.create_tween().set_loops()
-        # The refresh glyph depicts counter-clockwise motion. Godot's positive
-        # UI rotation is clockwise because the canvas Y axis points down.
+        # Mirror the counter-clockwise refresh glyph so it follows this
+        # clockwise loading motion without changing shared refresh icons.
         spinner_tween.tween_property(
             loading_spinner, "rotation", LOADING_SPINNER_ROTATION, 0.85
         ).from(0.0).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)

--- a/apps/godot_app/tests/mobile_safe_area_test.gd
+++ b/apps/godot_app/tests/mobile_safe_area_test.gd
@@ -147,6 +147,8 @@ func _initialize() -> void:
     assert(not launch_shell.visible)
     assert(launch_shell.scale == Vector2.ONE)
     assert(is_equal_approx(launch_shell.modulate.a, 1.0))
+    assert(app.LOADING_SPINNER_ROTATION < 0.0)
+    assert(is_equal_approx(absf(app.LOADING_SPINNER_ROTATION), TAU))
 
     var immediate_loading_panel := Control.new()
     var immediate_loading_card := Control.new()

--- a/apps/godot_app/tests/mobile_safe_area_test.gd
+++ b/apps/godot_app/tests/mobile_safe_area_test.gd
@@ -147,8 +147,9 @@ func _initialize() -> void:
     assert(not launch_shell.visible)
     assert(launch_shell.scale == Vector2.ONE)
     assert(is_equal_approx(launch_shell.modulate.a, 1.0))
-    assert(app.LOADING_SPINNER_ROTATION < 0.0)
-    assert(is_equal_approx(absf(app.LOADING_SPINNER_ROTATION), TAU))
+    assert(app.LOADING_SPINNER_ROTATION > 0.0)
+    assert(is_equal_approx(app.LOADING_SPINNER_ROTATION, TAU))
+    assert(app.LOADING_SPINNER_FLIP_H)
 
     var immediate_loading_panel := Control.new()
     var immediate_loading_card := Control.new()

--- a/cpp/plugins/motionplayer/PlayerInternal.h
+++ b/cpp/plugins/motionplayer/PlayerInternal.h
@@ -54,6 +54,30 @@ namespace internal {
             return type != ltBinder;
         }
 
+        inline bool d3dEmoteFrameReuseRouteEligible(
+            bool isEmoteMode,
+            bool retainD3DPresentation,
+            std::size_t commandCount) {
+            return isEmoteMode && !retainD3DPresentation &&
+                commandCount != 0;
+        }
+
+        inline bool d3dEmoteFrameCacheMatches(
+            const detail::PlayerRuntime::EmoteRenderFrameCacheEntry &entry,
+            const std::string &motion,
+            double frame,
+            int canvasWidth,
+            int canvasHeight,
+            std::size_t commandSignature) {
+            return entry.bitmap && entry.motion == motion &&
+                entry.canvasWidth == canvasWidth &&
+                entry.canvasHeight == canvasHeight &&
+                std::fabs(entry.frame - frame) < 0.0001 &&
+                entry.bitmap->GetWidth() == canvasWidth &&
+                entry.bitmap->GetHeight() == canvasHeight &&
+                entry.commandSignature == commandSignature;
+        }
+
         inline const MotionRenderPolicyV1 *motionRenderPolicy() {
             const auto *extension = motionPlayerExtension();
             return extension != nullptr ? extension->renderPolicy : nullptr;

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -11220,6 +11220,14 @@ namespace motion {
         }
 
         buildRenderCommands(adaptor->getWidth(), adaptor->getHeight());
+        const bool canReuseD3DEmoteRender =
+            motion::internal::d3dEmoteFrameReuseRouteEligible(
+                _runtime->isEmoteMode, retainD3DPresentation,
+                _runtime->renderCommands.size());
+        const auto d3dCommandSignature = canReuseD3DEmoteRender
+            ? renderCommandReuseSignature(_runtime->renderCommands,
+                                          _maskMode)
+            : 0;
         const std::size_t renderLayerIndex =
             retainD3DPresentation ? 0u
                                   : _runtime->nextD3DRenderLayer;
@@ -11305,6 +11313,68 @@ namespace motion {
         if(!renderLayerObject) {
             return false;
         }
+        if(canReuseD3DEmoteRender) {
+            const auto &entry = _runtime->d3dEmoteRenderFrameCache;
+            const bool exactCacheMatch =
+                motion::internal::d3dEmoteFrameCacheMatches(
+                    entry, motionPath, _clampedEvalTime,
+                    adaptor->getWidth(), adaptor->getHeight(),
+                    d3dCommandSignature);
+            auto *cachedLayer = exactCacheMatch
+                ? resolveNativeLayer(renderLayerObject)
+                : nullptr;
+            if(cachedLayer) {
+                if(!cachedLayer->GetHasImage()) {
+                    cachedLayer->SetHasImage(true);
+                }
+                if(cachedLayer->GetImageWidth() < adaptor->getWidth() ||
+                   cachedLayer->GetImageHeight() < adaptor->getHeight()) {
+                    cachedLayer->SetImageSize(
+                        static_cast<tjs_uint>(adaptor->getWidth()),
+                        static_cast<tjs_uint>(adaptor->getHeight()));
+                }
+                if(cachedLayer->GetWidth() != adaptor->getWidth() ||
+                   cachedLayer->GetHeight() != adaptor->getHeight()) {
+                    cachedLayer->SetSize(adaptor->getWidth(),
+                                         adaptor->getHeight());
+                }
+                cachedLayer->SetClip(0, 0, adaptor->getWidth(),
+                                     adaptor->getHeight());
+                // d3dRenderLayers are private scratch surfaces. Keep them
+                // hidden while captureCanvas aliases their texture into the
+                // authored character layer.
+                if(cachedLayer->GetVisible()) {
+                    cachedLayer->SetVisible(false);
+                }
+                auto *cachedImage = cachedLayer->GetMainImage();
+                if(cachedImage &&
+                   cachedImage->GetWidth() == adaptor->getWidth() &&
+                   cachedImage->GetHeight() == adaptor->getHeight()) {
+                    cachedImage->CopyRect(
+                        0, 0, entry.bitmap.get(),
+                        tTVPRect(0, 0, adaptor->getWidth(),
+                                 adaptor->getHeight()));
+                    adaptor->setRenderedLayer(renderLayerObject);
+                    ++_runtime->d3dEmoteRenderFrameReuseSkips;
+                    if(motionRenderProfileEnabled() && LOGGER) {
+                        LOGGER->info(
+                            "motion emote render reuse: motion={} frame={:.2f} target={} canvas={}x{} commands={} signature={:016x} cached_signature={:016x} skips={} reason={} age_us={} route=d3d",
+                            motionPath, _clampedEvalTime,
+                            static_cast<const void *>(renderLayerObject),
+                            adaptor->getWidth(), adaptor->getHeight(),
+                            _runtime->renderCommands.size(),
+                            d3dCommandSignature,
+                            entry.commandSignature,
+                            _runtime->d3dEmoteRenderFrameReuseSkips,
+                            "exact",
+                            motionRenderProfileNowUs() >= entry.storedUs
+                                ? motionRenderProfileNowUs() - entry.storedUs
+                                : 0);
+                    }
+                    return true;
+                }
+            }
+        }
         TVPGodotGpuBatchScope d3dGpuBatch(
             _runtime->isEmoteMode && _runtime->renderCommands.size() > 1);
         if(!prepareLayerForRender(renderLayerObject, adaptor->getWidth(),
@@ -11379,7 +11449,38 @@ namespace motion {
         } else {
             adaptor->setRenderedLayer(renderLayerObject);
         }
-        return d3dGpuBatch.finish();
+        if(!d3dGpuBatch.finish()) {
+            adaptor->setRenderedLayer(nullptr);
+            return false;
+        }
+        if(canReuseD3DEmoteRender) {
+            auto *executedImage = layer->GetMainImage();
+            if(executedImage &&
+               executedImage->GetWidth() == layerW &&
+               executedImage->GetHeight() == layerH) {
+                auto &entry = _runtime->d3dEmoteRenderFrameCache;
+                if(!entry.bitmap ||
+                   entry.bitmap->GetWidth() != layerW ||
+                   entry.bitmap->GetHeight() != layerH) {
+                    entry.bitmap = std::make_shared<tTVPBaseBitmap>(
+                        static_cast<tjs_uint>(layerW),
+                        static_cast<tjs_uint>(layerH), 32);
+                }
+                // Full CopyRect retains the same ordered GPU texture by
+                // reference. An enclosing batch may still own its completion;
+                // no CPU readback or extra synchronization is required here.
+                entry.bitmap->CopyRect(
+                    0, 0, executedImage,
+                    tTVPRect(0, 0, layerW, layerH));
+                entry.motion = motionPath;
+                entry.frame = _clampedEvalTime;
+                entry.canvasWidth = layerW;
+                entry.canvasHeight = layerH;
+                entry.commandSignature = d3dCommandSignature;
+                entry.storedUs = motionRenderProfileNowUs();
+            }
+        }
+        return true;
     }
 
     bool Player::renderToRgba(std::uint8_t *pixels, int width, int height,

--- a/cpp/plugins/motionplayer/RuntimeSupport.h
+++ b/cpp/plugins/motionplayer/RuntimeSupport.h
@@ -370,9 +370,9 @@ namespace motion::detail {
         std::unordered_map<iTJSDispatch2 *, PresentationRenderCacheEntry>
             presentationRenderCache;
         int presentationRenderReuseSkips = 0;
-        // D3DEmote draws every character through one shared work layer.  A
+        // E-mote can draw several characters through shared work layers. A
         // target-only cache cannot survive the next character overwriting
-        // that layer, so retain this player's completed frame separately.
+        // that layer, so retain each player's completed frame separately.
         // The bitmap keeps Godot-native GPU contents resident when available.
         struct EmoteRenderFrameCacheEntry {
             std::shared_ptr<tTVPBaseBitmap> bitmap;
@@ -385,6 +385,12 @@ namespace motion::detail {
         };
         EmoteRenderFrameCacheEntry emoteRenderFrameCache;
         int emoteRenderFrameReuseSkips = 0;
+        // The D3D adaptor route clears to transparent and hands a private
+        // scratch texture to captureCanvas. Keep it separate from the direct
+        // layer route, whose authored target can have a different neutral
+        // color and presentation lifetime.
+        EmoteRenderFrameCacheEntry d3dEmoteRenderFrameCache;
+        int d3dEmoteRenderFrameReuseSkips = 0;
         // E-mote rebuilds the render-command vector on every tick, but most
         // transformed leaves and composite subtrees are unchanged between
         // ticks. Keep their GPU-backed work layers alive across that rebuild
@@ -660,6 +666,8 @@ namespace motion::detail {
             motionPreparedMaterializedKeysBySource.clear();
             emoteRenderFrameCache = {};
             emoteRenderFrameReuseSkips = 0;
+            d3dEmoteRenderFrameCache = {};
+            d3dEmoteRenderFrameReuseSkips = 0;
             emoteCommandOutputCache.clear();
             emoteCommandOutputCacheGeneration = 0;
             emoteCommandOutputCacheHits = 0;

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -244,6 +244,46 @@ TEST_CASE("motion presentation excludes structural binder layers") {
         motion::internal::presentationLayerTypeCanReceivePixels(ltAlpha));
 }
 
+TEST_CASE("D3D E-mote frame reuse only covers its transparent scratch route") {
+    using motion::internal::d3dEmoteFrameReuseRouteEligible;
+
+    CHECK(d3dEmoteFrameReuseRouteEligible(true, false, 1));
+    CHECK_FALSE(d3dEmoteFrameReuseRouteEligible(false, false, 1));
+    CHECK_FALSE(d3dEmoteFrameReuseRouteEligible(true, true, 1));
+    CHECK_FALSE(d3dEmoteFrameReuseRouteEligible(true, false, 0));
+}
+
+TEST_CASE("D3D E-mote frame cache requires exact render identity") {
+    using motion::internal::d3dEmoteFrameCacheMatches;
+
+    motion::detail::PlayerRuntime::EmoteRenderFrameCacheEntry entry;
+    entry.bitmap = std::make_shared<tTVPBaseBitmap>(2, 3, 32);
+    entry.motion = "emote/vanilla";
+    entry.frame = 12.5;
+    entry.canvasWidth = 2;
+    entry.canvasHeight = 3;
+    entry.commandSignature = 0x1234u;
+
+    CHECK(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.5, 2, 3, 0x1234u));
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/chocola", 12.5, 2, 3, 0x1234u));
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.51, 2, 3, 0x1234u));
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.5, 3, 3, 0x1234u));
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.5, 2, 3, 0x4321u));
+
+    entry.canvasWidth = 4;
+    entry.canvasHeight = 5;
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.5, 4, 5, 0x1234u));
+    entry.bitmap.reset();
+    CHECK_FALSE(d3dEmoteFrameCacheMatches(
+        entry, "emote/vanilla", 12.5, 4, 5, 0x1234u));
+}
+
 TEST_CASE("startup logo presentation preserves its authored origin") {
     using motion::internal::startupLogoMotionScalesAroundCanvasCenter;
     using motion::internal::startupLogoMotionUsesStableBackdropReference;


### PR DESCRIPTION
## Summary

- add an exact-frame reuse path for E-mote players rendered through the D3D adaptor
- keep D3D cached frames separate from direct-layer presentation caches because the routes have different clear and lifetime semantics
- keep private D3D scratch layers hidden and gate reuse on motion, frame, canvas dimensions, bitmap dimensions, and render-command signature
- add focused tests for route eligibility and cache identity invalidation
- mirror the game-launch loading glyph and rotate it clockwise to match common loading-spinner motion

## Root cause

NEKOPARA Extra renders its in-game characters through `renderToD3DAdaptor`, while the existing whole-frame reuse path only covered direct layer rendering. Unchanged characters therefore replayed roughly 200–340 render commands per character every tick. Non-Live2D compute work and its required barriers scaled almost linearly with character count, leading to sustained teens and single-digit FPS in crowded scenes.

The change retains the completed Godot-native texture by reference and reuses it only when the full render identity is unchanged. Real misses still follow the existing ordered GPU batch path.

## Impact

On the same macOS Metal Release build and NEKOPARA Extra flow:

- stable two-character dialogue: 19.531 ms average (~51 FPS) to 16.667 ms (locked 60 FPS)
- non-Live2D GPU operations: reduced by about 81.5%
- rapid 30-click transition sequence: worst one-second average improved from 55.906 ms to 41.942 ms
- final crowded breakfast scene: 12 consecutive one-second windows at 16.667 ms, with no white frames, tearing, stale layers, or double composition
- bridge failures, timeouts, and rejected batches remained zero

Asset/setup transitions can still produce isolated loading spikes; this PR targets the sustained character-count scaling problem.

## Loading motion

The shared refresh artwork is `arrows-counter-clockwise-fill.svg`. The loading spinner now mirrors only its own `TextureRect` horizontally and rotates through positive `TAU`, which appears clockwise in Godot's downward-Y canvas. Other uses of the shared refresh icon remain unchanged. Duration, linear motion, and reduced-motion behavior are preserved.

## Validation

- `ctest --test-dir out/macos/release --output-on-failure -j8` — 149/149 passed
- `./build.sh macos release --jobs=8`
- `godot --headless --path apps/godot_app --script res://tests/mobile_safe_area_test.gd` — `MOBILE_SAFE_AREA_OK`
- exported `Aether.app` passes strict deep code-signature verification
- normal UI playthrough covering two-character dialogue, rapid transitions, and the crowded breakfast scene
- exported Release loading overlay visually checked for centered layout, clockwise glyph, and active rotation

Not yet validated on iPad/A17 hardware; the current runtime validation is macOS Metal Release.
