### PR TITLE
Wire private QLIE runtime provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -747,7 +747,7 @@ jobs:
             2>&1 | tee "$configure_log"
 
           if [[ "$AETHERKIRI_WITH_INTERNAL" == "true" ]]; then
-            grep -F "AetherInternal E-mote/Live2D package: enabled" "$configure_log"
+            grep -F "AetherInternal E-mote/Live2D/Artemis/QLIE package: enabled" "$configure_log"
           else
             grep -F "AetherInternal package: unavailable; using public fallbacks" "$configure_log"
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ option(AETHERKIRI_ENABLE_INTERNAL
 set(AETHERKIRI_MOTIONPLAYER_BACKEND_API_VERSION 3)
 set(AETHERKIRI_LIVE2D_HOST_API_VERSION 1)
 set(AETHERKIRI_FRAME_EFFECT_HOST_API_VERSION 2)
+set(AETHERKIRI_QLIE_HOST_API_VERSION 1)
 set(AETHERKIRI_INTERNAL_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/packages/AetherInternal"
     CACHE PATH "path to an AetherInternal package checkout")
@@ -112,18 +113,21 @@ if(AETHERKIRI_ENABLE_INTERNAL)
     find_package(AetherInternal CONFIG QUIET
         NO_DEFAULT_PATH)
     if(AetherInternal_FOUND)
-        if(NOT AETHERINTERNAL_PACKAGE_API_VERSION EQUAL 6 OR
+        if(NOT AETHERINTERNAL_PACKAGE_API_VERSION EQUAL 7 OR
            NOT AETHERINTERNAL_REQUIRED_MOTIONPLAYER_API_VERSION EQUAL
                AETHERKIRI_MOTIONPLAYER_BACKEND_API_VERSION OR
            NOT AETHERINTERNAL_REQUIRED_LIVE2D_HOST_API_VERSION EQUAL
                AETHERKIRI_LIVE2D_HOST_API_VERSION OR
            NOT AETHERINTERNAL_REQUIRED_FRAME_EFFECT_HOST_API_VERSION EQUAL
                AETHERKIRI_FRAME_EFFECT_HOST_API_VERSION OR
+           NOT AETHERINTERNAL_REQUIRED_QLIE_HOST_API_VERSION EQUAL
+               AETHERKIRI_QLIE_HOST_API_VERSION OR
            NOT COMMAND aetherinternal_extend_motionplayer OR
            NOT COMMAND aetherinternal_extend_psbfile OR
            NOT COMMAND aetherinternal_extend_legacy_plugins OR
            NOT COMMAND aetherinternal_extend_live2d OR
            NOT COMMAND aetherinternal_extend_artemis OR
+           NOT COMMAND aetherinternal_extend_qlie OR
            NOT COMMAND aetherinternal_extend_godot_extension OR
            NOT COMMAND aetherinternal_extend_krkr2plugin OR
            NOT COMMAND aetherinternal_extend_krkr2plugin_tests)
@@ -136,7 +140,7 @@ if(AETHERKIRI_ENABLE_INTERNAL)
 endif()
 
 if(AETHERKIRI_INTERNAL_ENABLED)
-    message(STATUS "AetherInternal E-mote/Live2D package: enabled")
+    message(STATUS "AetherInternal E-mote/Live2D/Artemis/QLIE package: enabled")
 else()
     message(STATUS "AetherInternal package: unavailable; using public fallbacks")
 endif()

--- a/bridge/engine_api/CMakeLists.txt
+++ b/bridge/engine_api/CMakeLists.txt
@@ -78,6 +78,10 @@ if(AETHERKIRI_INTERNAL_ENABLED AND COMMAND aetherinternal_extend_artemis)
     aetherinternal_extend_artemis(engine_api)
 endif()
 
+if(AETHERKIRI_INTERNAL_ENABLED AND COMMAND aetherinternal_extend_qlie)
+    aetherinternal_extend_qlie(engine_api "${CMAKE_SOURCE_DIR}")
+endif()
+
 if(TARGET aetherinternal_artemis_lua)
     set(AETHERKIRI_ARTEMIS_LUA_PREFIX_HEADER
         "${CMAKE_CURRENT_SOURCE_DIR}/src/artemis_lua_symbol_prefix.h")

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -30,6 +30,9 @@
     defined(AETHERKIRI_ENABLE_ARTEMIS_RUNTIME)
 extern "C" void AetherInternalRegisterArtemisRuntime(void);
 #endif
+#if defined(AETHERKIRI_INTERNAL_QLIE)
+extern "C" void AetherInternalRegisterQlieRuntime(void);
+#endif
 
 namespace {
 
@@ -399,6 +402,9 @@ engine_result_t engine_create(const engine_create_desc_t* desc,
 #if defined(AETHERKIRI_INTERNAL_ARTEMIS) && \
     defined(AETHERKIRI_ENABLE_ARTEMIS_RUNTIME)
   AetherInternalRegisterArtemisRuntime();
+#endif
+#if defined(AETHERKIRI_INTERNAL_QLIE)
+  AetherInternalRegisterQlieRuntime();
 #endif
   if (desc->struct_size < sizeof(engine_create_desc_t)) {
     return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,


### PR DESCRIPTION
## Summary

- validate AetherInternal package API v7 and the QLIE host ABI version
- invoke the private package CMake extension when available
- register the private runtime provider during engine creation
- pin the matching AetherInternal revision and update the CI package assertion

## Privacy boundary

This public change contains no QLIE parser, VM, archive, rendering, text, audio, or game-detection implementation. Those details remain exclusively in the private `AetherInternal` package referenced by the submodule commit.

## Validation

- local Debug and Release host builds pass
- dialogue/text/audio product regression passes
- prior organization workflow completed successfully on Web, macOS, Android, and iOS

## Dependency

Depends on the matching draft PR in `AetherKiri/AetherInternal`.