### PR TITLE
fix: close plugin and Artemis compatibility gaps

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -61,6 +61,18 @@ Kirikiri Z 64bit Project Contributors
 Thanks for many libraries to contributors and other supporters that were not
 listed here.
 
+-------------------------------------------------------------------------------
+krkrsdl3 supplemental term
+-------------------------------------------------------------------------------
+The `ExtKAGParser.dll` compatibility implementation is adapted from krkrsdl3.
+Its upstream supplemental redistribution term is preserved here:
+
+When distributing binary files of ported versions of commercial games that run
+on, but were not originally developed with, the KRKRSDL3 software, you must, if
+you have made any modifications to the KRKRSDL3 code itself, make the complete
+and corresponding source code of those modifications publicly available under
+the same terms as this license.
+
 This software is based in part on the work of Independent JPEG Group.
 ------------------------------------------------------------------------------
 libjpeg-turbo

--- a/build/build_ios.sh
+++ b/build/build_ios.sh
@@ -57,6 +57,7 @@ PARALLEL_JOBS="${JOBS:-8}"
 FORCE_LOAD_PLUGIN_ARCHIVES=(
     "libSDL2.a"
     "libkrkr2plugin.a"
+    "libextkagparser.a"
     "libkagparserex.a"
     "liblayerExDraw.a"
     "libmotionplayer.a"
@@ -67,6 +68,7 @@ FORCE_LOAD_PLUGIN_ARCHIVES=(
 FORCE_LOAD_PLUGIN_SOURCES=(
     "vcpkg_installed/$VCPKG_TRIPLET_DIR/lib/libSDL2.a"
     "cpp/plugins/libkrkr2plugin.a"
+    "cpp/plugins/extkagparser/libextkagparser.a"
     "cpp/plugins/kagparserex/libkagparserex.a"
     "cpp/plugins/layerex_draw/liblayerExDraw.a"
     "cpp/plugins/motionplayer/libmotionplayer.a"
@@ -272,6 +274,7 @@ combine_ios_static_extension() {
         "$CMAKE_BUILD_DIR/cpp/core/visual/libcore_visual_module.a"
         "$CMAKE_BUILD_DIR/cpp/core/visual/simd/libtvpgl_simd.a"
         "$CMAKE_BUILD_DIR/cpp/plugins/libkrkr2plugin.a"
+        "$CMAKE_BUILD_DIR/cpp/plugins/extkagparser/libextkagparser.a"
         "$CMAKE_BUILD_DIR/cpp/plugins/kagparserex/libkagparserex.a"
         "$CMAKE_BUILD_DIR/cpp/plugins/layerex_draw/liblayerExDraw.a"
         "$CMAKE_BUILD_DIR/cpp/plugins/motionplayer/libmotionplayer.a"

--- a/cpp/core/base/ScriptMgnIntf.cpp
+++ b/cpp/core/base/ScriptMgnIntf.cpp
@@ -4010,8 +4010,10 @@ void TVPShowScriptException(eTJSScriptError &e) {
         // Application->GetTitle(), mtStop, mbOK );
 
 #ifdef TVP_ENABLE_EXECUTE_AT_EXCEPTION
-        const tjs_char *scriptName = e.GetBlockNoAddRef()->GetName();
-        if(scriptName != nullptr && scriptName[0] != 0) {
+        auto *scriptBlock = e.GetBlockNoAddRef();
+        const tjs_char *scriptName = scriptBlock ? scriptBlock->GetName()
+                                                 : nullptr;
+        if(scriptBlock && scriptName != nullptr && scriptName[0] != 0) {
             ttstr path(scriptName);
             try {
                 ttstr newpath = TVPGetPlacedPath(path);
@@ -4022,9 +4024,9 @@ void TVPShowScriptException(eTJSScriptError &e) {
                 }
                 TVPGetLocalName(path);
                 std::wstring scriptPath(path.AsStdString());
-                tjs_int lineno = 1 +
-                    e.GetBlockNoAddRef()->SrcPosToLine(e.GetPosition()) -
-                    e.GetBlockNoAddRef()->GetLineOffset();
+                tjs_int lineno =
+                    1 + scriptBlock->SrcPosToLine(e.GetPosition()) -
+                    scriptBlock->GetLineOffset();
 
 #if defined(WIN32) && defined(_DEBUG) && !defined(ENABLE_DEBUGGER)
                 // デバッガ実行されている時、Visual Studio

--- a/cpp/core/tjs2/tjsError.cpp
+++ b/cpp/core/tjs2/tjsError.cpp
@@ -60,19 +60,22 @@ namespace TJS {
     eTJSScriptError::tScriptBlockHolder::tScriptBlockHolder(
         tTJSScriptBlock *block) {
         Block = block;
-        Block->AddRef();
+        if(Block)
+            Block->AddRef();
     }
 
     //---------------------------------------------------------------------------
     eTJSScriptError::tScriptBlockHolder::~tScriptBlockHolder() {
-        Block->Release();
+        if(Block)
+            Block->Release();
     }
 
     //---------------------------------------------------------------------------
     eTJSScriptError::tScriptBlockHolder::tScriptBlockHolder(
         const tScriptBlockHolder &holder) {
         Block = holder.Block;
-        Block->AddRef();
+        if(Block)
+            Block->AddRef();
     }
 
     //---------------------------------------------------------------------------
@@ -82,11 +85,13 @@ namespace TJS {
 
     //---------------------------------------------------------------------------
     tjs_int eTJSScriptError::GetSourceLine() const {
-        return Block.Block->SrcPosToLine(Position) + 1;
+        return Block.Block ? Block.Block->SrcPosToLine(Position) + 1 : 0;
     }
 
     //---------------------------------------------------------------------------
     const tjs_char *eTJSScriptError::GetBlockName() const {
+        if(!Block.Block)
+            return TJS_W("");
         const tjs_char *name = Block.Block->GetName();
         return name ? name : TJS_W("");
     }
@@ -99,7 +104,8 @@ namespace TJS {
 
         if(len != 0)
             Trace += TJS_W("\n<-- ");
-        Trace += block->GetLineDescriptionString(srcpos);
+        Trace += block ? block->GetLineDescriptionString(srcpos)
+                       : ttstr(TJS_W("(expression)"));
 
         return true;
     }
@@ -137,6 +143,8 @@ namespace TJS {
     static void TJSReportExceptionSource(const ttstr &msg,
                                          const tTJSScriptBlock *block,
                                          tjs_int srcpos) {
+        if(!block)
+            return;
         {
             tTJS *tjs = block->GetTJS();
             tjs->OutputExceptionToConsole(
@@ -149,12 +157,15 @@ namespace TJS {
     static void TJSReportExceptionSource(const ttstr &msg,
                                          const tTJSInterCodeContext *context,
                                          tjs_int codepos) {
+        if(!context)
+            return;
         {
-            tTJS *tjs = context->GetBlock()->GetTJS();
-            tjs->OutputExceptionToConsole(
-                (msg + TJS_W(" at ") +
-                 context->GetPositionDescriptionString(codepos))
-                    .c_str());
+            tTJS *tjs = context->GetTJS();
+            if(tjs)
+                tjs->OutputExceptionToConsole(
+                    (msg + TJS_W(" at ") +
+                     context->GetPositionDescriptionString(codepos))
+                        .c_str());
         }
     }
 
@@ -191,16 +202,16 @@ namespace TJS {
     void TJS_eTJSScriptError(const ttstr &msg, tTJSInterCodeContext *context,
                              tjs_int codepos) {
         TJSReportExceptionSource(msg, context, codepos);
-        throw eTJSScriptError(msg, context->GetBlock(),
-                              context->CodePosToSrcPos(codepos));
+        throw eTJSScriptError(msg, context ? context->GetBlock() : nullptr,
+                              context ? context->CodePosToSrcPos(codepos) : 0);
     }
 
     //---------------------------------------------------------------------------
     void TJS_eTJSScriptError(const tjs_char *msg, tTJSInterCodeContext *context,
                              tjs_int codepos) {
         TJSReportExceptionSource(msg, context, codepos);
-        throw eTJSScriptError(msg, context->GetBlock(),
-                              context->CodePosToSrcPos(codepos));
+        throw eTJSScriptError(msg, context ? context->GetBlock() : nullptr,
+                              context ? context->CodePosToSrcPos(codepos) : 0);
     }
 
     //---------------------------------------------------------------------------
@@ -222,8 +233,9 @@ namespace TJS {
                                  tTJSInterCodeContext *context, tjs_int codepos,
                                  tTJSVariant &val) {
         TJSReportExceptionSource(msg, context, codepos);
-        throw eTJSScriptException(msg, context->GetBlock(),
-                                  context->CodePosToSrcPos(codepos), val);
+        throw eTJSScriptException(
+            msg, context ? context->GetBlock() : nullptr,
+            context ? context->CodePosToSrcPos(codepos) : 0, val);
     }
 
     //---------------------------------------------------------------------------
@@ -231,8 +243,9 @@ namespace TJS {
                                  tTJSInterCodeContext *context, tjs_int codepos,
                                  tTJSVariant &val) {
         TJSReportExceptionSource(msg, context, codepos);
-        throw eTJSScriptException(msg, context->GetBlock(),
-                                  context->CodePosToSrcPos(codepos), val);
+        throw eTJSScriptException(
+            msg, context ? context->GetBlock() : nullptr,
+            context ? context->CodePosToSrcPos(codepos) : 0, val);
     }
 
     //---------------------------------------------------------------------------

--- a/cpp/plugins/CMakeLists.txt
+++ b/cpp/plugins/CMakeLists.txt
@@ -137,6 +137,7 @@ if(NOT WEB AND NOT EMSCRIPTEN)
 endif()
 add_subdirectory(motionplayer)
 add_subdirectory(kagparserex)
+add_subdirectory(extkagparser)
 
 #add_subdirectory(json)
 #add_subdirectory(steam)
@@ -146,6 +147,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
         psbfile
         motionplayer
         kagparserex
+        extkagparser
 #        json steam DrawDeviceForSteam
 )
 if(NOT WEB AND NOT EMSCRIPTEN)

--- a/cpp/plugins/extkagparser/CMakeLists.txt
+++ b/cpp/plugins/extkagparser/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.19)
+project(extkagparser)
+
+add_library(${PROJECT_NAME} STATIC)
+
+target_sources(${PROJECT_NAME} PRIVATE
+    ExtKAG.cpp
+    ExtKAGParser.cpp
+    TJSAry.cpp
+    TJSDic.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} PRIVATE krkr2plugin)

--- a/cpp/plugins/extkagparser/ExtKAG.cpp
+++ b/cpp/plugins/extkagparser/ExtKAG.cpp
@@ -1,0 +1,63 @@
+#include "tjsCommHead.h"
+#include "ncbind.hpp"
+
+#define NCB_MODULE_NAME TJS_W("ExtKAGParser.dll")
+#define TVP_KAGPARSER_EX_CLASSNAME TJS_W("KAGParser")
+
+extern tTJSNativeClass* TVPCreateNativeClass_ExtKAGParser();
+extern void ExtTVPResetScenarioCache();
+static iTJSDispatch2* origKAGParser = nullptr;
+
+void extkagparser_init()
+{
+    iTJSDispatch2* global = TVPGetScriptDispatch();
+    if (global)
+    {
+        if (origKAGParser)
+        {
+            origKAGParser->Release();
+            origKAGParser = nullptr;
+        }
+        tTJSVariant val;
+        if (TJS_SUCCEEDED(global->PropGet(0, TVP_KAGPARSER_EX_CLASSNAME, nullptr, &val, global)) &&
+            val.Type() == tvtObject && val.AsObjectNoAddRef())
+        {
+            origKAGParser = val.AsObject();
+            val.Clear();
+        }
+        iTJSDispatch2* tjsclass = TVPCreateNativeClass_ExtKAGParser();
+        val = tTJSVariant(tjsclass);
+        tjsclass->Release();
+        global->PropSet(TJS_MEMBERENSURE, TVP_KAGPARSER_EX_CLASSNAME, nullptr, &val, global);
+        global->Release();
+    }
+}
+
+void extkagparser_done()
+{
+    ExtTVPResetScenarioCache();
+
+    iTJSDispatch2* global = TVPGetScriptDispatch();
+    if (global)
+    {
+        global->DeleteMember(0, TVP_KAGPARSER_EX_CLASSNAME, nullptr, global);
+        if (origKAGParser)
+        {
+            tTJSVariant val(origKAGParser);
+            origKAGParser->Release();
+            origKAGParser = nullptr;
+            global->PropSet(TJS_MEMBERENSURE, TVP_KAGPARSER_EX_CLASSNAME, nullptr, &val, global);
+        }
+        global->Release();
+    }
+    else if (origKAGParser)
+    {
+        origKAGParser->Release();
+        origKAGParser = nullptr;
+    }
+}
+
+NCB_PRE_REGIST_CALLBACK(extkagparser_init);
+NCB_POST_UNREGIST_CALLBACK(extkagparser_done);
+
+extern "C" void TVPRegisterExtKAGParserPluginAnchor() {}

--- a/cpp/plugins/extkagparser/ExtKAGParser.cpp
+++ b/cpp/plugins/extkagparser/ExtKAGParser.cpp
@@ -1,0 +1,3907 @@
+//---------------------------------------------------------------------------
+/*
+        TVP2 ( T Visual Presenter 2 )  A script authoring tool
+        Copyright (C) 2000 W.Dee <dee@kikyou.info> and contributors
+
+        See details of license at "license.txt"
+
+        Modified by KAICHO for extentions
+*/
+//---------------------------------------------------------------------------
+// KAG Parser Utility Class
+//---------------------------------------------------------------------------
+
+#include "tjsCommHead.h"
+#include "StorageImpl.h"
+#include "tjsDictionary.h"
+#include "MsgIntf.h"
+#include "DebugIntf.h"
+#include "ScriptMgnIntf.h"
+#include "TextStream.h"
+#include "tjsGlobalStringMap.h"
+#include "EventIntf.h"
+
+#include "ExtKAGParser.hpp"
+
+namespace {
+
+int utf16_char_len(const tjs_char *text)
+{
+    if (!text || text[0] == 0)
+        return 0;
+    const tjs_char first = text[0];
+    if (first >= 0xd800 && first <= 0xdbff)
+    {
+        const tjs_char second = text[1];
+        if (second >= 0xdc00 && second <= 0xdfff)
+            return 2;
+    }
+    return 1;
+}
+
+} // namespace
+
+//---------------------------------------------------------------------------
+/*
+  KAG System (Kirikiri Adventure Game System) is an application script for
+  TVP(Kirikiri), providing core system for Adventure Game/Visual Novel.
+  KAG has a simple tag-based mark-up language ("scenario file").
+  Version under 2.x of KAG is slow since the parser is written in TJS1.
+  KAG 3.x uses TVP's internal KAG parser written in C++ in this unit, will
+  acquire speed in compensation for ability of customizing.
+*/
+//---------------------------------------------------------------------------
+
+#define TVPCurPosErrorString \
+    (TJS_W("CurPos = ") + ttstr(CurPos) + TJS_W(", CurLineStr = \"") + ttstr(CurLineStr) + \
+     TJS_W("\""))
+#define SWITCH_TVPEXECUTEEXPRESSION(content, context, result) \
+    TVPExecuteExpression((content), (context), (result))
+
+const tjs_char* TVPExtKAGNoLine = TJS_W("読み込もうとしたシナリオファイル %1 は空です");
+const tjs_char* TVPExtKAGCannotOmmitFirstLabelName =
+    TJS_W("シナリオファイルの最初のラベル名は省略できません");
+//const tjs_char* TVPInternalError = TJS_W("内部エラーが発生しました: at %1 line %2");
+const tjs_char* TVPExtKAGMalformedSaveData =
+    TJS_W("栞データが異常です。データが破損している可能性があります");
+const tjs_char* TVPExtKAGLabelNotFound =
+    TJS_W("シナリオファイル %1 内にラベル %2 が見つかりません");
+const tjs_char* TVPExtLabelInMacro = TJS_W("ラベルはマクロ中に記述できません");
+const tjs_char* TVPExtKAGInlineScriptNotEnd = TJS_W("[endscript] または @endscript が見つかりません");
+const tjs_char* TVPExtKAGSyntaxError =
+    TJS_W("タグの文法エラーです。'[' や ']' の対応、\" と \" "
+          "の対応、スペースの入れ忘れ、余分な改行、macro ～ endmacro "
+          "の対応、必要な属性の不足などを確認してください\n\n%1\n%2");
+const tjs_char* TVPExtKAGCallStackUnderflow =
+    TJS_W("return タグが call タグと対応していません ( return タグが多い )");
+const tjs_char* TVPExtKAGReturnLostSync =
+    TJS_W("シナリオファイルに変更があったため return の戻り先位置を特定できません");
+const tjs_char* TVPExtKAGSpecifyKAGParser = TJS_W("KAGParser クラスのオブジェクトを指定してください");
+const tjs_char* TVPExtUnknownMacroName = TJS_W("マクロ \"%1\" は登録されていません");
+const tjs_char* TVPExtKAGWhileStackUnderflow =
+    TJS_W("endwhile/continue/break タグが while タグと対応していません");
+const tjs_char* TVPExtKAGWhileLostSync =
+    TJS_W("シナリオファイルに変更があったため endwhile の戻り先位置を特定できません");
+const tjs_char* TVPExtKAGLabelInConditionScope =
+    TJS_W("ラベル %1 が if/ignore/while/pushlocalvar スコープ中に存在しています");
+const tjs_char* TVPExtKAGIfStackUnderflow =
+    TJS_W("else, endif, endignore タグが if, ignore タグと対応していません");
+const tjs_char* TVPKAGWrongAttrOutOfMacro =
+    TJS_W("マクロ外でタグの属性に '*' や arg=%val が指定されています");
+const tjs_char* TVPExtKAGMultiLineDisabled = TJS_W(
+    "タグ内に複数行タグを示す '\' が存在しますが、multiLineTagEnabled が true ではありません");
+const tjs_char* TVPExtNoStorageAndLabelAtJump =
+    TJS_W("call/jump タグに storage と label が両方指定されていません");
+const tjs_char* TVPExtLocalVaiablesUnderFlow =
+    TJS_W("poplocalvar タグが pushlocalvar タグと対応していません");
+
+#define TVPThrowInternalError TVPThrowExceptionMessage(TVPInternalError, __FILE__, __LINE__)
+
+//---------------------------------------------------------------------------
+// tTVPScenarioCacheItem : Scenario Cache Item
+//---------------------------------------------------------------------------
+tExtTVPScenarioCacheItem::tExtTVPScenarioCacheItem(const ttstr& name, bool isstring)
+{
+    RefCount = 1;
+    Lines = NULL;
+    LineCount = 0;
+    LabelCached = false;
+    try
+    {
+        LoadScenario(name, isstring);
+    }
+    catch (...)
+    {
+        if (Lines)
+            delete[] Lines;
+        throw;
+    }
+}
+//---------------------------------------------------------------------------
+tExtTVPScenarioCacheItem::~tExtTVPScenarioCacheItem()
+{
+    if (Lines)
+        delete[] Lines;
+}
+//---------------------------------------------------------------------------
+void tExtTVPScenarioCacheItem::AddRef()
+{
+    RefCount++;
+}
+//---------------------------------------------------------------------------
+void tExtTVPScenarioCacheItem::Release()
+{
+    if (RefCount == 1)
+        delete this;
+    else
+        RefCount--;
+}
+//---------------------------------------------------------------------------
+void tExtTVPScenarioCacheItem::LoadScenario(const ttstr& name, bool isstring)
+{
+    // load scenario from file or string to buffer
+
+    if (isstring)
+    {
+        // when onScenarioLoad returns string;
+        // assumes the string is scenario
+        Buffer = name.c_str();
+    }
+    else
+    {
+        // else load from file
+
+        iTJSTextReadStream* stream = NULL;
+
+        try
+        {
+            stream = TVPCreateTextStreamForRead(name, TJS_W(""));
+            //			stream = TVPCreateTextStreamForReadByEncoding(name, TJS_W(""),
+            //TJS_W("Shift_JIS"));
+            ttstr tmp;
+            if (stream)
+                stream->Read(tmp, 0);
+            Buffer = tmp.c_str();
+        }
+        catch (...)
+        {
+            if (stream)
+                stream->Destruct();
+            throw;
+        }
+        if (stream)
+            stream->Destruct();
+    }
+
+    tjs_char* buffer_p = Buffer;
+
+    // pass1: count lines
+    tjs_int count = 0;
+    tjs_char* ls = buffer_p;
+    tjs_char* p = buffer_p;
+    while (*p)
+    {
+        if (*p == TJS_W('\r') || *p == TJS_W('\n'))
+        {
+            count++;
+            if (*p == TJS_W('\r') && p[1] == TJS_W('\n'))
+                p++;
+            p++;
+            ls = p;
+        }
+        else
+        {
+            p++;
+        }
+    }
+
+    if (p != ls)
+    {
+        count++;
+    }
+
+    if (count == 0)
+        TVPThrowExceptionMessage(TVPExtKAGNoLine, name);
+
+    Lines = new tLine[count];
+    LineCount = count;
+
+    // pass2: split lines
+    count = 0;
+    ls = buffer_p;
+    while (*ls == '\t')
+        ls++; // skip leading tabs
+    p = ls;
+    while (*p)
+    {
+        if (*p == TJS_W('\r') || *p == TJS_W('\n'))
+        {
+            Lines[count].Start = ls;
+            Lines[count].Length = p - ls;
+            count++;
+            tjs_char* rp = p;
+            if (*p == TJS_W('\r') && p[1] == TJS_W('\n'))
+                p++;
+            p++;
+            ls = p;
+            while (*ls == '\t')
+                ls++; // skip leading tabs
+            p = ls;
+            *rp = 0; // end line with null terminater
+        }
+        else
+        {
+            p++;
+        }
+    }
+
+    if (p != ls)
+    {
+        Lines[count].Start = ls;
+        Lines[count].Length = p - ls;
+        count++;
+    }
+
+    LineCount = count;
+    // tab-only last line will not be counted in pass2, thus makes
+    // pass2 counted lines are lesser than pass1 lines.
+}
+//---------------------------------------------------------------------------
+void tExtTVPScenarioCacheItem::EnsureLabelCache()
+{
+    // construct label cache
+    if (!LabelCached)
+    {
+        // make label cache
+        LabelAliases.resize(LineCount);
+        ttstr prevlabel;
+        const tjs_char* p;
+        const tjs_char* vl;
+        tjs_int i;
+        bool out_of_iscript = true;
+        for (i = 0; i < LineCount; i++)
+        {
+            p = Lines[i].Start;
+
+            // check whether this is in/out of iscript range
+            if (p[0] == TJS_W('[') || p[0] == TJS_W('@'))
+            {
+                if (TJS_strcmp(p, TJS_W("[iscript]")) == 0 ||
+                    TJS_strcmp(p, TJS_W("[iscript]\\")) == 0 ||
+                    TJS_strcmp(p, TJS_W("@iscript")) == 0)
+                {
+                    out_of_iscript = false;
+                    continue;
+                }
+                if (TJS_strcmp(p, TJS_W("[endscript]")) == 0 ||
+                    TJS_strcmp(p, TJS_W("[endscript]\\")) == 0 ||
+                    TJS_strcmp(p, TJS_W("@endscript")) == 0)
+                {
+                    out_of_iscript = true;
+                    continue;
+                }
+            }
+
+            // if this is not in iscript range, search label(*XXX)
+            if (out_of_iscript && Lines[i].Length >= 2 && p[0] == TJS_W('*'))
+            {
+                vl = TJS_strchr(p, TJS_W('|'));
+                ttstr label;
+                if (vl)
+                {
+                    // page name found
+                    label = ttstr(p, vl - p);
+                }
+                else
+                {
+                    label = p;
+                }
+
+                if (!label.c_str()[1])
+                {
+                    if (prevlabel.IsEmpty())
+                        TVPThrowExceptionMessage(TVPExtKAGCannotOmmitFirstLabelName);
+                    label = prevlabel;
+                }
+
+                prevlabel = label;
+
+                tLabelCacheData* data = LabelCache.Find(label);
+                if (data)
+                {
+                    // previous label name found (duplicated label)
+                    data->Count++;
+                    label = label + TJS_W(":") + ttstr(data->Count);
+                }
+
+                LabelCache.Add(label, tLabelCacheData(i, 1));
+                LabelAliases[i] = label;
+            }
+        }
+
+        LabelCached = true;
+    }
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// tTVPScenarioCache
+//---------------------------------------------------------------------------
+#define TVP_SCENARIO_MAX_CACHE_SIZE 8
+typedef tTJSRefHolder<tExtTVPScenarioCacheItem> tTVPScenarioCacheItemHolder;
+typedef tTJSHashCache<ttstr,
+                      tTVPScenarioCacheItemHolder,
+                      tTJSHashFunc<ttstr>,
+                      (TVP_SCENARIO_MAX_CACHE_SIZE * 2)>
+    tTVPScenarioCache;
+tTVPScenarioCache ExtTVPScenarioCache(TVP_SCENARIO_MAX_CACHE_SIZE);
+//---------------------------------------------------------------------------
+void ExtTVPClearScnearioCache()
+{
+    ExtTVPScenarioCache.Clear();
+}
+//---------------------------------------------------------------------------
+struct tTVPClearScenarioCacheCallback : public tTVPCompactEventCallbackIntf
+{
+    virtual void OnCompact(tjs_int level)
+    {
+        if (level >= TVP_COMPACT_LEVEL_DEACTIVATE)
+        {
+            // clear the scenario cache
+#ifndef _DEBUG
+            ExtTVPClearScnearioCache();
+#endif
+        }
+    }
+} static TVPClearScenarioCacheCallback;
+static bool TVPClearScenarioCacheCallbackInit = false;
+//---------------------------------------------------------------------------
+void ExtTVPResetScenarioCache()
+{
+    if (TVPClearScenarioCacheCallbackInit)
+    {
+        TVPRemoveCompactEventHook(&TVPClearScenarioCacheCallback);
+        TVPClearScenarioCacheCallbackInit = false;
+    }
+    ExtTVPClearScnearioCache();
+}
+//---------------------------------------------------------------------------
+static tExtTVPScenarioCacheItem* TVPGetScenario(const ttstr& storagename, bool isstring)
+{
+    // compact interface initialization
+    if (!TVPClearScenarioCacheCallbackInit)
+    {
+        TVPAddCompactEventHook(&TVPClearScenarioCacheCallback);
+        TVPClearScenarioCacheCallbackInit = true;
+    }
+
+    if (isstring)
+    {
+        // we do not cache when the string is passed as a scenario
+        return new tExtTVPScenarioCacheItem(storagename, true);
+    }
+
+    // make hash and search over cache
+    tjs_uint32 hash = tTVPScenarioCache::MakeHash(storagename);
+
+    tTVPScenarioCacheItemHolder* ptr = ExtTVPScenarioCache.FindAndTouchWithHash(storagename, hash);
+    if (ptr)
+    {
+        // found in the cache
+        return ptr->GetObject();
+    }
+
+    // not found in the cache
+    tExtTVPScenarioCacheItem* item = new tExtTVPScenarioCacheItem(storagename, false);
+    try
+    {
+        // push into scenario cache hash
+        tTVPScenarioCacheItemHolder holder(item);
+        ExtTVPScenarioCache.AddWithHash(storagename, hash, holder);
+    }
+    catch (...)
+    {
+        item->Release();
+        throw;
+    }
+
+    return item;
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// tTJSNI_KAGParser : KAGParser TJS native instance
+//---------------------------------------------------------------------------
+// KAGParser is implemented as a TJS native class/object
+tTJSNI_ExtKAGParser::tTJSNI_ExtKAGParser()
+{
+    Owner = NULL;
+    Scenario = NULL;
+    Lines = NULL;
+    CurLineStr = NULL;
+    ProcessSpecialTags = true;
+    IgnoreCR = false;
+    RecordingMacro = false;
+    DebugLevel = tkdlSimple;
+    Interrupted = false;
+    MacroArgStackDepth = 0;
+    MacroArgStackBase = 0;
+
+    EnableNP = false;
+    FuzzyReturn = false;
+    ReturnErrorStorage = TJS_W("");
+
+    MultiLineTagEnabled = false;
+    NumericMacroArgumentsEnabled = false;
+
+    ClearLocalVariables();
+}
+//---------------------------------------------------------------------------
+tjs_error tTJSNI_ExtKAGParser::Construct(tjs_int numparams,
+                                         tTJSVariant** param,
+                                         iTJSDispatch2* tjs_obj)
+{
+    tjs_error hr = inherited::Construct(numparams, param, tjs_obj);
+    if (TJS_FAILED(hr))
+        return hr;
+
+    Owner = tjs_obj;
+
+    return TJS_S_OK;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::Invalidate()
+{
+    // invalidate this object
+
+    // release objects
+    ClearMacroArgs();
+    ClearBuffer();
+
+    Owner = NULL;
+
+    inherited::Invalidate();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::operator=(const tTJSNI_ExtKAGParser& ref)
+{
+    // copy Macros
+    Macros.Assign(ref.Macros.GetDicNoAddRef()); // GetDicNoAddRef() is const
+
+    // copy ParamMacros
+    ParamMacros.Assign(ref.ParamMacros.GetDicNoAddRef()); // GetDicNoAddRef() is const
+
+    // copy MacroArgs
+    {
+        ClearMacroArgs();
+
+        for (tjs_uint i = 0; i < ref.MacroArgStackDepth; i++)
+        {
+            tTJSDic* dicp = new tTJSDic(*ref.MacroArgs[i]);
+            MacroArgs.push_back(dicp);
+        }
+        MacroArgStackDepth = ref.MacroArgStackDepth;
+    }
+    MacroArgStackBase = ref.MacroArgStackBase;
+
+    // copy CallStack
+    CallStack = ref.CallStack;
+
+    // copy StorageName, StorageShortName
+    StorageName = ref.StorageName;
+    StorageShortName = ref.StorageShortName;
+
+    // copy Scenario
+    if (Scenario != ref.Scenario)
+    {
+        if (Scenario)
+            Scenario->Release(), Scenario = NULL, Lines = NULL, CurLineStr = NULL;
+        Scenario = ref.Scenario;
+        Lines = ref.Lines;
+        LineCount = ref.LineCount;
+        if (Scenario)
+            Scenario->AddRef();
+    }
+
+    // copy CurStorage, CurLine, CurPos
+    CurLine = ref.CurLine;
+    CurPos = ref.CurPos;
+
+    // copy CurLineStr, LineBuffer, LineBufferUsing
+    CurLineStr = ref.CurLineStr;
+    LineBuffer = ref.LineBuffer;
+    LineBufferUsing = ref.LineBufferUsing;
+
+    // copy CurLabel, CurPage
+    CurLabel = ref.CurLabel;
+    CurPage = ref.CurPage;
+
+    // copy DebugLebel, IgnoreCR
+    DebugLevel = ref.DebugLevel;
+    IgnoreCR = ref.IgnoreCR;
+
+    // copy EnableNP, FuzzyReturn, ReturnErrorStorage
+    EnableNP = ref.EnableNP;
+    FuzzyReturn = ref.FuzzyReturn;
+    ReturnErrorStorage = ref.ReturnErrorStorage;
+
+    // copy RecordingMacro, RecordingMacroStr, RecordingMacroName
+    RecordingMacro = ref.RecordingMacro;
+    RecordingMacroStr = ref.RecordingMacroStr;
+    RecordingMacroName = ref.RecordingMacroName;
+
+    // copy ExcludeLevel, IfLevel
+    ExcludeLevel = ref.ExcludeLevel;
+    IfLevel = ref.IfLevel;
+    ExcludeLevelStack = ref.ExcludeLevelStack;
+    IfLevelExecutedStack = ref.IfLevelExecutedStack;
+
+    // copy WhileStack/WhileLevel
+    WhileLevelExp = ref.WhileLevelExp;
+    WhileLevelEach = ref.WhileLevelEach;
+    WhileStack = ref.WhileStack;
+
+    // copy LocalVariables
+    // This is a bit silly, but need to have "tmp" as
+    // tTJSAry.Assign() needs non-const argument.
+    tTJSVariant tmp(ref.LocalVariables);
+    LocalVariables.Assign(tmp);
+}
+//---------------------------------------------------------------------------
+iTJSDispatch2* tTJSNI_ExtKAGParser::Store()
+{
+    // store current status into newly created dictionary object
+    // and return the dictionary object.
+    iTJSDispatch2* dic = TJSCreateDictionaryObject();
+    try
+    {
+        tTJSVariant val;
+
+        // store LocalVariables
+        LocalVariables.Store(dic, TJS_W("LocalVariables"));
+
+        // store MacroArgs
+        ParamMacros.Store(dic, TJS_W("paramMacros"));
+
+        // create and assign macro dictionary
+        Macros.Store(dic, TJS_W("macros"));
+
+        // create and assign macro arguments
+        {
+            iTJSDispatch2* dsp;
+            dsp = TJSCreateArrayObject();
+            tTJSVariant tmp(dsp, dsp);
+            dsp->Release();
+            dic->PropSet(TJS_MEMBERENSURE, TJS_W("macroArgs"), NULL, &tmp, dic);
+
+            for (tjs_uint i = 0; i < MacroArgStackDepth; i++)
+                MacroArgs[i]->Store(dsp, i);
+        }
+
+        // create call stack array and copy call stack status
+        {
+            iTJSDispatch2* dsp;
+            dsp = TJSCreateArrayObject();
+            tTJSVariant tmp(dsp, dsp);
+            dsp->Release();
+            dic->PropSet(TJS_MEMBERENSURE, TJS_W("callStack"), NULL, &tmp, dic);
+
+            std::vector<tCallStackData>::iterator i;
+            for (i = CallStack.begin(); i != CallStack.end(); i++)
+            {
+                iTJSDispatch2* dic;
+                dic = TJSCreateDictionaryObject();
+                tTJSVariant tmp(dic, dic);
+                dic->Release();
+                dsp->PropSetByNum(TJS_MEMBERENSURE, i - CallStack.begin(), &tmp, dsp);
+
+                tTJSVariant val;
+                val = i->Storage;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("storage"), NULL, &val, dic);
+                val = i->Label;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("label"), NULL, &val, dic);
+                val = i->Offset;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("offset"), NULL, &val, dic);
+                val = i->OrgLineStr;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("orgLineStr"), NULL, &val, dic);
+                val = i->LineBuffer;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBuffer"), NULL, &val, dic);
+                val = i->Pos;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("pos"), NULL, &val, dic);
+                val = (tjs_int)i->LineBufferUsing;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBufferUsing"), NULL, &val, dic);
+                val = (tjs_int)i->MacroArgStackBase;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("macroArgStackBase"), NULL, &val, dic);
+                val = (tjs_int)i->MacroArgStackDepth;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("macroArgStackDepth"), NULL, &val, dic);
+                val = i->ExcludeLevel;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("ExcludeLevel"), NULL, &val, dic);
+                val = (tjs_int)i->IfLevel;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("IfLevel"), NULL, &val, dic);
+
+                StoreIntStackToDic(dic, i->ExcludeLevelStack, TJS_W("ExcludeLevelStack"));
+                StoreBoolStackToDic(dic, i->IfLevelExecutedStack, TJS_W("IfLevelExecutedStack"));
+
+                val = (tjs_int)i->WhileStackDepth;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("WhileStackDepth"), NULL, &val, dic);
+                val = i->LocalVariablesCount;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("LocalVariablesCount"), NULL, &val, dic);
+            }
+        }
+
+        // store StorageName, StorageShortName ( Buffer is not stored )
+        val = StorageName;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("storageName"), NULL, &val, dic);
+        val = StorageShortName;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("storageShortName"), NULL, &val, dic);
+
+        // ( Lines and LineCount are not stored )
+
+        // store CurStorage, CurLine, CurPos
+        val = CurLine;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("curLine"), NULL, &val, dic);
+        val = CurPos;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("curPos"), NULL, &val, dic);
+
+        // ( CurLineStr is not stored )
+
+        // LineBuffer, LineBufferUsing
+        val = LineBuffer;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBuffer"), NULL, &val, dic);
+        val = (tjs_int)LineBufferUsing;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBufferUsing"), NULL, &val, dic);
+
+        // store CurLabel ( CurPage is not stored )
+        val = CurLabel;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("curLabel"), NULL, &val, dic);
+
+        //// ( DebugLabel and IgnoreCR are not stored )
+        // KAICHO added: IgnoreCR should be stored/restored for the
+        // case it is changed in the KAG scenario.
+        // If it is not stored/restored, the change of IgnoreCR in KAG
+        // senario could be forgotten after loading data.
+        val = IgnoreCR;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("IgnoreCR"), NULL, &val, dic);
+
+        // ( RecordingMacro, RecordingMacroStr, RecordingMacroName are not stored)
+
+        // EnableNP, FuzzyReturn, ReturnErrorStorage
+        val = EnableNP;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("EnableNP"), NULL, &val, dic);
+        // Note: FussyReturn is not stored for changing during plaing games
+        // val = FuzzyReturn;
+        // dic->PropSet(TJS_MEMBERENSURE, TJS_W("FuzzyReturn"), NULL,
+        //	&val, dic);
+        //
+        // Note: ReturnErrorStorage is not stored for changing during plaing games
+        // val = ReturnErrorStorage;
+        // dic->PropSet(TJS_MEMBERENSURE, TJS_W("ReturnErrorStorage"), NULL,
+        // 	&val, dic);
+
+        // ExcludeLevel, IfLevel, ExcludeLevelStack, IfLevelExecutedStack
+        val = ExcludeLevel;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("ExcludeLevel"), NULL, &val, dic);
+        val = IfLevel;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("IfLevel"), NULL, &val, dic);
+        StoreIntStackToDic(dic, ExcludeLevelStack, TJS_W("ExcludeLevelStack"));
+        StoreBoolStackToDic(dic, IfLevelExecutedStack, TJS_W("IfLevelExecutedStack"));
+
+        val = WhileLevelExp;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("WhileLevelExp"), NULL, &val, dic);
+        val = WhileLevelEach;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("WhileLevelEach"), NULL, &val, dic);
+        // create while stack array and copy call stack status
+        {
+            iTJSDispatch2* dsp;
+            dsp = TJSCreateArrayObject();
+            tTJSVariant tmp(dsp, dsp);
+            dsp->Release();
+            dic->PropSet(TJS_MEMBERENSURE, TJS_W("whileStack"), NULL, &tmp, dic);
+
+            std::vector<tWhileStackData>::iterator i;
+            for (i = WhileStack.begin(); i != WhileStack.end(); i++)
+            {
+                iTJSDispatch2* dic;
+                dic = TJSCreateDictionaryObject();
+                tTJSVariant tmp(dic, dic);
+                dic->Release();
+                dsp->PropSetByNum(TJS_MEMBERENSURE, i - WhileStack.begin(), &tmp, dsp);
+
+                tTJSVariant val;
+                val = i->Storage;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("storage"), NULL, &val, dic);
+                val = i->Label;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("label"), NULL, &val, dic);
+                val = i->Offset;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("offset"), NULL, &val, dic);
+                val = i->OrgLineStr;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("orgLineStr"), NULL, &val, dic);
+                val = i->LineBuffer;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBuffer"), NULL, &val, dic);
+                val = i->Pos;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("pos"), NULL, &val, dic);
+                val = (tjs_int)i->LineBufferUsing;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("lineBufferUsing"), NULL, &val, dic);
+                val = i->ExcludeLevel;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("ExcludeLevel"), NULL, &val, dic);
+                val = (tjs_int)i->IfLevel;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("IfLevel"), NULL, &val, dic);
+
+                val = i->WhileLevelExp;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("WhileLevelExp"), NULL, &val, dic);
+                val = i->WhileLevelEach;
+                dic->PropSet(TJS_MEMBERENSURE, TJS_W("WhileLevelEach"), NULL, &val, dic);
+            }
+        }
+
+        // store MacroArgStackBase, MacroArgStackDepth
+        val = (tjs_int)MacroArgStackBase;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("macroArgStackBase"), NULL, &val, dic);
+
+        val = (tjs_int)MacroArgStackDepth;
+        dic->PropSet(TJS_MEMBERENSURE, TJS_W("macroArgStackDepth"), NULL, &val, dic);
+    }
+    catch (...)
+    {
+        dic->Release();
+        throw;
+    }
+    return dic;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::StoreIntStackToDic(iTJSDispatch2* dic,
+                                             std::vector<tjs_int>& stack,
+                                             const tjs_char* membername)
+{
+    ttstr stack_str;
+    const static tjs_char hex[] = TJS_W("0123456789abcdef");
+    tjs_char* p = stack_str.AllocBuffer(stack.size() * 8);
+    for (std::vector<tjs_int>::iterator it = stack.begin(); it != stack.end(); ++it)
+    {
+        tjs_int v = *it;
+        p[0] = hex[(v >> 28) & 0x000f];
+        p[1] = hex[(v >> 24) & 0x000f];
+        p[2] = hex[(v >> 20) & 0x000f];
+        p[3] = hex[(v >> 16) & 0x000f];
+        p[4] = hex[(v >> 12) & 0x000f];
+        p[5] = hex[(v >> 8) & 0x000f];
+        p[6] = hex[(v >> 4) & 0x000f];
+        p[7] = hex[(v >> 0) & 0x000f];
+        p += 8;
+    }
+    *p = '\0';
+    stack_str.FixLen();
+    tTJSVariant val;
+    val = stack_str;
+    dic->PropSet(TJS_MEMBERENSURE, membername, NULL, &val, dic);
+}
+
+void tTJSNI_ExtKAGParser::RestoreIntStackFromStr(std::vector<tjs_int>& stack, const ttstr& str)
+{
+    stack.clear();
+    tjs_int len = str.length() / 8;
+    for (tjs_int i = 0; i < len; ++i)
+    {
+        stack.push_back(
+            (((str[i + 0] <= '9') ? (str[i + 0] - '0') : (str[i + 0] - 'a' + 10)) << 28) |
+            (((str[i + 1] <= '9') ? (str[i + 1] - '0') : (str[i + 1] - 'a' + 10)) << 24) |
+            (((str[i + 2] <= '9') ? (str[i + 2] - '0') : (str[i + 2] - 'a' + 10)) << 20) |
+            (((str[i + 3] <= '9') ? (str[i + 3] - '0') : (str[i + 3] - 'a' + 10)) << 16) |
+            (((str[i + 4] <= '9') ? (str[i + 4] - '0') : (str[i + 4] - 'a' + 10)) << 12) |
+            (((str[i + 5] <= '9') ? (str[i + 5] - '0') : (str[i + 5] - 'a' + 10)) << 8) |
+            (((str[i + 6] <= '9') ? (str[i + 6] - '0') : (str[i + 6] - 'a' + 10)) << 4) |
+            (((str[i + 7] <= '9') ? (str[i + 7] - '0') : (str[i + 7] - 'a' + 10)) << 0));
+    }
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::RestoreBoolStackFromStr(std::vector<bool>& stack, const ttstr& str)
+{
+    stack.clear();
+    tjs_int len = str.length();
+    for (tjs_int i = 0; i < len; ++i)
+    {
+        stack.push_back(str[i] == '1');
+    }
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::StoreBoolStackToDic(iTJSDispatch2* dic,
+                                              std::vector<bool>& stack,
+                                              const tjs_char* membername)
+{
+    ttstr stack_str;
+    const static tjs_char bit[] = TJS_W("01");
+    tjs_char* p = stack_str.AllocBuffer(stack.size());
+    for (std::vector<bool>::iterator it = stack.begin(); it != stack.end(); ++it)
+    {
+        *p = bit[(tjs_int)(*it)];
+        ++p;
+    }
+    *p = '\0';
+    stack_str.FixLen();
+    tTJSVariant val;
+    val = stack_str;
+    dic->PropSet(TJS_MEMBERENSURE, membername, NULL, &val, dic);
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::Restore(iTJSDispatch2* dic)
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: KAGParser::Restore()"));
+
+    // restore status from "dic"
+    tTJSVariant val;
+    //	tjs_error er;
+
+    // restore LocalVariables
+    LocalVariables.Restore(dic, TJS_W("LocalVariables"));
+
+    // restore ParamMacros
+    ParamMacros.Restore(dic, TJS_W("paramMacros"));
+
+    // restore macros
+    Macros.Restore(dic, TJS_W("macros"));
+
+    {
+        // restore macro args
+        MacroArgStackDepth = 0;
+
+        val.Clear();
+        dic->PropGet(0, TJS_W("macroArgs"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+        {
+            iTJSDispatch2* ary = val.AsObjectNoAddRef();
+            tTJSVariant v;
+            ary->PropGet(0, TJS_W("count"), NULL, &v, NULL);
+            tjs_int count = v;
+
+            ClearMacroArgs();
+
+            val.Clear();
+            dic->PropGet(0, TJS_W("macroArgStackDepth"), NULL, &val, dic);
+            if (val.Type() != tvtVoid)
+                MacroArgStackDepth = (tjs_uint)(tjs_int)val;
+
+            for (tjs_int i = 0; i < count; i++)
+            {
+                tTJSDic* dicp = new tTJSDic();
+                dicp->Restore(ary, i);
+                MacroArgs.push_back(dicp);
+            }
+        }
+
+        if (MacroArgStackDepth != MacroArgs.size())
+            TVPThrowExceptionMessage(TVPExtKAGMalformedSaveData);
+
+        MacroArgStackBase = MacroArgs.size(); // later reset to MacroArgStackBase
+
+        // restore call stack
+        val.Clear();
+        dic->PropGet(0, TJS_W("callStack"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+        {
+            tTJSVariantClosure clo = val.AsObjectClosureNoAddRef();
+            tTJSVariant v;
+            tjs_int count = 0;
+            clo.PropGet(0, TJS_W("count"), NULL, &v, NULL);
+            count = v;
+
+            CallStack.clear();
+
+            for (tjs_int i = 0; i < count; i++)
+            {
+                ttstr Storage;
+                ttstr Label;
+                tjs_int Offset;
+                ttstr OrgLineStr;
+                ttstr LineBuffer;
+                tjs_int Pos;
+                bool LineBufferUsing;
+                tjs_uint MacroArgStackBase;
+                tjs_uint MacroArgStackDepth;
+                tjs_int ExcludeLevel;
+                tjs_int IfLevel;
+                std::vector<tjs_int> ExcludeLevelStack;
+                std::vector<bool> IfLevelExecutedStack;
+
+                tTJSVariant val;
+
+                clo.PropGetByNum(0, i, &v, NULL);
+                tTJSVariantClosure dic = v.AsObjectClosureNoAddRef();
+                dic.PropGet(0, TJS_W("storage"), NULL, &val, NULL);
+                Storage = val;
+                dic.PropGet(0, TJS_W("label"), NULL, &val, NULL);
+                Label = val;
+                dic.PropGet(0, TJS_W("offset"), NULL, &val, NULL);
+                Offset = val;
+                dic.PropGet(0, TJS_W("orgLineStr"), NULL, &val, NULL);
+                OrgLineStr = val;
+                dic.PropGet(0, TJS_W("lineBuffer"), NULL, &val, NULL);
+                LineBuffer = val;
+                dic.PropGet(0, TJS_W("pos"), NULL, &val, NULL);
+                Pos = val;
+                dic.PropGet(0, TJS_W("lineBufferUsing"), NULL, &val, NULL);
+                LineBufferUsing = 0 != (tjs_int)val;
+                dic.PropGet(0, TJS_W("macroArgStackBase"), NULL, &val, NULL);
+                MacroArgStackBase = (tjs_int)val;
+                dic.PropGet(0, TJS_W("macroArgStackDepth"), NULL, &val, NULL);
+                MacroArgStackDepth = (tjs_int)val;
+                dic.PropGet(0, TJS_W("ExcludeLevel"), NULL, &val, NULL);
+                ExcludeLevel = val;
+                dic.PropGet(0, TJS_W("IfLevel"), NULL, &val, NULL);
+                IfLevel = val;
+
+                ttstr stack_str;
+                dic.PropGet(0, TJS_W("ExcludeLevelStack"), NULL, &val, NULL);
+                stack_str = val;
+                RestoreIntStackFromStr(ExcludeLevelStack, stack_str);
+
+                dic.PropGet(0, TJS_W("IfLevelExecutedStack"), NULL, &val, NULL);
+                stack_str = val;
+                RestoreBoolStackFromStr(IfLevelExecutedStack, stack_str);
+
+                dic.PropGet(0, TJS_W("WhileStackDepth"), NULL, &val, NULL);
+                tjs_uint WhileStackDepth = tjs_int(val);
+
+                dic.PropGet(0, TJS_W("LocalVariablesCount"), NULL, &val, NULL);
+                tjs_int LocalVariablesCount = tjs_int(val);
+
+                CallStack.push_back(tCallStackData(
+                    Storage, Label, Offset, OrgLineStr, LineBuffer, Pos, LineBufferUsing,
+                    MacroArgStackBase, MacroArgStackDepth, ExcludeLevelStack, ExcludeLevel,
+                    IfLevelExecutedStack, IfLevel, WhileStackDepth, LocalVariablesCount));
+            }
+        }
+
+        // restore StorageName, StorageShortName, CurStorage, CurLabel
+        val.Clear();
+        dic->PropGet(0, TJS_W("storageName"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            StorageName = val;
+        val.Clear();
+        dic->PropGet(0, TJS_W("storageShortName"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            StorageShortName = val;
+        val.Clear();
+        dic->PropGet(0, TJS_W("curLabel"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            CurLabel = val;
+
+        // restore while stack
+        val.Clear();
+        dic->PropGet(0, TJS_W("whileStack"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+        {
+            tTJSVariantClosure clo = val.AsObjectClosureNoAddRef();
+            tTJSVariant v;
+            tjs_int count = 0;
+            clo.PropGet(0, TJS_W("count"), NULL, &v, NULL);
+            count = v;
+
+            WhileStack.clear();
+
+            for (tjs_int i = 0; i < count; i++)
+            {
+                ttstr Storage;
+                ttstr Label;
+                tjs_int Offset;
+                ttstr OrgLineStr;
+                ttstr LineBuffer;
+                tjs_int Pos;
+                bool LineBufferUsing;
+                tjs_int ExcludeLevel;
+                tjs_int IfLevel;
+                ttstr WhileLevelExp;
+                ttstr WhileLevelEach;
+
+                tTJSVariant val;
+
+                clo.PropGetByNum(0, i, &v, NULL);
+                tTJSVariantClosure dic = v.AsObjectClosureNoAddRef();
+                dic.PropGet(0, TJS_W("storage"), NULL, &val, NULL);
+                Storage = val;
+                dic.PropGet(0, TJS_W("label"), NULL, &val, NULL);
+                Label = val;
+                dic.PropGet(0, TJS_W("offset"), NULL, &val, NULL);
+                Offset = val;
+                dic.PropGet(0, TJS_W("orgLineStr"), NULL, &val, NULL);
+                OrgLineStr = val;
+                dic.PropGet(0, TJS_W("lineBuffer"), NULL, &val, NULL);
+                LineBuffer = val;
+                dic.PropGet(0, TJS_W("pos"), NULL, &val, NULL);
+                Pos = val;
+                dic.PropGet(0, TJS_W("lineBufferUsing"), NULL, &val, NULL);
+                LineBufferUsing = 0 != (tjs_int)val;
+                dic.PropGet(0, TJS_W("ExcludeLevel"), NULL, &val, NULL);
+                ExcludeLevel = val;
+                dic.PropGet(0, TJS_W("IfLevel"), NULL, &val, NULL);
+                IfLevel = val;
+
+                dic.PropGet(0, TJS_W("WhileLevelExp"), NULL, &val, NULL);
+                WhileLevelExp = val;
+                dic.PropGet(0, TJS_W("WhileLevelEach"), NULL, &val, NULL);
+                WhileLevelEach = val;
+
+                WhileStack.push_back(tWhileStackData(Storage, Label, Offset, OrgLineStr, LineBuffer,
+                                                     Pos, LineBufferUsing, ExcludeLevel, IfLevel,
+                                                     WhileLevelExp, WhileLevelEach));
+            }
+        }
+        val.Clear();
+        dic->PropGet(0, TJS_W("WhileLevelExp"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            WhileLevelExp = (ttstr)val;
+        val.Clear();
+        dic->PropGet(0, TJS_W("WhileLevelEach"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            WhileLevelEach = (ttstr)val;
+
+        // load scenario
+        ttstr storage = StorageName, label = CurLabel;
+        ClearBuffer(); // ensure re-loading the scenario
+        LoadScenario(storage);
+        GoToLabel(label);
+
+        // KAICHO added: restore IgnoreCR, see tTJSNI_ExtKAGParser::Store()
+        // for more details and reasons to add this
+        val.Clear();
+        dic->PropGet(0, TJS_W("IgnoreCR"), NULL, &val, dic);
+        IgnoreCR = int(val) ? true : false; // to avoid compiler warning
+
+        // restore EnableNP, FuzzyReturn, ReturnErrorStorage
+        val.Clear();
+        dic->PropGet(0, TJS_W("EnableNP"), NULL, &val, dic);
+        EnableNP = int(val) ? true : false; // to avoid compiler warning
+        // Note: FussyReturn is not restored
+        // val.Clear();
+        // dic->PropGet(0, TJS_W("FuzzyReturn"), NULL, &val, dic);
+        // FuzzyReturn = int(val) ? true : false; // to avoid compiler warning
+        // Note: ReturnErrorStorage is not restored
+        // val.Clear();
+        // dic->PropGet(0, TJS_W("ReturnErrorStorage"), NULL, &val, dic);
+        // ReturnErrorStorage = val;
+
+        // ExcludeLevel, IfLevel
+        val.Clear();
+        dic->PropGet(0, TJS_W("ExcludeLevel"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            ExcludeLevel = (tjs_int)val;
+        val.Clear();
+        dic->PropGet(0, TJS_W("IfLevel"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            IfLevel = (tjs_int)val;
+
+        // ExcludeLevelStack, IfLevelExecutedStack
+        val.Clear();
+        dic->PropGet(0, TJS_W("ExcludeLevelStack"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+        {
+            ttstr stack_str;
+            stack_str = val;
+            RestoreIntStackFromStr(ExcludeLevelStack, stack_str);
+        }
+
+        val.Clear();
+        dic->PropGet(0, TJS_W("IfLevelExecutedStack"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+        {
+            ttstr stack_str;
+            stack_str = val;
+            RestoreBoolStackFromStr(IfLevelExecutedStack, stack_str);
+        }
+
+        // restore MacroArgStackBase
+        val.Clear();
+        dic->PropGet(0, TJS_W("macroArgStackBase"), NULL, &val, dic);
+        if (val.Type() != tvtVoid)
+            MacroArgStackBase = (tjs_uint)(tjs_int)val;
+    }
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::LoadScenario(const ttstr& name)
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: KAGParser::LoadScenario(") + name + TJS_W(")"));
+
+    // load scenario to buffer
+
+    BreakConditionAndMacro();
+
+    if (StorageName == name)
+    {
+        // avoid re-loading
+        Rewind();
+    }
+    else
+    {
+        ClearBuffer();
+
+        // fire onScenarioLoad
+        tTJSVariant param = name;
+        tTJSVariant* pparam = &param;
+        tTJSVariant result;
+        static ttstr funcname(TJSMapGlobalStringMap(TJS_W("onScenarioLoad")));
+        tjs_error status =
+            Owner->FuncCall(0, funcname.c_str(), funcname.GetHint(), &result, 1, &pparam, Owner);
+
+        if (status == TJS_S_OK && result.Type() == tvtString)
+        {
+            // when onScenarioLoad returns string;
+            // assumes the string is scenario
+            Scenario = TVPGetScenario(ttstr(result), true);
+        }
+        else
+        {
+            // else load from file
+            Scenario = TVPGetScenario(name, false);
+        }
+
+        Lines = Scenario->GetLines();
+        LineCount = Scenario->GetLineCount();
+
+        Rewind();
+
+        StorageName = name;
+        StorageShortName = TVPExtractStorageName(name);
+
+        if (DebugLevel >= tkdlSimple)
+        {
+            static ttstr hr(TJS_W("========================================")
+                                TJS_W("========================================"));
+            TVPAddLog(hr);
+            TVPAddLog(TJS_W("Scenario loaded : ") + name);
+        }
+    }
+
+    if (Owner)
+    {
+        tTJSVariant param = StorageName;
+        tTJSVariant* pparam = &param;
+        static ttstr funcname(TJSMapGlobalStringMap(TJS_W("onScenarioLoaded")));
+        Owner->FuncCall(0, funcname.c_str(), funcname.GetHint(), NULL, 1, &pparam, Owner);
+    }
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::Clear()
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: KAGParser::Clear()"));
+    // clear all states
+    ExtTVPClearScnearioCache(); // also invalidates the scenario cache
+    ClearBuffer();
+    ClearMacroArgs();
+    ClearCallStack();
+    ClearWhileStack();
+    ClearLocalVariables();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::ClearBuffer()
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: KAGParser::ClearBuffer()"));
+    // clear internal buffer
+    BreakConditionAndMacro();
+    // BreakConditionAndMacro() should be before Scenario = NULL,
+    // as Scenario is referenced in PopWhileStack();
+    // however it has been checked in the func. This is a "double check".
+    if (Scenario)
+        Scenario->Release(), Scenario = NULL, Lines = NULL, CurLineStr = NULL;
+    StorageName.Clear();
+    StorageShortName.Clear();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::Rewind()
+{
+    // set current position to first
+    CurLine = 0;
+    CurPos = 0;
+    CurLineStr = Lines[0].Start;
+    LineBufferUsing = false;
+    BreakConditionAndMacro();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::BreakConditionAndMacro()
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: BreakConditionAndMacro()"));
+
+    // pop LocalVariables to the top level of the senario
+    PopLocalVariablesBeforeTheLatestCallStack();
+
+    // pop WhileStack to the top level of the senerio
+    ClearWhileStackToTheLatestCallStack();
+    // BreakCondition means that it will begin to run new senario
+    // (could be called), need to clear WhileLevel* also.
+    WhileLevelExp = TJS_W("");
+    WhileLevelEach = TJS_W("");
+
+    // break condition state and macro recording
+    RecordingMacro = false;
+    ExcludeLevel = -1;
+    ExcludeLevelStack.clear();
+    IfLevelExecutedStack.clear();
+    IfLevel = 0;
+    PopMacroArgsTo(MacroArgStackBase);
+    // clear macro argument down to current base stack position
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::GoToLabel(const ttstr& name)
+{
+    // search label and set current position
+    // parameter "name" must start with '*'
+    if (name.IsEmpty())
+        return;
+
+    Scenario->EnsureLabelCache();
+
+    tExtTVPScenarioCacheItem::tLabelCacheData* newline;
+
+    newline = Scenario->GetLabelCache().Find(name);
+
+    if (newline)
+    {
+        // found the label in cache
+        const tjs_char* vl;
+        vl = TJS_strchr(Lines[newline->Line].Start, TJS_W('|'));
+
+        CurLabel = Scenario->GetLabelAliasFromLine(newline->Line);
+        if (vl)
+            CurPage = vl + 1;
+        else
+            CurPage.Clear();
+        CurLine = newline->Line;
+        CurPos = 0;
+        LineBufferUsing = false;
+    }
+    else
+    {
+        // not found
+        TVPThrowExceptionMessage(TVPExtKAGLabelNotFound, StorageName, name);
+    }
+
+    if (DebugLevel >= tkdlSimple)
+    {
+        static ttstr hr(TJS_W("- - - - - - - - - - - - - - - - - - - - ")
+                            TJS_W("- - - - - - - - - - - - - - - - - - - - "));
+        TVPAddLog(hr);
+        TVPAddLog(StorageShortName + TJS_W(" : jumped to : ") + name);
+    }
+
+    BreakConditionAndMacro();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::GoToStorageAndLabel(const ttstr& storage, const ttstr& label)
+{
+    // This is added for further strong check
+    if (storage.IsEmpty() && label.IsEmpty())
+        TVPThrowExceptionMessage(TVPExtNoStorageAndLabelAtJump);
+
+    if (!storage.IsEmpty())
+        LoadScenario(storage);
+    if (!label.IsEmpty())
+        GoToLabel(label);
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::CallLabel(const ttstr& name)
+{
+    // for extra conductor or so
+    tTJSDic tmp;
+    PushCallStack(tTJSVariant(false), tmp);
+    GoToLabel(name);
+}
+//---------------------------------------------------------------------------
+bool tTJSNI_ExtKAGParser::SkipCommentOrLabel()
+{
+    // skip comment or label, and go to next line.
+    // fire OnScript event if [script] thru [endscript] ( or @script thru
+    // @endscript ) is found.
+    Scenario->EnsureLabelCache();
+
+    CurPos = 0;
+    if (CurLine >= LineCount)
+        return false;
+    for (; CurLine < LineCount; CurLine++)
+    {
+        if (!Lines)
+            return false; // in this loop, Lines can be NULL when onScript does so.
+
+        const tjs_char* p = Lines[CurLine].Start;
+
+        if (p[0] == TJS_W(';'))
+            continue; // comment
+
+        if (p[0] == TJS_W('*'))
+        {
+            // label
+            if (RecordingMacro)
+                TVPThrowExceptionMessage(TVPExtLabelInMacro);
+            // check IfLevel, whether the label is placed in
+            // [if][ignore][while] scope
+            if (IfLevel > 0)
+                TVPThrowExceptionMessage(TVPExtKAGLabelInConditionScope, p);
+            // check whether the label is in LocalVariables scope
+            if ((CallStack.empty() && LocalVariables.GetSize() != 1) ||
+                (!CallStack.empty() &&
+                 LocalVariables.GetSize() != CallStack.back().LocalVariablesCount))
+                TVPThrowExceptionMessage(TVPExtKAGLabelInConditionScope, p);
+
+            tjs_char* vl = TJS_strchr(const_cast<tjs_char*>(p), TJS_W('|'));
+            bool pagename;
+            if (vl)
+            {
+                CurLabel = Scenario->GetLabelAliasFromLine(CurLine);
+                CurPage = ttstr(vl + 1);
+                pagename = true;
+            }
+            else
+            {
+                CurLabel = Scenario->GetLabelAliasFromLine(CurLine);
+                CurPage.Clear();
+                pagename = false;
+            }
+
+            // fire onLabel callback event
+            if (Owner)
+            {
+                tTJSVariant param[2];
+                param[0] = CurLabel;
+                if (pagename)
+                    param[1] = CurPage;
+                tTJSVariant* pparam[2] = {param, param + 1};
+                static ttstr onLabel_name(TJSMapGlobalStringMap(TJS_W("onLabel")));
+                Owner->FuncCall(0, onLabel_name.c_str(), onLabel_name.GetHint(), NULL, 2, pparam,
+                                Owner);
+            }
+
+            continue;
+        }
+
+        if (p[0] == TJS_W('[') &&
+                (!TJS_strcmp(p, TJS_W("[iscript]")) || !TJS_strcmp(p, TJS_W("[iscript]\\"))) ||
+            p[0] == TJS_W('@') && (!TJS_strcmp(p, TJS_W("@iscript"))))
+        {
+            // inline TJS script
+            ttstr script;
+            CurLine++;
+
+            tjs_int script_start = CurLine;
+
+            for (; CurLine < LineCount; CurLine++)
+            {
+                p = Lines[CurLine].Start;
+                if (p[0] == TJS_W('[') && (!TJS_strcmp(p, TJS_W("[endscript]")) ||
+                                           !TJS_strcmp(p, TJS_W("[endscript]\\"))) ||
+                    p[0] == TJS_W('@') && (!TJS_strcmp(p, TJS_W("@endscript"))))
+                {
+                    break;
+                }
+
+                if (RecordingMacro)
+                { // in [macro]-[endmacro] tag
+                    // generate escaped(with '`') string onto "script"
+                    // for passing to [eval]
+                    while (*p)
+                    {
+                        if (*p == TJS_W('`') || *p == TJS_W('\''))
+                            script += TJS_W('`');
+                        script += *p++;
+                    }
+                    script += TJS_W("`\r`\n");
+                }
+                else if (NeedToDoThisTag())
+                {
+                    script += p;
+                    script += TJS_W("\r\n");
+                }
+            }
+
+            if (CurLine == LineCount)
+                TVPThrowExceptionMessage(TVPExtKAGInlineScriptNotEnd);
+
+            if (RecordingMacro)
+            {
+                // if this is in macro, transrate it to [eval exp=...]
+                LineBuffer = TJS_W("[eval exp='") + script + TJS_W("']");
+                LineBufferUsing = true;
+                CurLineStr = LineBuffer.c_str();
+                return true;
+            }
+            else if (NeedToDoThisTag())
+            {
+                // fire onScript callback event
+                if (Owner)
+                {
+                    tTJSVariant param[3] = {script, StorageShortName, script_start};
+                    tTJSVariant* pparam[3] = {param, param + 1, param + 2};
+                    static ttstr onScript_name(TJSMapGlobalStringMap(TJS_W("onScript")));
+                    Owner->FuncCall(0, onScript_name.c_str(), onScript_name.GetHint(), NULL, 3,
+                                    pparam, Owner);
+                }
+            }
+
+            continue;
+        }
+
+        break;
+    }
+
+    if (CurLine >= LineCount)
+        return false;
+
+    CurLineStr = Lines[CurLine].Start;
+    LineBufferUsing = false;
+
+    if (DebugLevel >= tkdlVerbose)
+    {
+        TVPAddLog(StorageShortName + TJS_W(" : ") + CurLineStr);
+    }
+
+    return true;
+}
+//---------------------------------------------------------------------------
+ttstr tTJSNI_ExtKAGParser::GetTagName(const tjs_char ldelim)
+{
+    SkipWhiteSpace();
+    if (IsEndOfLine() || GetCurChar() == ldelim)
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError, TJS_W("タグ名が取得できません"),
+                                 TVPCurPosErrorString);
+
+    const tjs_char* tagnamestart = CurLineStr + CurPos;
+    while (!IsEndOfLine() && !IsWhiteSpace(GetCurChar()) && GetCurChar() != ldelim)
+        CurPos++;
+
+    if (tagnamestart == CurLineStr + CurPos)
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError, TJS_W("タグ名が指定されていません"),
+                                 TVPCurPosErrorString);
+
+    const tjs_char* tagnameend = CurLineStr + CurPos;
+
+    ttstr tagname(tagnamestart, tagnameend - tagnamestart);
+    tagname.ToLowerCase();
+
+    // now attribname is the attribution name, as "attr1" in [tagname attr1=value1]
+    return tagname;
+}
+//---------------------------------------------------------------------------
+ttstr tTJSNI_ExtKAGParser::GetAttributeName(const tjs_char ldelim)
+{
+    SkipWhiteSpace();
+    if (IsEndOfLine() || GetCurChar() == ldelim)
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError, TJS_W("タグの属性名が取得できません"),
+                                 TVPCurPosErrorString);
+
+    const tjs_char* attribnamestart = CurLineStr + CurPos;
+    while (!IsEndOfLine() && !IsWhiteSpace(GetCurChar()) && GetCurChar() != TJS_W('=') &&
+           GetCurChar() != ldelim)
+        CurPos++;
+
+    const tjs_char* attribnameend = CurLineStr + CurPos;
+
+    ttstr attribname(attribnamestart, attribnameend - attribnamestart);
+    attribname.ToLowerCase();
+
+    // now attribname is the attribution name, as "attr1" in [tagname attr1=value1]
+    return attribname;
+}
+//---------------------------------------------------------------------------
+ttstr tTJSNI_ExtKAGParser::GetAttributeValue(const tjs_char ldelim)
+{
+    // now The CurPos is on the next to '=' of "[tagname attrib=value]"
+    // pick up the value string from the tag string onto "ttstr value"
+    SkipWhiteSpace();
+    if (IsEndOfLine() || GetCurChar() == ldelim)
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError, TJS_W("タグの属性値が取得できません"),
+                                 TVPCurPosErrorString);
+
+    // attribute value which will be returned
+    ttstr value(TJS_W(""));
+
+    tjs_char ch;
+
+    if ((ch = GetCurChar()) == TJS_W('&'))
+    {
+        value += ch;
+        CurPos++; // for expression &"abc def"
+        ch = GetCurChar();
+    }
+
+    tjs_char vdelim = 0; // value delimiter
+
+    if (ch == TJS_W('\"') || ch == TJS_W('\''))
+    {
+        vdelim = GetCurChar();
+        CurPos++;
+    }
+
+    while ((ch = GetCurChar()) && // <- !IsEndOfLine()
+           (vdelim ? ch != vdelim : (ch != ldelim && !IsWhiteSpace(ch))))
+    {
+        if (ch == TJS_W('`'))
+        {
+            // escaped with '`'
+            CurPos++;
+            if (IsEndOfLine())
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                         TJS_W("'`'(バッククォート)直後が行末です"),
+                                         TVPCurPosErrorString);
+            ch = GetCurChar();
+        }
+        value += ch;
+        CurPos++;
+    }
+    if ((ldelim != 0 || (vdelim && GetCurChar() != vdelim)) && IsEndOfLine())
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                 TJS_W("属性値が無いか、\' や \" の対応が間違っています"),
+                                 TVPCurPosErrorString);
+
+    if (vdelim)
+        CurPos++;
+
+    value.FixLen();
+
+    // return attribute value string and now CurPos is in the next to "attrib=value"
+    return value;
+}
+
+//---------------------------------------------------------------------------
+inline ttstr& tTJSNI_ExtKAGParser::InsertStringOntoLineBuffer(tjs_int startpos,
+                                                              const ttstr& insertstr,
+                                                              tjs_int replacesiz)
+{
+    ttstr firststr = ttstr(CurLineStr, startpos);
+    ttstr laststr = ttstr(CurLineStr + startpos + replacesiz);
+    LineBuffer = firststr + insertstr + laststr;
+    LineBufferUsing = true;
+    CurLineStr = LineBuffer.c_str();
+    return LineBuffer;
+}
+
+#if 0  /* unused */
+// escape valuestring with '`'
+inline ttstr tTJSNI_ExtKAGParser::EscapeValueString(const ttstr &valuestr)
+{
+	const tjs_char *p = valuestr.c_str();
+
+	if (TJS_strchr(p, TJS_W(' '))  == NULL &&
+		TJS_strchr(p, TJS_W('\t')) == NULL &&
+		TJS_strchr(p, TJS_W('`'))  == NULL)
+		return valuestr;
+
+	ttstr ret;
+	tjs_char ch;
+	while ((ch = *p++) != 0)
+	{
+		if (ch == TJS_W('`')  || ch == TJS_W(' ') || ch == TJS_W('\t'))
+			ret += TJS_W('`');
+		ret += ch;
+	}
+	return ret;
+}
+
+// unescape valuestring with '`'
+inline ttstr tTJSNI_ExtKAGParser::UnEscapeValueString(const ttstr &valuestr)
+{
+	const tjs_char *p = valuestr.c_str();
+
+	if (TJS_strchr(p, TJS_W('`')) == NULL)
+		return valuestr;
+
+	tjs_char ch;
+	ttstr ret;
+	while ((ch = *p++) != 0)
+	{
+		if (ch == TJS_W('`'))
+			ch = *p++;
+		ret += ch;
+	}
+	return ret;
+}
+#endif /* unused */
+
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PushMacroArgs(tTJSDic& args)
+{
+    if (MacroArgs.size() > MacroArgStackDepth)
+        MacroArgs[MacroArgStackDepth]->Assign(args);
+    else
+    {
+        if (MacroArgStackDepth > MacroArgs.size())
+            TVPThrowInternalError;
+        tTJSDic* newdic = new tTJSDic(args);
+        MacroArgs.push_back(newdic);
+    }
+    MacroArgStackDepth++;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PopMacroArgs()
+{
+    if (MacroArgStackDepth == 0)
+        TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                 TJS_W("マクロスタックが空のため、PopMacroArg() が実行できません"),
+                                 TVPCurPosErrorString);
+    MacroArgStackDepth--;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::ClearMacroArgs()
+{
+    for (std::vector<tTJSDic*>::iterator i = MacroArgs.begin(); i != MacroArgs.end(); i++)
+    {
+        delete *i;
+    }
+    MacroArgs.clear();
+    MacroArgStackDepth = 0;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PopMacroArgsTo(tjs_uint base)
+{
+    MacroArgStackDepth = base;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::FindNearestLabel(tjs_int start, tjs_int& labelline, ttstr& labelname)
+{
+    // find nearest label which be pleced before "start".
+    // "labelline" is to be the label's line number (0-based), and
+    // "labelname" is to be its label name.
+    // "labelline" will be -1 and "labelname" be empty if the label is not found.
+    Scenario->EnsureLabelCache();
+
+    bool out_of_iscript = true;
+    for (start--; start >= 0; start--)
+    {
+        const tjs_char* p = Lines[start].Start;
+        // check whether the label is in [iscript] range
+        if (p[0] == TJS_W('[') &&
+                (!TJS_strcmp(p, TJS_W("[endscript]")) || !TJS_strcmp(p, TJS_W("[endscript]\\"))) ||
+            p[0] == TJS_W('@') && (!TJS_strcmp(p, TJS_W("@endscript"))))
+        {
+            out_of_iscript = false;
+            continue;
+        }
+        if (p[0] == TJS_W('[') &&
+                (!TJS_strcmp(p, TJS_W("[iscript]")) || !TJS_strcmp(p, TJS_W("[iscript]\\"))) ||
+            p[0] == TJS_W('@') && (!TJS_strcmp(p, TJS_W("@iscript"))))
+        {
+            out_of_iscript = true;
+            continue;
+        }
+
+        if (out_of_iscript && p[0] == TJS_W('*'))
+        {
+            // label found
+            labelname = Scenario->GetLabelAliasFromLine(start);
+            break;
+        }
+    }
+    labelline = start;
+    if (labelline == -1)
+        labelname.Clear();
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PushCallStack(const tTJSVariant& copyvar, tTJSDic& DicObj)
+{
+    // push current position information
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PushCallStack()"));
+        TVPAddLog(StorageShortName + TJS_W(" : call stack depth before calling : ") +
+                  ttstr((int)CallStack.size()));
+    }
+
+    tjs_int labelline;
+    ttstr labelname;
+    FindNearestLabel(CurLine, labelline, labelname);
+    if (labelline < 0)
+        labelline = 0;
+
+    const tjs_char* curline_content;
+    if (Lines && CurLine < LineCount)
+        curline_content = Lines[CurLine].Start;
+    else
+        curline_content = TJS_W("");
+
+    // whilestack/localvariables must be pushed *before* saving
+    // callstack.
+    PushWhileStack();
+    PushLocalVariables(copyvar, DicObj);
+
+    CallStack.push_back(tCallStackData(
+        StorageName, labelname, CurLine - labelline, curline_content, LineBuffer, CurPos,
+        LineBufferUsing, MacroArgStackBase, MacroArgStackDepth, ExcludeLevelStack, ExcludeLevel,
+        IfLevelExecutedStack, IfLevel, WhileStack.size(), LocalVariables.GetSize()));
+    MacroArgStackBase = MacroArgStackDepth;
+}
+//---------------------------------------------------------------------------
+// This is called by PopCallStack() only,
+// return true if it could [return] to the call source
+// return false if it could NOT [return] to there.
+bool tTJSNI_ExtKAGParser::CanReturn(const tCallStackData& data)
+{
+    if (CurLine == LineCount || (CurLine < LineCount && data.OrgLineStr == Lines[CurLine].Start))
+        // this is normal case, could [return]
+        return true;
+
+    // following is abnormal case, there are changes on source script
+    // after [call] and before [return].
+
+    if (!FuzzyReturn)
+        return false;
+
+    // if FuzzyReturn is enabled,
+    // search whether the call source exists between +-10 lines.
+    // At first, check the 10 lines *after* CurLine, as a senario could be
+    // increased in most cases.
+    for (tjs_int i = 1; i <= 10; i++)
+    {
+        // Note: CurLine+i == LineCount can not be checked
+        if (CurLine + i < LineCount && data.OrgLineStr == Lines[CurLine + i].Start)
+        {
+            CurLine += i;
+            return true; // found the call source at CurLine+i
+        }
+    }
+    // Then next, check the 10 lines *before* CurLine.
+    for (tjs_int i = 1; i <= 10; i++)
+    {
+        if (CurLine - i >= 0 && data.OrgLineStr == Lines[CurLine - i].Start)
+        {
+            CurLine -= i;
+            return true; // found the call source at CurLine-i
+        }
+    }
+
+    // could not find call source
+    return false;
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PopCallStack(const ttstr& storage, const ttstr& label)
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: PopCallStack(storage=") + storage + TJS_W(", label=") + label +
+                  TJS_W(")"));
+
+    // check call stack
+    if (CallStack.empty())
+        TVPThrowExceptionMessage(TVPExtKAGCallStackUnderflow);
+
+    // get current call stack data
+    tCallStackData& data = CallStack.back();
+
+    // pop macro argument information
+    MacroArgStackBase = data.MacroArgStackDepth; // later reset to MacroArgStackBase
+    PopMacroArgsTo(data.MacroArgStackDepth);
+
+    // get back local variables to previous one,
+    // as the "call subroutine" will be exited.
+    PopLocalVariablesBeforeTheLatestCallStack();
+    // take back WhileStack before the [call]
+    ClearWhileStackToTheLatestCallStack();
+    // Note: whilestack/localvariables are necessary
+    // to be popped one more later to the correct place
+
+    // goto label or previous position
+    if (!storage.IsEmpty() || !label.IsEmpty())
+    {
+        // return to specified position
+        GoToStorageAndLabel(storage, label);
+    }
+    else
+    {
+        // return to previous calling position
+        LoadScenario(data.Storage);
+        if (!data.Label.IsEmpty())
+            GoToLabel(data.Label);
+        CurLine += data.Offset;
+
+        if (!CanReturn(data))
+        {
+            // if we can NOT [return] as the data.Storage was changed
+            if (ReturnErrorStorage.IsEmpty() || ReturnErrorStorage == TJS_W(""))
+                TVPThrowExceptionMessage(TVPExtKAGReturnLostSync);
+
+            // run ReturnErrorStorage immediately
+            LoadScenario(ReturnErrorStorage);
+            return;
+        }
+
+        if (data.LineBufferUsing)
+        {
+            LineBuffer = data.LineBuffer;
+            CurLineStr = LineBuffer.c_str();
+            LineBufferUsing = true;
+        }
+        else
+        {
+            if (CurLine < LineCount)
+            {
+                CurLineStr = Lines[CurLine].Start;
+                LineBufferUsing = false;
+            }
+        }
+        CurPos = data.Pos;
+
+        ExcludeLevelStack = data.ExcludeLevelStack;
+        ExcludeLevel = data.ExcludeLevel;
+        IfLevelExecutedStack = data.IfLevelExecutedStack;
+        IfLevel = data.IfLevel;
+
+        if (DebugLevel >= tkdlSimple)
+        {
+            ttstr label;
+            if (data.Label.IsEmpty())
+                label = TJS_W("(start)");
+            else
+                label = data.Label;
+            TVPAddLog(StorageShortName + TJS_W(" : returned to : ") + label +
+                      TJS_W(" line offset ") + ttstr(data.Offset));
+        }
+    }
+
+    // reset MacroArgStackBase
+    MacroArgStackBase = data.MacroArgStackBase;
+
+    // pop call stack
+    CallStack.pop_back();
+
+    // These "pop" belows must be here because LoadScenario()
+    // above invokes BreakConditionAndMacro() which breaks
+    // while state.
+    // pop while stack after pop_call_stack
+    PopWhileStack(false /*=loop_again*/);
+    // pop local variables after pop_call_stack
+    PopLocalVariables();
+
+    if (!storage.IsEmpty() || !label.IsEmpty())
+    {
+        // if return position is specified, we need to
+        // clear whilestack/localvariablesstack here.
+        BreakConditionAndMacro();
+        // this considers the case below:
+        // [while exp=1]
+        //     [call target=*label1]
+        // [endwhile]
+        // *label2
+        // [s]
+        //
+        // *label1
+        // [return target=*label2]
+    }
+
+    // call function back
+    if (Owner)
+    {
+        static ttstr onAfterReturn_name(TJS_W("onAfterReturn"));
+        Owner->FuncCall(0, onAfterReturn_name.c_str(), onAfterReturn_name.GetHint(), NULL, 0, NULL,
+                        Owner);
+    }
+
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(StorageShortName + TJS_W(" : call stack depth after returning : ") +
+                  ttstr((int)CallStack.size()));
+    }
+}
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::PushWhileStack()
+{
+    // just only for debugging
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PushWhileStack()"));
+        TVPAddLog(StorageShortName + TJS_W(" : while stack depth before PushWhileStack() : " +
+                                           ttstr((int)WhileStack.size())));
+    }
+
+    tjs_int labelline;
+    ttstr labelname;
+    FindNearestLabel(CurLine, labelline, labelname);
+    if (labelline < 0)
+        labelline = 0;
+
+    const tjs_char* curline_content;
+    if (Lines && CurLine < LineCount)
+        curline_content = Lines[CurLine].Start;
+    else
+        curline_content = TJS_W("");
+
+    WhileStack.push_back(tWhileStackData(StorageName, labelname, CurLine - labelline,
+                                         curline_content, LineBuffer, CurPos, LineBufferUsing,
+                                         ExcludeLevel, IfLevel, WhileLevelExp, WhileLevelEach));
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(StorageShortName + TJS_W(" : while stack depth after PushWhileStack() : ") +
+                  ttstr((int)WhileStack.size()));
+}
+
+// pop while stack information
+void tTJSNI_ExtKAGParser::PopWhileStack(const bool& loop_again)
+{
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PopWhileStack(") + ttstr(loop_again) + TJS_W(")"));
+        TVPAddLog(StorageShortName + TJS_W(" : while stack depth before PopWhileStack() : " +
+                                           ttstr((int)WhileStack.size())));
+    }
+
+    if (WhileStack.empty() ||
+        (!CallStack.empty() && CallStack.back().WhileStackDepth >= WhileStack.size()))
+        TVPThrowExceptionMessage(TVPExtKAGWhileStackUnderflow);
+
+    // pop macro argument information
+    const tWhileStackData& data = WhileStack.back();
+
+    if (loop_again && Scenario != NULL)
+    // Note: Scenario should be checked as it could be NULL when this is called from ClearBuffer().
+    {
+        // return to previous [while] position
+        if (data.Label.IsEmpty())
+        {
+            // Do not call Rewind() to avoid infinite loop of
+            // BreakConditionAndMacro() -> PopWhileStack()
+            CurLine = 0;
+        }
+        else
+        {
+            tExtTVPScenarioCacheItem::tLabelCacheData* newline;
+            if (!(newline = Scenario->GetLabelCache().Find(data.Label)))
+                TVPThrowExceptionMessage(TVPExtKAGLabelNotFound, StorageName, data.Label);
+            CurLine = newline->Line;
+        }
+        CurLine += data.Offset;
+
+        if (CurLine > LineCount)
+            TVPThrowExceptionMessage(TVPExtKAGWhileStackUnderflow);
+        /* CurLine == LineCount is OK (at end of file) */
+
+        if (CurLine < LineCount)
+            if (data.OrgLineStr != Lines[CurLine].Start) // check original line information
+                TVPThrowExceptionMessage(TVPExtKAGWhileLostSync);
+        if (data.LineBufferUsing)
+        {
+            LineBuffer = data.LineBuffer;
+            CurLineStr = LineBuffer.c_str();
+            LineBufferUsing = true;
+        }
+        else
+        {
+            if (CurLine < LineCount)
+            {
+                CurLineStr = Lines[CurLine].Start;
+                LineBufferUsing = false;
+            }
+        }
+        CurPos = data.Pos;
+    }
+
+    IfLevel = data.IfLevel;
+    ExcludeLevel = data.ExcludeLevel;
+
+    WhileLevelExp = data.WhileLevelExp;
+    WhileLevelEach = data.WhileLevelEach;
+
+    // pop while stack
+    WhileStack.pop_back();
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(StorageShortName + TJS_W(" : while stack depth after PopWhileStack() : ") +
+                  ttstr((int)WhileStack.size()));
+}
+
+void tTJSNI_ExtKAGParser::WhileStackControlForEndwhile(const bool& loop_again)
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: WhileStackControlForEndwhile(") + ttstr(loop_again) +
+                  TJS_W(")"));
+
+    if (loop_again)
+    { // continue the loop
+        // back to just after [while], with saving current
+        // WhileLevelExp and WhileLevelEach
+        ttstr exp = WhileLevelExp, each = WhileLevelEach;
+        PopWhileStack(true /*=loop_again*/);
+        PushWhileStack();
+        WhileLevelExp = exp, WhileLevelEach = each;
+        IfLevel++;
+    }
+    else
+    { // exit the loop
+        // Note: this must be at the end of [endmacro] to exit while
+        // loop and goto next line. otherwise, consider calling this
+        // func with loop_again=true and set ExcludeIfLevel=IfLevel
+        // to skip next loop
+        PopWhileStack(false /*=loop_exit*/);
+    }
+}
+
+void tTJSNI_ExtKAGParser::ClearWhileStack()
+{
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("Invoking: ClearWhileStack()"));
+
+    // WhileLevel* are cleared
+    WhileStack.clear();
+    WhileLevelExp = TJS_W("");
+    WhileLevelEach = TJS_W("");
+}
+
+void tTJSNI_ExtKAGParser::ClearWhileStackToTheLatestCallStack()
+{
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: ClearWhileStackToTheLatestCallStack()"));
+        TVPAddLog(StorageShortName +
+                  TJS_W(" : while stack depth before ClearWhileStackToTheLatestCallStack() : " +
+                        ttstr((int)WhileStack.size())));
+    }
+
+    if (CallStack.empty())
+    {
+        ClearWhileStack();
+        if (DebugLevel > tkdlVerbose)
+            TVPAddLog(StorageShortName +
+                      TJS_W(" : while stack depth after ClearWhileStackToTheLatestCallStack() : " +
+                            ttstr((int)WhileStack.size())));
+        return;
+    }
+
+    tjs_uint depth = CallStack.back().WhileStackDepth;
+
+    // This check must be omitted, in case this is called
+    // from LoadScenario(), after PopWhileStack() in PopCallStack().
+    if (depth > (tjs_int)WhileStack.size())
+    {
+        TVPThrowExceptionMessage(TJS_W("WhileStack: saveddepth = %1, size = %2"),
+                                 ttstr((tjs_int)depth), WhileStack.size());
+        // TVPThrowExceptionMessage(TVPInternalError, __FILE__, __LINE__);
+    }
+
+    // WhileStack.resize() is not used since it needs constructor "WhileStack(void)",
+    for (tjs_uint i = WhileStack.size(); i > depth; i--)
+        PopWhileStack(false);
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(StorageShortName +
+                  TJS_W(" : while stack depth after ClearWhileStackToTheLatestCallStack() : " +
+                        ttstr((int)WhileStack.size())));
+}
+
+void tTJSNI_ExtKAGParser::PushLocalVariables(const tTJSVariant& copyvar, tTJSDic& dicobj)
+{
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PushLocalVariables()"));
+        TVPAddLog(TJS_W("LocalVariables stack depth beforer PushLocalVariables() = ") +
+                  ttstr(LocalVariables.GetSize()));
+    }
+
+    // This is invoked by [call] and [localvar]tag.
+    // This creates new local variables in this scope by copying current
+    // one or creating new one, switched by "copyvar" parameter in the tags.
+
+    if (copyvar.Type() == tvtVoid)
+    {
+        tTJSDic tmp;
+        LocalVariables.Push(tmp); // push new one
+    }
+    else
+    {
+        tTJSVariant v;
+        SWITCH_TVPEXECUTEEXPRESSION(ttstr(copyvar), Owner, &v);
+        if (v.operator bool())
+        {
+            tTJSVariant tmpV = LocalVariables.GetLast();
+            tTJSDic tmp(tmpV);
+            LocalVariables.Push(tmp); // push copyed one
+        }
+        else
+        {
+            tTJSDic tmp;
+            LocalVariables.Push(tmp); // push new one
+        }
+    }
+
+    CopyDicToCurrentLocalVariables(dicobj);
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("LocalVariables stack depth after PushLocalVariables() = ") +
+                  ttstr(LocalVariables.GetSize()));
+}
+
+void tTJSNI_ExtKAGParser::PopLocalVariables()
+{
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PopLocalVariables()"));
+        TVPAddLog(TJS_W("LocalVariables stack depth before PopLocalVariables() = ") +
+                  ttstr(LocalVariables.GetSize()));
+    }
+
+    if (LocalVariables.GetSize() == 0 ||
+        (!CallStack.empty() && CallStack.back().LocalVariablesCount >= LocalVariables.GetSize()))
+        TVPThrowExceptionMessage(TVPExtLocalVaiablesUnderFlow);
+
+    LocalVariables.Pop();
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(TJS_W("LocalVariables stack depth after PopLocalVariables() = ") +
+                  ttstr(LocalVariables.GetSize()));
+}
+
+void tTJSNI_ExtKAGParser::PopLocalVariablesBeforeTheLatestCallStack()
+{
+    if (DebugLevel > tkdlVerbose)
+    {
+        TVPAddLog(TJS_W("Invoking: PopLocalVariablesBeforeTheLatestCallStack()"));
+        TVPAddLog(TJS_W("LocalVariables stack depth before "
+                        "PopLocalVariablesBeforeTheLatestCallStack() = ") +
+                  ttstr(LocalVariables.GetSize()));
+    }
+
+    // if CallStack.empty(), it will go back to 1, as the
+    // top level of LocalVariables ary is 1.
+    tjs_int count = 1;
+
+    if (!CallStack.empty())
+        count = CallStack.back().LocalVariablesCount;
+
+    // This check must be omitted, in case this is called
+    // from LoadScenario(), after PopWhileStack() in PopCallStack().
+    if (count > LocalVariables.GetSize())
+    {
+        TVPThrowExceptionMessage(TJS_W("LocalVariables: savedsize = %1, size = %2"),
+                                 ttstr((tjs_int)count), LocalVariables.GetSize());
+        // TVPThrowExceptionMessage(TVPInternalError, __FILE__, __LINE__);
+    }
+
+    for (tjs_int i = LocalVariables.GetSize(); i > count; i--)
+        PopLocalVariables();
+
+    if (DebugLevel > tkdlVerbose)
+        TVPAddLog(
+            TJS_W(
+                "LocalVariables stack depth after PopLocalVariablesBeforeTheLatestCallStack() = ") +
+            ttstr(LocalVariables.GetSize()));
+}
+
+void tTJSNI_ExtKAGParser::CopyDicToCurrentLocalVariables(tTJSDic& dic)
+{
+    // Note:this includes tagname, sometimes also storage/target.
+    // What to do here is "LocalVariables.GetLast().AddDic(dicobj);",
+    // isn't this a bad coding to convert instance from tTJSVariant to tTJSDic?
+    tTJSVariant tmp = LocalVariables.GetLast();
+    ((tTJSDic*)&tmp)->AddDic(dic);
+}
+
+//---------------------------------------------------------------------------
+// followings are for multiline extention
+
+// add Lines[CurLine] to CurLineStr, and set LineBufferUsint=true;
+// CurPos is now on '\' in CurLineStr
+void tTJSNI_ExtKAGParser::AddMultiLine()
+{
+    ttstr newbuf;
+    tjs_int curlen =
+        CurPos; // CurPos is now on '\\'. So, to exclude '\\', this is not "CurPos-1" but "CurPos"
+    tjs_int newlen = curlen + Lines[CurLine].Length;
+    tjs_char* d = newbuf.AllocBuffer(newlen + 1);
+    TJS_strncpy(d, CurLineStr, curlen); // ignore the last '\\'
+    TJS_strcpy(d + curlen, Lines[CurLine].Start);
+    newbuf.FixLen();
+    LineBuffer = newbuf;
+    CurLineStr = LineBuffer.c_str();
+    LineBufferUsing = true;
+}
+
+//---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::ClearCallStack()
+{
+    CallStack.clear();
+    PopMacroArgsTo(MacroArgStackBase = 0); // macro arguments are also cleared
+
+    // Clearing whilestack/localvariables in this function
+    // would be a bad conding but this is necessary for
+    // script compatibility.
+    // Because most TJS scripts call clearCallStack() as
+    // meaning of clearing all data on the parser before
+    // running new KAG script.
+    ClearWhileStack();
+    ClearLocalVariables();
+}
+//---------------------------------------------------------------------------
+iTJSDispatch2* tTJSNI_ExtKAGParser::_GetNextTag()
+{
+    // get next tag and return information dictionary object.
+    // return NULL if the tag not found.
+    // normal characters are interpreted as a "ch" tag.
+    // CR code is interpreted as a "r" tag.
+    // tag paremeters are stored into return value(DicObj).
+    // tag name is also stored into return value(DicObj), as a "tagname" tag.
+
+    // pretty a nasty code.
+
+    static ttstr __tag_name(TJSMapGlobalStringMap(TJS_W("tagname")));
+    static ttstr __eol_name(TJSMapGlobalStringMap(TJS_W("eol")));
+    static ttstr __storage_name(TJSMapGlobalStringMap(TJS_W("storage")));
+    static ttstr __target_name(TJSMapGlobalStringMap(TJS_W("target")));
+    static ttstr __exp_name(TJSMapGlobalStringMap(TJS_W("exp")));
+    static ttstr __name(TJSMapGlobalStringMap(TJS_W("name")));
+
+    while (true)
+    {
+    parse_start:
+        // start tag analyzing
+        // "continue" (== parse_start) in this while lopp means read next tag/char
+        // from the tag begining.
+        // "continue" is O.K. but "goto parse_start" can be used in this function
+        // for more readable code, since this function is really long.
+
+        // clear dictionary object at first
+        DicObj.Empty();
+
+        if (Interrupted)
+        {
+            // interrupt current parsing
+            // return as "interrupted" tag
+            static tTJSVariant r_val(TJS_W("interrupt"));
+            DicObj.SetProp(__tag_name, r_val);
+            Interrupted = false;
+            return DicObj.GetDic(); // We need AddRef() here
+        }
+
+        if (!Lines || CurLine >= LineCount)
+            return NULL; // all of scenario was decoded
+
+        if (!LineBufferUsing && CurPos == 0) // If this is pure new line
+        {
+            if (!SkipCommentOrLabel()) // this also processes [iscript]-[endscript], and set
+                                       // CurLineStr
+                return NULL;
+        }
+
+        SkipTab(); // skipping '\t', which is meeningless in KAG script
+
+        if (IsEndOfLine()) // if now on the end of the line
+        {
+            if (IgnoreCR)
+            {
+                GoToNextLine();
+                continue;
+            }
+
+            // Followings are for the case IgnoreCR=false
+
+            if (CurPos >= 3 && TJS_strcmp(&(CurLineStr[CurPos - 3]), TJS_W("[p]")) == 0)
+            {
+                // if !IgnoreCR and the line ends with "[p]"
+                // then do nothing and go to next line
+                GoToNextLine();
+                continue;
+            }
+
+            // this must be here
+            GoToNextLine();
+
+            if (EnableNP && CurLine < LineCount && IsEndOfLine())
+            {
+                // if EnableNP and appears "\n\n", then insert "[np]".
+                // No need to set LineBuffer with Lines[CurLine], since
+                // now Lines[CurLine] == "" and LineBufferUsing = false,
+                LineBufferUsing = true;
+                LineBuffer = TJS_W("[np]\\");
+                CurLineStr = LineBuffer.c_str();
+
+                // if this is in macro, this will be added to RecordingMacroStr
+                // in the next loop, necessary as "[np]" is a macro.
+                continue;
+            }
+
+            if (RecordingMacro)
+            {
+                // insert [r eol=true]
+                RecordingMacroStr += TJS_W("[r eol=true]");
+                continue;
+            }
+
+            if (NeedToDoThisTag())
+            {
+                static tTJSVariant r_val(TJS_W("r"));
+                static tTJSVariant true_val(TJS_W("true"));
+                DicObj.SetProp(__tag_name, r_val);
+                DicObj.SetProp(__eol_name, true_val);
+                return DicObj.GetDic(); // We need AddRef() here
+            }
+            continue;
+        }
+
+        // if (!IgnoreCR) and here is at the end of line with '\'
+        if (!IgnoreCR && GetCurChar() == TJS_W('\\') && IsEndOfLine(+1))
+        {
+            // go to next line without adding "[r eol=true]"
+            GoToNextLine();
+            continue;
+        }
+
+        tjs_int tagstartpos = CurPos;
+        tjs_char ldelim; // last delimiter
+                         // is 0 if the tag begins with '@', is ']' if it begins with '['
+
+        if (!LineBufferUsing && CurPos == 0 && GetCurChar() == TJS_W('@'))
+        // need to check LineBufferUsing/CurPos for the case "str@not_tag"
+        // and [emb exp="'@abc'"] on the top of the line.
+        {
+            // line command mode (@tag mode)
+            ldelim = 0; // tag last delimiter is a null terminater
+        }
+        else if (GetCurChar() == TJS_W('[') && GetCurChar(+1) != TJS_W('['))
+        {
+            // brace command mode ([tag] mode)
+            ldelim = TJS_W(']'); // tag last delimiter is a ']'
+        }
+        else
+        {
+            // normal character
+            const tjs_char* chstart = CurLineStr + CurPos;
+            int chLen = utf16_char_len(CurLineStr + CurPos);
+            CurPos += chLen;
+
+            if (chLen == 1 && chstart[0] == TJS_W('['))
+                CurPos++; // If '[' then the next char must be skipped as it is '['
+
+            if (RecordingMacro)
+            { // if record tag
+                RecordingMacroStr += ttstr(chstart, chLen);
+                if (chLen == 1 && chstart[0] == TJS_W('['))
+                    RecordingMacroStr += ttstr(chstart, chLen);
+                continue;
+            }
+
+            if (NeedToDoThisTag())
+            {
+                static tTJSVariant tag_val(TJS_W("ch"));
+                DicObj.SetProp(__tag_name, tag_val);
+                tTJSVariant ch_val(ttstr(chstart, chLen));
+                static ttstr text_name(TJSMapGlobalStringMap(TJS_W("text")));
+                DicObj.SetProp(text_name, ch_val);
+
+                return DicObj.GetDic(); // We need AddRef() here
+            }
+
+            continue; // same as "goto parse_start"
+        } // end of processing normal character
+
+        CurPos++;
+
+        // ********************************************************************
+        // a tag analysis below:
+        // CurPos is now on "[(here:CurPos)tagname attr=val]"
+
+        bool condition = true; // = result of "cond=###" in the tag
+        ttstr tagname;         // will be "tagname" in [tagname arg1=val1]
+
+        // get tagname
+        SkipWhiteSpace();
+        if (GetCurChar() != TJS_W('&'))
+            tagname = GetTagName(ldelim); // for normal tagname
+        else
+            tagname = GetAttributeValue(ldelim); // for [&embval]
+
+        // register tagname into DicObj as "tagname" => tagname
+        tTJSVariant tmptag(tagname);
+        DicObj.SetProp(__tag_name, tmptag);
+
+        // check special control tags
+        enum tSpecialTags
+        {
+            tag_other,
+            tag_if,
+            tag_else,
+            tag_elsif,
+            tag_ignore,
+            tag_endif,
+            tag_endignore,
+            tag_emb,
+            tag_macro,
+            tag_endmacro,
+            tag_macropop,
+            tag_erasemacro,
+            tag_jump,
+            tag_call,
+            tag_return,
+            tag_while,
+            tag_endwhile,
+            tag_break,
+            tag_continue,
+            tag_spemb,
+            tag_localvar,
+            tag_pushlocalvar,
+            tag_poplocalvar,
+            tag_pmacro
+        } tagkind;
+        static bool tag_checker_init = false;
+        static tTJSHashTable<ttstr, tjs_int> special_tags_hash;
+        if (!tag_checker_init)
+        {
+            tag_checker_init = true;
+            special_tags_hash.Add(ttstr(TJS_W("if")), (tjs_int)tag_if);
+            special_tags_hash.Add(ttstr(TJS_W("ignore")), (tjs_int)tag_ignore);
+            special_tags_hash.Add(ttstr(TJS_W("endif")), (tjs_int)tag_endif);
+            special_tags_hash.Add(ttstr(TJS_W("endignore")), (tjs_int)tag_endignore);
+            special_tags_hash.Add(ttstr(TJS_W("else")), (tjs_int)tag_else);
+            special_tags_hash.Add(ttstr(TJS_W("elsif")), (tjs_int)tag_elsif);
+            special_tags_hash.Add(ttstr(TJS_W("emb")), (tjs_int)tag_emb);
+            special_tags_hash.Add(ttstr(TJS_W("macro")), (tjs_int)tag_macro);
+            special_tags_hash.Add(ttstr(TJS_W("endmacro")), (tjs_int)tag_endmacro);
+            special_tags_hash.Add(ttstr(TJS_W("macropop")), (tjs_int)tag_macropop);
+            special_tags_hash.Add(ttstr(TJS_W("erasemacro")), (tjs_int)tag_erasemacro);
+            special_tags_hash.Add(ttstr(TJS_W("jump")), (tjs_int)tag_jump);
+            special_tags_hash.Add(ttstr(TJS_W("call")), (tjs_int)tag_call);
+            special_tags_hash.Add(ttstr(TJS_W("return")), (tjs_int)tag_return);
+            special_tags_hash.Add(ttstr(TJS_W("while")), (tjs_int)tag_while);
+            special_tags_hash.Add(ttstr(TJS_W("endwhile")), (tjs_int)tag_endwhile);
+            special_tags_hash.Add(ttstr(TJS_W("break")), (tjs_int)tag_break);
+            special_tags_hash.Add(ttstr(TJS_W("continue")), (tjs_int)tag_continue);
+            special_tags_hash.Add(ttstr(TJS_W("localvar")), (tjs_int)tag_localvar);
+            special_tags_hash.Add(ttstr(TJS_W("pushlocalvar")), (tjs_int)tag_pushlocalvar);
+            special_tags_hash.Add(ttstr(TJS_W("poplocalvar")), (tjs_int)tag_poplocalvar);
+            special_tags_hash.Add(ttstr(TJS_W("pmacro")), (tjs_int)tag_pmacro);
+        }
+
+        // set tagkind
+        tagkind = tag_other;
+        if (ProcessSpecialTags) // if "do not ignore special tags"
+        {
+            if (tagname.StartsWith(TJS_W('&')))
+                tagkind = tag_spemb; // in case [&special_emb]
+            else
+            {
+                // in case normal tag [tagname attr=val]
+                tjs_int* tag = special_tags_hash.Find(tagname);
+                if (tag)
+                    tagkind = (tSpecialTags)*tag;
+            }
+        }
+
+        // This is used for bringing %1, %2, ... in Macro, which
+        // indicate 1st attribname, 2nd attribname...
+        std::vector<ttstr> MacroArgArray;
+        // Note: This does not write %0 as tagname
+
+        // ********************************************************************
+        // tag attributes analysis below:
+        // now CurPos is next to tagname, [tagname(here:CurPos) attr1=val1]
+        // This "while" repeats to read each attribution in the tag
+
+        while (true)
+        {
+            SkipWhiteSpace();
+
+            if (GetCurChar() == ldelim)
+            {
+                // exit this loop, now on the end of the tag
+                if (ldelim == TJS_W(']'))
+                    CurPos++;
+                break;
+            }
+            // TVPAddLog(TJS_W("CurLineStr = ") + ttstr(CurLineStr) + TJS_W(", CurPos = ") +
+            // ttstr(CurPos)); For Multiline tag which is separated by "\\\n", can NOT include
+            // comment lines. Generate CurLineStr as one line which is combined from multiline. ex:
+            //	   [tag arg1=abc \
+			//        arg2=def]
+            // is combined to:
+            //     [tag arg1=abc   arg2=def]
+            // Note: Any characters after '\' to the end of the line is ignored!
+            if (GetCurChar() == TJS_W('\\')) // check CurLineStr
+            {
+                if (!MultiLineTagEnabled)
+                    TVPThrowExceptionMessage(TVPExtKAGMultiLineDisabled);
+                // Do NOT invoke GoToNextLine() to avoid clearing CurLinStr/CurPos
+                if (++CurLine >= LineCount)
+                    TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                             TJS_W("複数行タグ(行末 \\)がスクリプト末尾にあります"),
+                                             TVPCurPosErrorString);
+                // combine multilines to CurLineStr with removing the
+                // last '\' of CurLineStr.
+                AddMultiLine();
+                continue; // try to read next attribute
+            }
+
+            if (IsEndOfLine())
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError, TJS_W("タグ途中で行末に達しました"),
+                                         TVPCurPosErrorString);
+
+            ttstr attribname(GetAttributeName(ldelim));
+            // now attribname is the attribution name, as "attr1" in [tagname attr1=value1]
+            // and CurLineStr[CurPos] is on the next to the "attr1"
+
+            // searching '='
+            SkipWhiteSpace();
+
+            ttstr value(TJS_W("true")); // def=true in case attr value is omitted
+            if (GetCurChar() == TJS_W('='))
+            {
+                CurPos++; // attr value is specified
+                value = GetAttributeValue(ldelim);
+            }
+            else
+            {
+                // Check Parameter Macros
+                // We check this here to reduce parser work load,
+                // as pmacro does not need anything after "=".
+                tTJSVariant v = ParamMacros[attribname];
+                // v should not be tTJSDic here, as it could be void and
+                // tTJSDic can not be void.
+                if (v.Type() != tvtVoid)
+                {
+                    tTJSDic d(v);
+                    DicObj.AddDic(d);
+                    // now DicObj includes ParamMacro[attribname]
+
+                    if (NumericMacroArgumentsEnabled)
+                    {
+                        // Copy keys onto MacroArgArray
+                        // FIXME: this does not show us the order of the keys
+                        tTJSAry keys(d.GetKeys());
+                        for (tjs_int i = 0; i < keys.GetSize(); i++)
+                            MacroArgArray.push_back(keys[i]);
+                    }
+
+                    continue; // try to read next attribute
+                }
+                // If parameter macros can not be found, go through down
+            }
+
+            // now value is attribute value string, occasionally including
+            // '&', '%' or '$' on its top.
+            // CurPos is on: ex.(at 1st loop) [tagname attr1=value1(here:CurPos) attr2=value2]
+
+            // if the attribname=value does not need to store onto DicObj,
+            // just skip the string and continue. "elsif" is the only tag
+            // which could change ExcludeLevel and has attributions
+            if (RecordingMacro || (!NeedToDoThisTag() && tagkind != tag_elsif))
+                continue; // try to read next attribute
+
+            // special attibute processing, "*", "&", macroarg "%", localval "$", "|" and cond=.
+            // process expression entity or macro argument
+
+            // check if attribname == '*'
+            if (attribname == TJS_W('*'))
+            {
+                // macro entity all
+                // assign macro arguments to current arguments
+                DicObj.AddDic(GetMacroTopNoAddRef());
+                // overwrite tag_name as marg includes caller's "tagname"
+                tTJSVariant tag_val(tagname);
+                DicObj.SetProp(__tag_name, tag_val);
+
+                continue; // try to read next attribute
+            }
+
+            tTJSVariant ValueVariant = value;
+
+            if (value.StartsWith(TJS_W('&')))
+            {
+                // if this is entity like: "&int(mp.arg)+1"
+                SWITCH_TVPEXECUTEEXPRESSION(value.c_str() + 1, Owner, &ValueVariant);
+                if (ValueVariant.Type() != tvtVoid)
+                    ValueVariant.ToString();
+            }
+            else if (value.StartsWith(TJS_W('%')))
+            {
+                // if this is macro argument like: "%arg" or "%arg|defval"
+                tTJSDic& args = GetMacroTopNoAddRef();
+
+                value = value.c_str() + 1;
+                tjs_char* vp = TJS_strchr(const_cast<tjs_char*>(value.c_str()), TJS_W('|'));
+
+                if (vp)
+                { // if this includes "|"
+                    ttstr name(value.c_str(), vp - value.c_str());
+                    ValueVariant = args[name];
+                    if (ValueVariant.Type() == tvtVoid)
+                        ValueVariant = ttstr(vp + 1);
+                }
+                else
+                { // if this does not include "|"
+                    ValueVariant = args[value];
+                }
+            }
+            else if (value.StartsWith(TJS_W('$')))
+            {
+                // if this is local value argument like: "$arg" or "$arg|defval"
+                tTJSVariant argV = LocalVariables.GetLast();
+                tTJSDic args(argV);
+
+                value = value.c_str() + 1;
+                tjs_char* vp = TJS_strchr(const_cast<tjs_char*>(value.c_str()), TJS_W('|'));
+
+                if (vp)
+                { // if this includes "|"
+                    ttstr name(value.c_str(), vp - value.c_str());
+                    ValueVariant = args[name];
+                    if (ValueVariant.Type() == tvtVoid)
+                        ValueVariant = ttstr(vp + 1);
+                }
+                else
+                { // if this does not include "|"
+                    ValueVariant = args[value];
+                }
+
+                // Cast to String, as this could be Integer or others.
+                if (ValueVariant.Type() != tvtVoid)
+                    ValueVariant.ToString();
+            }
+
+            if (attribname == TJS_W("cond"))
+            {
+                // condition
+                tTJSVariant val;
+                SWITCH_TVPEXECUTEEXPRESSION(ttstr(ValueVariant), Owner, &val);
+                condition = val.operator bool();
+                continue; // try to read next attribute
+            }
+
+            // store value into the dictionary object, "attribname => ValueVariant"
+            DicObj.SetProp(attribname, ValueVariant);
+
+            if (NumericMacroArgumentsEnabled && tagkind == tag_other)
+            {
+                // In case the tag is NOT internal one,
+                // set "#(number) => attribname" onto MacroArgArry
+                // for argument %1, %2... in macro.
+                // we can not check "ismacro" here, which is good
+                // enough to pass %#, because it has not been set
+                // and will be done on the end of the tag processing.
+                MacroArgArray.push_back(attribname);
+            }
+            // try to read next attribute
+
+        } // while loop reading tag attribution
+
+        // ********************************************************************
+        // now tag has ended:
+        // now CurPos is on the end of the tag, "[tagname arg=val](here:CurPos)"
+        // DO NOT goto next line, because we need to get the character number
+        // in case RecordingMacro==true by using variable "tagstartpos"
+
+        bool ismacro = false; // Actually, these variables should NOT be defined
+        ttstr macrocontent;   // here, see commented variable definitions below.
+
+        // record macro
+        // this must be in the case RecordingMacro==true except "[endmacro]",
+        // as endmacro changes RecordingMacro into false.
+        // Note "[endmacro cond=0]" is also considered.
+        if (RecordingMacro && (tagkind != tag_endmacro || !condition))
+        { // no need to check "NeedToDoThisTag()(ExcludeLevel == -1)", as RecordingMacro guarantees
+          // it
+            // add the macro string onto RecordingMacroStr with '[' and ']'
+            if (ldelim != 0)
+            {
+                // normal tag (=[tag])
+                RecordingMacroStr += ttstr(CurLineStr + tagstartpos, CurPos - tagstartpos);
+            }
+            else
+            {
+                // line command (=@tag)
+                RecordingMacroStr += TJS_W("[") +
+                                     ttstr(CurLineStr + tagstartpos + 1, CurPos - tagstartpos - 1) +
+                                     TJS_W("]");
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        // ********************************************************************
+        // At first, check if/ignore/elsif/else/while/endwhile here
+        // without checking NeedToDoThisTag(), as they could change
+        // exec status like ExcludeLevel/IfLevel, IfLevelExcludeStack and so on.
+
+        // if/ignore
+        if (tagkind == tag_if || tagkind == tag_ignore)
+        {
+            IfLevel++;
+            IfLevelExecutedStack.push_back(false);
+            ExcludeLevelStack.push_back(ExcludeLevel);
+
+            if (NeedToDoThisTag())
+            {
+                tTJSVariant val = DicObj[__exp_name];
+
+                if (ttstr(val) == TJS_W(""))
+                    TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                             TJS_W("if/ignore タグに exp= が指定されていません"),
+                                             TVPCurPosErrorString);
+                SWITCH_TVPEXECUTEEXPRESSION(val, Owner, &val);
+
+                bool cond = val.operator bool();
+                if (tagkind == tag_ignore)
+                    cond = !cond;
+
+                IfLevelExecutedStack.back() = cond;
+                if (!cond)
+                {
+                    ExcludeLevel = IfLevel;
+                }
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        // elsif
+        else if (tagkind == tag_elsif)
+        {
+            if (IfLevelExecutedStack.empty() || ExcludeLevelStack.empty() || IfLevel <= 0)
+            {
+                // no preceded if/ignore tag.
+                TVPThrowExceptionMessage(TVPExtKAGIfStackUnderflow);
+            }
+
+            if (IfLevelExecutedStack.back())
+            {
+                ExcludeLevel = IfLevel;
+            }
+            else if (IfLevel == ExcludeLevel)
+            {
+                tTJSVariant val = DicObj[__exp_name];
+                ttstr exp = val;
+
+                // const std::string s = exp.AsStdString();
+                if (exp == TJS_W(""))
+                    TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                             TJS_W("elsif タグの exp= が指定されていません"),
+                                             TVPCurPosErrorString);
+                SWITCH_TVPEXECUTEEXPRESSION(exp, Owner, &val);
+
+                bool cond = val.operator bool();
+                if (cond)
+                {
+                    IfLevelExecutedStack.back() = true;
+                    ExcludeLevel = -1;
+                }
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        // else
+        else if (tagkind == tag_else)
+        {
+            if (IfLevelExecutedStack.empty() || ExcludeLevelStack.empty() || IfLevel <= 0)
+            {
+                // too much [else]
+                TVPThrowExceptionMessage(TVPExtKAGIfStackUnderflow);
+            }
+
+            if (IfLevelExecutedStack.back())
+            {
+                ExcludeLevel = IfLevel;
+            }
+            else if (IfLevel == ExcludeLevel)
+            {
+                IfLevelExecutedStack.back() = true;
+                ExcludeLevel = -1;
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        // endif/endignore
+        else if (tagkind == tag_endif || tagkind == tag_endignore)
+        {
+            if (IfLevelExecutedStack.empty() || ExcludeLevelStack.empty() || IfLevel <= 0)
+            {
+                // too much [endif] or [endignore]
+                TVPThrowExceptionMessage(TVPExtKAGIfStackUnderflow);
+            }
+
+            ExcludeLevel = ExcludeLevelStack.back();
+            ExcludeLevelStack.pop_back();
+            IfLevelExecutedStack.pop_back();
+            IfLevel--;
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        // [while init= exp= each=]
+        else if (tagkind == tag_while)
+        {
+            // Note: To save correct place in PushWhileStack(),
+            // check ldelim and goto next line if necessary here.
+            if (ldelim == 0)
+                GoToNextLine();
+
+            // save the state just after [while], to back from [endwhile]
+            PushWhileStack();
+            IfLevel++;
+
+            if (NeedToDoThisTag())
+            {
+                // in case the [while] loop is necessary,
+                tTJSVariant val;
+
+                // run "init=" at first
+                ttstr init(DicObj[TJS_W("init")]);
+                if (init != TJS_W(""))
+                    SWITCH_TVPEXECUTEEXPRESSION(init, Owner, &val);
+
+                // read the "exp=" string for [endwhile] and [break]
+                WhileLevelExp = DicObj[__exp_name.c_str()];
+                if (WhileLevelExp == TJS_W(""))
+                    TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                             TJS_W("while タグに exp= が指定されていません"),
+                                             TVPCurPosErrorString);
+
+                // read the "each=" string for [endwhile]
+                WhileLevelEach = DicObj[TJS_W("each")];
+
+                // check "exp=" whether we need to do this while scope
+                SWITCH_TVPEXECUTEEXPRESSION(WhileLevelExp, Owner, &val);
+                bool cond = val.operator bool();
+                if (!cond)
+                    ExcludeLevel = IfLevel;
+            }
+
+            goto parse_start;
+            // Do not goto tag_last, as it has been on the next line if
+            // necessary, especially for this tag
+        }
+
+        // [endwhile]
+        // Note: This evaluates "exp=" and "each=" which were specified in [while]
+        else if (tagkind == tag_endwhile)
+        {
+            // if [endwhile] illegally appear, this notifies it
+            if (WhileStack.empty() || IfLevel - 1 != WhileStack.back().IfLevel)
+            {
+                if (!WhileStack.empty())
+                    TVPAddLog(TJS_W("IfLevel = ") + ttstr(IfLevel) + TJS_W(", saved = ") +
+                              ttstr(WhileStack.back().IfLevel));
+                TVPThrowExceptionMessage(TVPExtKAGWhileStackUnderflow);
+            }
+
+            bool cond = false;
+            // Checking NeedToDoThisTag() is necessary in case the cond was false
+            // at the 1st loop of [while] and another case handling [break].
+            if (NeedToDoThisTag())
+            { // in case the next [while] loop will be necessary,
+                tTJSVariant val;
+
+                // evaluate "each="
+                SWITCH_TVPEXECUTEEXPRESSION(WhileLevelEach, Owner, &val);
+
+                // check whether exp= is true (=cond), must be after
+                // executing "each=" expression.
+                SWITCH_TVPEXECUTEEXPRESSION(WhileLevelExp, Owner, &val);
+                cond = val.operator bool();
+            }
+
+            // cond is the flag which decides if the loop will be continued
+            // cond = true:  in case the loop should continue, same as [continue]
+            // cond = false: in case the loop should end
+            WhileStackControlForEndwhile(cond);
+
+            // if loop again, goto parse_start to go back to correct place
+            // as WhileStack saves it as next line of the @while tab
+            if (cond)
+                goto parse_start;
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        // ********************************************************************
+        // other tags (except if/elsif/else/endif/while/endwhile) should
+        // only be handled when "condition && NeedToDoThisTag()"
+
+        if (!condition || !NeedToDoThisTag())
+        {
+            // this tag can be skipped.
+            goto tag_last; // last check and go to next tag
+        }
+
+        // ********************************************************************
+        // After here, this tag is obviously necessary to be processed
+
+        // bool ismacro = false; // These variables should be defined here,
+        // ttstr macrocontent;   // but defined above to avoid silly compiler
+        // (vc2010 only?) errors...
+        {
+            // is the tagname macro ?
+            tTJSVariant macroval = Macros[tagname];
+            if (macroval.Type() != tvtVoid)
+            {
+                ismacro = true;
+                macrocontent = ttstr(macroval);
+            }
+        }
+
+        // tag-specific processing
+        if (tagkind == tag_other && !ismacro)
+        {
+            if (ldelim == 0)
+                GoToNextLine();     // do GoToNextLine before this return
+            return DicObj.GetDic(); // do AddRef()
+        }
+
+        else if (tagkind == tag_emb || tagkind == tag_spemb)
+        {
+            // embed string, in the case this is [emb exp=...] or [&...],
+            // insert emb string to current position
+
+            // execute expression
+            // generate LineBuffer with replacing [emb] in CurLineStr into its actual string
+            // ex:
+            // "[r][p][emb exp=tjsval][r][p]" -> "[r][p]tjsvalstring[r][p]"
+            // "[r][p][&tjsval][r][p]"        -> "[r][p]tjsvalstring[r][p]"
+            tTJSVariant val;
+            ttstr exp;
+            if (tagkind == tag_emb)
+            { // for default [emb], get string of "exp="
+                val = DicObj[__exp_name];
+                exp = val;
+            }
+            else // if (tag_epemb)
+            {    // for entity tag [&embval], get string of embval;
+                exp = tagname.c_str() + 1;
+            }
+            if (exp == TJS_W(""))
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                         TJS_W("emb/& タグに exp= が指定されていません"),
+                                         TVPCurPosErrorString);
+            SWITCH_TVPEXECUTEEXPRESSION(exp, Owner, &val);
+            exp = val;
+
+            // replace '[' into '[[' to avoid "recursive tag handling".
+            // ex. if [emb exp="'[p]'"]  is replaced to "[p]", then
+            // unlikely it could be handled as a [p] tag. To avoid this,
+            // [emb exp="'[p]'"] should be replaced to "[[p]"
+
+            const tjs_char* p = exp.c_str();
+            tjs_int r_count = 0;
+            while (*p)
+            {
+                if (*p == TJS_W('['))
+                    r_count++;
+                p++;
+                r_count++;
+            }
+
+            tjs_int curposlen = TJS_strlen(CurLineStr + CurPos);
+            tjs_int finallen = r_count + tagstartpos + curposlen;
+
+            if (ldelim == 0 && !IgnoreCR)
+                finallen++;
+
+            ttstr newbuf;
+
+            tjs_char* d = newbuf.AllocBuffer(finallen + 1);
+
+            TJS_strncpy(d, CurLineStr, tagstartpos);
+            d += tagstartpos;
+
+            // escape '['
+            p = exp.c_str();
+            while (*p)
+            {
+                if (*p == TJS_W('['))
+                {
+                    *d = TJS_W('[');
+                    d++;
+                    *d = TJS_W('[');
+                    d++;
+                }
+                else
+                {
+                    *d = *p;
+                    d++;
+                }
+                p++;
+            }
+
+            TJS_strcpy(d, CurLineStr + CurPos);
+
+            if (ldelim == 0 && !IgnoreCR)
+            {
+                d += curposlen;
+                *d = TJS_W('\\');
+                d++;
+                *d = 0;
+            }
+
+            newbuf.FixLen();
+            LineBuffer = newbuf;
+
+            CurLineStr = LineBuffer.c_str();
+            CurPos = tagstartpos;
+            LineBufferUsing = true;
+
+            goto parse_start; // start analyzing *THIS REPLACED* tag
+        }
+
+        else if (ismacro /* && tag_others is not needed to be checked here */)
+        { // in case this is invoking defined macro
+            // generate LineBuffer with replacing macro in CurLineStr
+            // into its actual string
+            // ex:
+            // "[r][p][macronam arg=val][r][p]" -> "[r][p][if exp="val"]a[endif][macropop][p][r]"
+            tjs_int maclen = macrocontent.GetLen();              // = strlen(macro string)
+            tjs_int curposlen = TJS_strlen(CurLineStr + CurPos); // = strlen(after the tag)
+            tjs_int finallen = tagstartpos + maclen + curposlen; // = strlen(replaced CurLineStr)
+
+            if (ldelim == 0 && !IgnoreCR)
+                finallen++;
+
+            ttstr newbuf;
+            tjs_char* d = newbuf.AllocBuffer(finallen + 1);
+
+            TJS_strncpy(d, CurLineStr, tagstartpos);
+            d += tagstartpos;
+            TJS_strcpy(d, macrocontent.c_str());
+            d += maclen;
+            TJS_strcpy(d, CurLineStr + CurPos);
+
+            if (ldelim == 0 && !IgnoreCR)
+            {
+                // if it is "@macro" and IgnoreCR=false, need to
+                // replace it into "[actual_macro_str]\" to avoid
+                // unexpected "return(=[r])" on EOL.
+                d += curposlen;
+                *d = TJS_W('\\');
+                d++;
+                *d = 0;
+            }
+
+            newbuf.FixLen();
+            LineBuffer = newbuf;
+
+            if (NumericMacroArgumentsEnabled)
+            {
+                // add macro argument %1, %2, %3... (=mp['1'], mp['2'], ...)
+                for (tjs_int i = 0; i < (int)MacroArgArray.size(); i++)
+                {
+                    ttstr index(i + 1);
+                    tTJSVariant argname(MacroArgArray.at(i));
+                    DicObj.SetProp(index.AsVariantStringNoAddRef(), argname);
+                }
+            }
+
+            // push macro arguments, will be "mp"
+            PushMacroArgs(DicObj);
+
+            CurLineStr = LineBuffer.c_str();
+            CurPos = tagstartpos;
+            LineBufferUsing = true;
+
+            goto parse_start; // start analyzing *THIS REPLACED* tag
+        }
+
+        else if (tagkind == tag_jump)
+        {
+            // jump tag
+            ttstr attrib_storage = DicObj[__storage_name];
+            ttstr attrib_target = DicObj[__target_name];
+
+            // fire onJump event
+            bool process = true;
+            if (Owner)
+            {
+                tTJSVariant param(DicObj);
+                tTJSVariant* pparam = &param;
+                static ttstr event_name(TJSMapGlobalStringMap(TJS_W("onJump")));
+                tTJSVariant res;
+                tjs_error er = Owner->FuncCall(0, event_name.c_str(), event_name.GetHint(), &res, 1,
+                                               &pparam, Owner);
+                if (er == TJS_S_OK)
+                    process = res.operator bool();
+            }
+
+            if (process)
+            {
+                // Adding "CopyDicToCurrentLocalVariables(DicObj);" here
+                // WAS a good idea for the feature to set and
+                // pass local variables on @jump tag, however now
+                // it does not work since @jump pop_back the local
+                // variables stack.
+
+                GoToStorageAndLabel(attrib_storage, attrib_target);
+                goto parse_start; // go to next tag
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_call)
+        {
+            // call tag
+            ttstr attrib_storage = DicObj[__storage_name];
+            ttstr attrib_target = DicObj[__target_name];
+
+            // fire onCall event
+            bool process = true;
+            if (Owner)
+            {
+                tTJSVariant param(DicObj);
+                tTJSVariant* pparam = &param;
+                static ttstr event_name(TJSMapGlobalStringMap(TJS_W("onCall")));
+                tTJSVariant res;
+                tjs_error er = Owner->FuncCall(0, event_name.c_str(), event_name.GetHint(), &res, 1,
+                                               &pparam, Owner);
+                if (er == TJS_S_OK)
+                    process = res.operator bool();
+            }
+
+            if (process)
+            {
+                // Note: To save correct place in PushCallStack(),
+                // check ldelim and goto next line if necessary here.
+                if (ldelim == 0)
+                    GoToNextLine();
+
+                // push call stack and goto subroutine
+                PushCallStack(DicObj[TJS_W("copyvar")], DicObj);
+                GoToStorageAndLabel(attrib_storage, attrib_target);
+                goto parse_start; // go to next tag
+            }
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_return)
+        {
+            // return tag
+            ttstr attrib_storage = DicObj[__storage_name];
+            ttstr attrib_target = DicObj[__target_name];
+
+            // fire onReturn event
+            bool process = true;
+            if (Owner)
+            {
+                tTJSVariant param(DicObj);
+                tTJSVariant* pparam = &param;
+                static ttstr event_name(TJSMapGlobalStringMap(TJS_W("onReturn")));
+                tTJSVariant res;
+                tjs_error er = Owner->FuncCall(0, event_name.c_str(), event_name.GetHint(), &res, 1,
+                                               &pparam, Owner);
+                if (er == TJS_S_OK)
+                    process = res.operator bool();
+            }
+
+            if (process)
+            {
+                PopCallStack(attrib_storage, attrib_target);
+                goto parse_start; // go to next tag
+            }
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        // [continue]
+        // similar to continuous case of [endwhile]
+        else if (tagkind == tag_continue)
+        {
+            // if [continue] illegally appear, this notifies it
+            if (WhileStack.empty() || IfLevel - 1 != WhileStack.back().IfLevel)
+            {
+                if (!WhileStack.empty())
+                    TVPAddLog(TJS_W("IfLevel = ") + ttstr(IfLevel) + TJS_W(", saved = ") +
+                              ttstr(WhileStack.back().IfLevel));
+                TVPThrowExceptionMessage(TVPExtKAGWhileStackUnderflow);
+            }
+
+            // back to just after [while]
+            WhileStackControlForEndwhile(true /*=loop_again*/);
+
+            tTJSVariant val;
+
+            // evaluate "each="
+            SWITCH_TVPEXECUTEEXPRESSION(WhileLevelEach, Owner, &val);
+
+            // check whether exp= is true (=cond), must be after
+            // executing "each=" expression.
+            SWITCH_TVPEXECUTEEXPRESSION(WhileLevelExp, Owner, &val);
+            bool cond = val.operator bool();
+
+            if (!cond)
+                ExcludeLevel = IfLevel; // next loop will be skipped
+
+            goto parse_start; // go to next tag
+        }
+
+        // [break]
+        // realized as [continue] and ExcludeLevel=IfLevel.
+        // This wastes a bit time since this brings
+        // "one more empty loop" after the [break],
+        // although so simple.
+        else if (tagkind == tag_break)
+        {
+            // if [break] illegally appear, this notifies it
+            if (WhileStack.empty() || IfLevel - 1 != WhileStack.back().IfLevel)
+            {
+                if (!WhileStack.empty())
+                    TVPAddLog(TJS_W("IfLevel = ") + ttstr(IfLevel) + TJS_W(", saved = ") +
+                              ttstr(WhileStack.back().IfLevel));
+                TVPThrowExceptionMessage(TVPExtKAGWhileStackUnderflow);
+            }
+
+            // back to just after [while] with ExcludeLevel != -1
+            WhileStackControlForEndwhile(true /*=loop_again*/);
+            ExcludeLevel = IfLevel; // next loop will be skipped
+
+            goto parse_start; // go to next tag
+        }
+
+        else if (tagkind == tag_macro)
+        {
+            // start recording macro
+            RecordingMacroName = DicObj[__name];
+            RecordingMacroName.ToLowerCase();
+            if (RecordingMacroName == TJS_W(""))
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                         TJS_W("macro タグに name= が指定されていません"),
+                                         TVPCurPosErrorString);
+            // missing macro name
+            RecordingMacro = true; // start recording macro
+            RecordingMacroStr.Clear();
+
+            // for initial argument for [macro]
+            // description ex: [macro name=abc attr1=val1 attr2=val2...]
+
+            tTJSAry ary(DicObj.GetKeys());
+            tjs_int count = ary.GetSize();
+            for (tjs_int i = 0; i < count; i++)
+            {
+                ttstr member_name = ary[i];
+                if (member_name == __tag_name || member_name == __name)
+                    continue;
+                ttstr member_value = DicObj[member_name];
+
+                // add [eval exp="mp.name='initial value'" cond=mp.name===void]
+                // onto the begining of the macro definitions.
+                // escape all single/double quotes
+                member_value.Replace(TJS_W("'"), TJS_W("\\'"));
+                member_value.Replace(TJS_W("\""), TJS_W("\\\""));
+                if ((member_name[0] & 0xff00) || !isdigit(member_name[0]))
+                {
+                    // If !isdigit(member_name), then try putting mp.member_name
+                    RecordingMacroStr += TJS_W("[eval exp=mp.") + member_name + TJS_W("='") +
+                                         member_value + TJS_W("'") + TJS_W(" cond=mp.") +
+                                         member_name + TJS_W("===void]");
+                }
+                else
+                {
+                    // If !isdigit(member_name), then try putting mp.member_name
+                    RecordingMacroStr += TJS_W("[eval exp=\"mp['") + member_name + TJS_W("']='") +
+                                         member_value + TJS_W("'\"") + TJS_W(" cond=\"mp['") +
+                                         member_name + TJS_W("']===void\"]");
+                }
+            }
+
+            goto tag_last; // last check and go to next tag
+        }
+        else if (tagkind == tag_endmacro)
+        {
+            // end recording macro
+            if (!RecordingMacro)
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                         TJS_W("macro タグなしに endmacro タグが使用されました"),
+                                         TVPCurPosErrorString);
+            RecordingMacro = false;
+            if (DebugLevel >= tkdlVerbose)
+            {
+                TVPAddLog(TJS_W("macro : ") + RecordingMacroName + TJS_W(" : ") +
+                          RecordingMacroStr);
+            }
+
+            RecordingMacroStr += TJS_W("[macropop]");
+            // ensure macro arguments are to be popped
+
+            // register macro
+            tTJSVariant tmp(RecordingMacroStr);
+            Macros.SetProp(RecordingMacroName, tmp);
+
+            goto tag_last; // last check and go to next tag
+        }
+        else if (tagkind == tag_macropop)
+        {
+            // pop macro arguments
+            PopMacroArgs();
+            goto tag_last; // last check and go to next tag
+        }
+        else if (tagkind == tag_erasemacro)
+        {
+            ttstr macroname = DicObj.GetProp(__name);
+            if (TJS_FAILED(Macros.DelProp(macroname)))
+                TVPThrowExceptionMessage(TVPExtUnknownMacroName, macroname);
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_pmacro)
+        {
+            // for [pmacro name=xxx arg1=#1 arg2=#2]
+            tTJSDic pmacrodic(DicObj);
+            tTJSVariant pmacroname = pmacrodic[__name];
+            if (pmacroname.Type() == tvtVoid)
+                TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                         TJS_W("pmacro タグに name= がありません"),
+                                         TVPCurPosErrorString);
+            pmacrodic.DelProp(__name);
+            pmacrodic.DelProp(__tag_name);
+            ParamMacros.SetProp(pmacroname.AsStringNoAddRef(), pmacrodic);
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_localvar)
+        {
+            CopyDicToCurrentLocalVariables(DicObj);
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_pushlocalvar)
+        {
+            // create new local variables in this scope
+            PushLocalVariables(DicObj[TJS_W("copyvar")], DicObj);
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        else if (tagkind == tag_poplocalvar)
+        {
+            PopLocalVariables();
+
+            goto tag_last; // last check and go to next tag
+        }
+
+        // no need to check "else" tags, as all of others have been checled above.
+        // But just for more strict error check...
+        else
+        {
+            TVPThrowExceptionMessage(TVPExtKAGSyntaxError,
+                                     TJS_W("未知のエラーです tagkind=") + ttstr(tagkind),
+                                     TVPCurPosErrorString);
+        }
+
+    tag_last:
+        // if this is @tag, goto next line as CurPos is now at the end of
+        //  the line: "@tag(here:CurPos)"
+        // IsEndOfLine() can not be used here because we need newline
+        // procedure in the next loop if (!ignoreCR && at_the_end_of("[tag]\0"))
+        if (ldelim == 0)
+            GoToNextLine();
+        // now go back to while loop top, same as "goto parse_start;"
+    } // while(true) for reading next tag/char
+
+    return NULL;
+}
+//---------------------------------------------------------------------------
+iTJSDispatch2* tTJSNI_ExtKAGParser::GetNextTag()
+{
+    return _GetNextTag();
+}
+//---------------------------------------------------------------------------
+tTJSDic& tTJSNI_ExtKAGParser::GetMacroTopNoAddRef() const
+{
+    if (MacroArgStackDepth == 0)
+        TVPThrowExceptionMessage(TVPKAGWrongAttrOutOfMacro);
+    return *MacroArgs[MacroArgStackDepth - 1];
+}
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// tTJSNC_KAGParser : KAGParser TJS native class
+//---------------------------------------------------------------------------
+tjs_uint32 tTJSNC_ExtKAGParser::ClassID = (tjs_uint32)-1;
+tTJSNC_ExtKAGParser::tTJSNC_ExtKAGParser()
+  : tTJSNativeClass(TJS_W("KAGParser")){
+
+        TJS_BEGIN_NATIVE_MEMBERS(KAGParser) TJS_DECL_EMPTY_FINALIZE_METHOD
+            //----------------------------------------------------------------------
+            // constructor/methods
+            //----------------------------------------------------------------------
+            TJS_BEGIN_NATIVE_CONSTRUCTOR_DECL(/*var.name*/ _this,
+                                              /*var.type*/ tTJSNI_ExtKAGParser,
+                                              /*TJS class name*/ KAGParser){return TJS_S_OK;
+}
+TJS_END_NATIVE_CONSTRUCTOR_DECL(/*TJS class name*/ KAGParser)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ loadScenario)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    if (numparams < 1)
+        return TJS_E_BADPARAMCOUNT;
+    _this->LoadScenario(*param[0]);
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ loadScenario)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ goToLabel)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    if (numparams < 1)
+        return TJS_E_BADPARAMCOUNT;
+    _this->GoToLabel(*param[0]);
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ goToLabel)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ callLabel)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    if (numparams < 1)
+        return TJS_E_BADPARAMCOUNT;
+    _this->CallLabel(*param[0]);
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ callLabel)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ getNextTag)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    //	if(numparams < 0) return TJS_E_BADPARAMCOUNT;
+    iTJSDispatch2* dsp = _this->GetNextTag();
+    if (dsp == NULL)
+    {
+        if (result)
+            result->Clear(); // return void ( not null )
+    }
+    else
+    {
+        if (result)
+            *result = tTJSVariant(dsp, dsp);
+        dsp->Release();
+    }
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ getNextTag)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ assign)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    if (numparams < 1)
+        return TJS_E_BADPARAMCOUNT;
+
+    tTJSNI_ExtKAGParser* src = NULL;
+    tTJSVariantClosure clo = param[0]->AsObjectClosureNoAddRef();
+    if (clo.Object)
+    {
+        if (TJS_FAILED(clo.Object->NativeInstanceSupport(TJS_NIS_GETINSTANCE, tTJSNC_ExtKAGParser::ClassID,
+                                                         (iTJSNativeInstance**)&src)))
+            TVPThrowExceptionMessage(TVPExtKAGSpecifyKAGParser);
+    }
+    else
+    {
+        TVPThrowExceptionMessage(TVPExtKAGSpecifyKAGParser);
+    }
+
+    _this->Assign(*src);
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ assign)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ clear)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    _this->Clear();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ clear)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ store)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    iTJSDispatch2* dsp = _this->Store();
+    if (result)
+        *result = tTJSVariant(dsp, dsp);
+    dsp->Release();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ store)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ restore)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    if (numparams < 1)
+        return TJS_E_BADPARAMCOUNT;
+    iTJSDispatch2* dsp = param[0]->AsObjectNoAddRef();
+
+    _this->Restore(dsp);
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ restore)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ clearCallStack)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    _this->ClearCallStack();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ clearCallStack)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ popMacroArgs) // undoc
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    _this->PopMacroArgs();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ popMacroArgs)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ interrupt)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    _this->Interrupt();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ interrupt)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_METHOD_DECL(/*func. name*/ resetInterrupt)
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+
+    _this->ResetInterrupt();
+
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_METHOD_DECL(/*func. name*/ resetInterrupt)
+//----------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+
+//----------------------------------------------------------------------
+// properties
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(curLine){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCurLine();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(curLine)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(curPos){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCurPos();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(curPos)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(curLineStr){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = ttstr(_this->GetCurLineStr());
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(curLineStr)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(processSpecialTags){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetProcessSpecialTags();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetProcessSpecialTags(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(processSpecialTags)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(ignoreCR){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetIgnoreCR();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetIgnoreCR(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(ignoreCR)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(debugLevel){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetDebugLevel();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetDebugLevel((tTVPKAGDebugLevel)(tjs_int)(*param));
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(debugLevel)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(enableNP){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetEnableNP();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetEnableNP(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(enableNP)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(fuzzyReturn){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetFuzzyReturn();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetFuzzyReturn(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(fuzzyReturn)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(returnErrorStorage){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetReturnErrorStorage();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetReturnErrorStorage(*param);
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(returnErrorStorage)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(macros){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+iTJSDispatch2* macros = _this->GetMacrosNoAddRef();
+*result = tTJSVariant(macros, macros);
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(macros)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(macroParams){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+iTJSDispatch2* params = _this->GetMacroTopNoAddRef().GetDicNoAddRef();
+*result = tTJSVariant(params, params);
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(macroParams)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(mp){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+iTJSDispatch2* params = _this->GetMacroTopNoAddRef().GetDicNoAddRef();
+*result = tTJSVariant(params, params);
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(mp)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(callStackDepth){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCallStackDepth();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(callStackDepth)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(curStorage){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetStorageName();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->LoadScenario(*param);
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(curStorage)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(curLabel){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCurLabel();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(curLabel)
+//---------------------------------------------------------------------------
+// For Multiline feature
+TJS_BEGIN_NATIVE_PROP_DECL(multiLineTagEnabled){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetMultiLineTagEnabled();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetMultiLineTagEnabled(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(multiLineTagEnabled)
+//---------------------------------------------------------------------------
+// For Numeric Macro Arguments
+TJS_BEGIN_NATIVE_PROP_DECL(numericMacroArgumentsEnabled){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = (tjs_int)_this->GetNumericMacroArgumentsEnabled();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_BEGIN_NATIVE_PROP_SETTER
+{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+    _this->SetNumericMacroArgumentsEnabled(param->operator bool());
+    return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(numericMacroArgumentsEnabled)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(currentLocalVariables){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCurrentLocalVariables();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(currentLocalVariables)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(lf){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetCurrentLocalVariables();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(lf)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(prelf){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetPreviousLocalVariables();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(prelf)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(pmacros){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetParamMacros();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(pmacros)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(ifLevel){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetIfLevel();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(ifLevel)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(whileStackDepth){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetWhileStackDepth();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(whileStackDepth)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(localVariablesDepth){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetLocalVariablesDepth();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(localVariablesDepth)
+//----------------------------------------------------------------------
+TJS_BEGIN_NATIVE_PROP_DECL(localVariables){TJS_BEGIN_NATIVE_PROP_GETTER{
+    TJS_GET_NATIVE_INSTANCE(/*var. name*/ _this, /*var. type*/ tTJSNI_ExtKAGParser);
+*result = _this->GetLocalVariables();
+return TJS_S_OK;
+}
+TJS_END_NATIVE_PROP_GETTER
+
+TJS_DENY_NATIVE_PROP_SETTER
+}
+TJS_END_NATIVE_PROP_DECL(localVariables)
+//----------------------------------------------------------------------
+
+TJS_END_NATIVE_MEMBERS
+}
+//---------------------------------------------------------------------------
+tTJSNativeInstance* tTJSNC_ExtKAGParser::CreateNativeInstance()
+{
+    return new tTJSNI_ExtKAGParser();
+}
+//---------------------------------------------------------------------------
+
+tTJSNativeClass* TVPCreateNativeClass_ExtKAGParser()
+{
+    return new tTJSNC_ExtKAGParser();
+}
+//---------------------------------------------------------------------------

--- a/cpp/plugins/extkagparser/ExtKAGParser.hpp
+++ b/cpp/plugins/extkagparser/ExtKAGParser.hpp
@@ -1,0 +1,435 @@
+//---------------------------------------------------------------------------
+/*
+	TVP2 ( T Visual Presenter 2 )  A script authoring tool
+	Copyright (C) 2000 W.Dee <dee@kikyou.info> and contributors
+
+	See details of license at "license.txt"
+*/
+//---------------------------------------------------------------------------
+// KAG Parser Utility Class
+//---------------------------------------------------------------------------
+
+#ifndef KAGParserH
+#define KAGParserH
+//---------------------------------------------------------------------------
+
+#include "ExttjsHashSearch.h"
+#include <vector>
+#include "TJSAry.h"
+#include "TJSDic.h"
+using namespace TJS;
+/*[*/
+//---------------------------------------------------------------------------
+// KAG Parser debug level
+//---------------------------------------------------------------------------
+enum tTVPKAGDebugLevel
+{
+	tkdlNone, // none is reported
+	tkdlSimple, // simple report
+	tkdlVerbose // complete report ( verbose )
+};
+/*]*/
+
+
+//---------------------------------------------------------------------------
+// tTVPCharHolder
+//---------------------------------------------------------------------------
+class tTVPCharHolder
+{
+	tjs_char *Buffer;
+	size_t BufferSize;
+public:
+	tTVPCharHolder() : Buffer(NULL), BufferSize(0)
+	{
+	}
+	~tTVPCharHolder()
+	{
+		Clear();
+	}
+
+	tTVPCharHolder(const tTVPCharHolder &ref) : Buffer(NULL), BufferSize(0)
+	{
+		operator =(ref);
+	}
+
+	void Clear()
+	{
+		if(Buffer) delete [] Buffer, Buffer = NULL;
+		BufferSize = 0;
+	}
+
+	void operator =(const tTVPCharHolder &ref)
+	{
+		Clear();
+		BufferSize = ref.BufferSize;
+		Buffer = new tjs_char[BufferSize];
+		memcpy(Buffer, ref.Buffer, BufferSize *sizeof(tjs_char));
+	}
+
+	void operator =(const tjs_char *ref)
+	{
+		Clear();
+		if(ref)
+		{
+			BufferSize = TJS_strlen(ref) + 1;
+			Buffer = new tjs_char[BufferSize];
+			memcpy(Buffer, ref, BufferSize*sizeof(tjs_char));
+		}
+	}
+
+	operator const tjs_char *() const
+	{
+		return Buffer;
+	}
+
+	operator tjs_char *()
+	{
+		return Buffer;
+	}
+};
+//---------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------
+// tTVPScenarioCacheItem : Scenario Cache Item
+//---------------------------------------------------------------------------
+class tExtTVPScenarioCacheItem
+{
+public:
+	struct tLine
+	{
+		const tjs_char *Start;
+		tjs_int Length;
+	};
+
+private:
+	tTVPCharHolder Buffer;
+	tLine *Lines;
+	tjs_int LineCount;
+
+public:
+	struct tLabelCacheData
+	{
+		tjs_int Line;
+		tjs_int Count;
+		tLabelCacheData(tjs_int line, tjs_int count)
+		{
+			Line = line;
+			Count = count;
+		}
+	};
+
+public:
+        typedef ExttTJSHashTable<ttstr, tLabelCacheData> tLabelCacheHash;
+private:
+	tLabelCacheHash LabelCache; // Label cache
+	std::vector<ttstr> LabelAliases;
+	bool LabelCached; // whether the label is cached
+
+	tjs_int RefCount;
+
+public:
+	tExtTVPScenarioCacheItem(const ttstr & name, bool istring);
+protected:
+	~tExtTVPScenarioCacheItem();
+public:
+	void AddRef();
+	void Release();
+private:
+	void LoadScenario(const ttstr & name, bool isstring);
+		// load file or string to buffer
+public:
+	const ttstr & GetLabelAliasFromLine(tjs_int line) const
+		{ return LabelAliases[line]; }
+	void EnsureLabelCache();
+
+	tLine * GetLines() const { return Lines; }
+	tjs_int GetLineCount() const { return LineCount; }
+	const tLabelCacheHash & GetLabelCache() const { return LabelCache; }
+};
+//---------------------------------------------------------------------------
+
+
+
+//---------------------------------------------------------------------------
+// tTJSNI_KAGParser
+//---------------------------------------------------------------------------
+class tTJSNI_ExtKAGParser : public tTJSNativeInstance
+{
+	typedef tTJSNativeInstance inherited;
+
+public:
+	tTJSNI_ExtKAGParser();
+	tjs_error Construct(tjs_int numparams, tTJSVariant **param,
+			iTJSDispatch2 *tjs_obj);
+	void Invalidate();
+
+private:
+	iTJSDispatch2 * Owner; // owner object
+
+	tTJSDic DicObj; // DictionaryObject
+
+	tTJSDic Macros; // Macro Dictionary Object
+	tTJSDic ParamMacros; // Parameter Macro Dictionary Object
+
+	std::vector<tTJSDic*> MacroArgs; // Macro arguments
+	tjs_uint MacroArgStackDepth;
+	tjs_uint MacroArgStackBase;
+
+	// ExtKAGParser: for local variables extention.
+	// can be accessed by "lf" from TJS, these variables
+	// are nested and be local one in if/while/call scope.
+	tTJSAry LocalVariables;
+
+	// ExtKagParser: for [while]/[endwhile] extention
+	ttstr WhileLevelExp;
+	ttstr WhileLevelEach;
+
+	struct tWhileStackData
+	{
+		ttstr Storage; // caller storage
+		ttstr Label; // caller nearest label
+		tjs_int Offset; // line offset from the label
+		ttstr OrgLineStr; // original line string
+		ttstr LineBuffer; // line string (if alive)
+		tjs_int Pos;
+		bool LineBufferUsing; // whether LineBuffer is used or not
+        tjs_int ExcludeLevel;
+        tjs_int IfLevel;
+		ttstr WhileLevelExp;
+		ttstr WhileLevelEach;
+
+		tWhileStackData(const ttstr &storage, const ttstr &label,
+			tjs_int offset, const ttstr &orglinestr, const ttstr &linebuffer,
+			tjs_int pos, bool linebufferusing,
+			tjs_int excludelevel, tjs_int iflevel,
+			const ttstr &whilelevelexp, const ttstr &whileleveleach) :
+			Storage(storage), Label(label), Offset(offset), OrgLineStr(orglinestr),
+			LineBuffer(linebuffer), Pos(pos), LineBufferUsing(linebufferusing),
+			ExcludeLevel(excludelevel), IfLevel(iflevel),
+			WhileLevelExp(whilelevelexp), WhileLevelEach(whileleveleach) {;}
+	};
+	std::vector<tWhileStackData> WhileStack;
+
+	struct tCallStackData
+	{
+		ttstr Storage; // caller storage
+		ttstr Label; // caller nearest label
+		tjs_int Offset; // line offset from the label
+		ttstr OrgLineStr; // original line string
+		ttstr LineBuffer; // line string (if alive)
+		tjs_int Pos;
+		bool LineBufferUsing; // whether LineBuffer is used or not
+		tjs_uint MacroArgStackBase;
+		tjs_uint MacroArgStackDepth;
+		std::vector<tjs_int> ExcludeLevelStack;
+		std::vector<bool> IfLevelExecutedStack;
+		tjs_int ExcludeLevel;
+		tjs_int IfLevel;
+
+		// ExtKAGParser extends
+		tjs_uint WhileStackDepth;
+		tjs_int  LocalVariablesCount;
+
+		tCallStackData(const ttstr &storage, const ttstr &label,
+			tjs_int offset, const ttstr &orglinestr, const ttstr &linebuffer,
+			tjs_int pos, bool linebufferusing, tjs_uint macroargstackbase,
+			tjs_uint macroargstackdepth,
+			const std::vector<tjs_int> &excludelevelstack, tjs_int excludelevel,
+			const std::vector<bool> &iflevelexecutedstack, tjs_int iflevel,
+			tjs_uint whilestackdepth,
+			tjs_int localvariablescount) :
+			Storage(storage), Label(label), Offset(offset), OrgLineStr(orglinestr),
+			LineBuffer(linebuffer), Pos(pos), LineBufferUsing(linebufferusing),
+			MacroArgStackBase(macroargstackbase),
+			MacroArgStackDepth(macroargstackdepth),
+			ExcludeLevelStack(excludelevelstack), ExcludeLevel(excludelevel),
+			IfLevelExecutedStack(iflevelexecutedstack), IfLevel(iflevel),
+			WhileStackDepth(whilestackdepth),
+			LocalVariablesCount(localvariablescount) {;}
+	};
+	std::vector<tCallStackData> CallStack;
+
+	tExtTVPScenarioCacheItem* Scenario;
+	tExtTVPScenarioCacheItem::tLine * Lines; // is copied from Scenario
+	tjs_int LineCount; // is copied from Scenario
+
+	ttstr StorageName;
+	ttstr StorageShortName;
+
+	tjs_int CurLine; // current processing line
+	tjs_int CurPos; // current processing position ( column )
+	const tjs_char *CurLineStr; // current line string
+	ttstr LineBuffer; // line buffer ( if any macro/emb was expanded )
+	bool LineBufferUsing;
+	ttstr CurLabel; // Current Label
+	ttstr CurPage; // Current Page Name
+
+	tTVPKAGDebugLevel DebugLevel; // debugging log level
+	bool ProcessSpecialTags; // whether to process special tags
+	bool IgnoreCR; // CR is not interpreted as [r] tag when this is true
+	bool RecordingMacro; // recording a macro
+	ttstr RecordingMacroStr; // recording macro content
+	ttstr RecordingMacroName; // recording macro's name
+
+	bool EnableNP; // macro [np] is called when IgnoreCR=true and "\n\n" exists
+	bool FuzzyReturn; // whether [return] can return before/after 10 lines even if the source script was changed
+	ttstr ReturnErrorStorage; // KAG script which is run when [return] fails
+
+	tjs_int ExcludeLevel;
+	tjs_int IfLevel;
+
+	std::vector<tjs_int> ExcludeLevelStack;
+	std::vector<bool> IfLevelExecutedStack;
+
+	bool Interrupted;
+
+	// ExtKAGParser extends
+	bool MultiLineTagEnabled;
+	bool NumericMacroArgumentsEnabled;
+
+public:
+        void operator=(const tTJSNI_ExtKAGParser& ref);
+	iTJSDispatch2 *Store();
+	void Restore(iTJSDispatch2 *dic);
+
+	void Clear(); // clear all states
+
+private:
+	void ClearBuffer(); // clear internal buffer
+
+	void Rewind(); // set current position to first
+	void inline GoToNextLine() { CurLine++; CurPos = 0; LineBufferUsing = false; }
+	void BreakConditionAndMacro(); // break condition state and macro expansion
+
+public:
+	void LoadScenario(const ttstr & name);
+	const ttstr & GetStorageName() const { return StorageName; }
+	void GoToLabel(const ttstr &name); // search label and set current position
+	void GoToStorageAndLabel(const ttstr &storage, const ttstr &label);
+	void CallLabel(const ttstr &name);
+private:
+	bool SkipCommentOrLabel(); // skip comment or label and go to next line
+	bool inline NeedToDoThisTag() { return (ExcludeLevel == -1); }
+	bool inline IsEndOfLine(tjs_int idx=0) { return (GetCurChar(idx) == 0); }
+	bool inline IsWhiteSpace(tjs_char ch) { return (ch == TJS_W(' ') || ch == TJS_W('\t')); } // is white space ?
+	void inline SkipWhiteSpace() { while(IsWhiteSpace(CurLineStr[CurPos]) && !IsEndOfLine()) CurPos++; } // skip white spece to delim
+	void inline SkipWhiteSpaceAndComma() { SkipWhiteSpace(); if (CurLineStr[CurPos] == TJS_W('\'')) CurPos++; SkipWhiteSpace(); };
+	void inline SkipTab() { while(CurLineStr[CurPos] == TJS_W('\t')) CurPos++; }
+	const tjs_char inline GetCurChar(tjs_int idx=0) { return CurLineStr[CurPos+idx]; }
+	ttstr GetTagName(const tjs_char ldelim);
+	ttstr GetAttributeName(const tjs_char ldelim);
+	ttstr GetAttributeValue(const tjs_char ldelim);
+	inline ttstr &InsertStringOntoLineBuffer(tjs_int startpos, const ttstr &insertstr, tjs_int replacesiz=0);
+//	inline ttstr EscapeValueString(const ttstr &valuestr);
+//	inline ttstr UnEscapeValueString(const ttstr &valuestr);
+
+	void PushMacroArgs(tTJSDic &dic);
+public:
+	void PopMacroArgs();
+private:
+	void ClearMacroArgs();
+	void PopMacroArgsTo(tjs_uint base);
+
+	void FindNearestLabel(tjs_int start, tjs_int &labelline, ttstr &labelname);
+
+	void PushCallStack(const tTJSVariant &copyvar, tTJSDic &dicobj);
+	bool CanReturn(const tCallStackData &data);
+	void PopCallStack(const ttstr &storage, const ttstr &label);
+	void StoreIntStackToDic(iTJSDispatch2 *dic, std::vector<tjs_int> &stack, const tjs_char *membername);
+	void StoreBoolStackToDic(iTJSDispatch2 *dic, std::vector<bool> &stack, const tjs_char *membername);
+	void RestoreIntStackFromStr(std::vector<tjs_int> &stack, const ttstr &str);
+	void RestoreBoolStackFromStr(std::vector<bool> &stack, const ttstr &str);
+
+	// ExtKAGParser [while] extends
+	void PushWhileStack();
+	void PopWhileStack(const bool &loop_again);
+	void ClearWhileStack();
+	void WhileStackControlForEndwhile(const bool &loop_again);
+	void ClearWhileStackToTheLatestCallStack();
+	// ExtKAGParser [localvar] extends
+	void PushLocalVariables(const tTJSVariant &copyvar, tTJSDic &dicobj);
+	void PopLocalVariables();
+	void PopLocalVariablesBeforeTheLatestCallStack();
+	void CopyDicToCurrentLocalVariables(tTJSDic &dic);
+	// Note: ClearLocalVariables() pushes one vars at least.
+        void ClearLocalVariables() {tTJSVariant tmp = tTJSDic(); LocalVariables.Empty(); LocalVariables.Push(tmp); }
+
+	// For MultiLine extends
+	void AddMultiLine();
+
+public:
+	void ClearCallStack();
+
+	void Interrupt() { Interrupted = true; };
+	void ResetInterrupt() { Interrupted = false; };
+
+private:
+	iTJSDispatch2 * _GetNextTag();
+
+public:
+	iTJSDispatch2 * GetNextTag();
+
+	const ttstr & GetCurLabel() const { return CurLabel; }
+	tjs_int GetCurLine() const { return CurLine; }
+	tjs_int GetCurPos() const { return CurPos; }
+	const tjs_char* GetCurLineStr() const { return CurLineStr; }
+
+	void SetProcessSpecialTags(bool b) { ProcessSpecialTags = b; }
+	bool GetProcessSpecialTags() const { return ProcessSpecialTags; }
+
+	void SetIgnoreCR(bool b) { IgnoreCR = b; }
+	bool GetIgnoreCR() const { return IgnoreCR; }
+
+	void SetDebugLevel(tTVPKAGDebugLevel level) { DebugLevel = level; }
+	tTVPKAGDebugLevel GetDebugLevel(void) const { return DebugLevel; }
+
+	void SetEnableNP(bool b) { EnableNP = b; }
+	bool GetEnableNP() const { return EnableNP; }
+	void SetFuzzyReturn(bool b) { FuzzyReturn = b; }
+	bool GetFuzzyReturn() const { return FuzzyReturn; }
+	void SetReturnErrorStorage(ttstr s) { ReturnErrorStorage = s; }
+	const ttstr & GetReturnErrorStorage() const { return ReturnErrorStorage; }
+
+	iTJSDispatch2 *GetMacrosNoAddRef() const { return Macros.GetDicNoAddRef(); }
+
+	tTJSDic &GetMacroTopNoAddRef() const;
+		// get current macro argument (parameters)
+
+	tjs_int GetCallStackDepth() const { return CallStack.size(); }
+	tjs_int GetIfLevel() const { return IfLevel; }
+	tjs_int GetWhileStackDepth() const { return WhileStack.size(); }
+	tjs_int GetLocalVariablesDepth() const { return LocalVariables.GetSize(); }
+	tTJSAry &GetLocalVariables() { return LocalVariables; }
+
+	void Assign(tTJSNI_ExtKAGParser& ref) { operator=(ref); }
+
+	// ExtKAGParser extends
+	void SetMultiLineTagEnabled(bool b) { MultiLineTagEnabled = b; }
+	bool GetMultiLineTagEnabled() const { return MultiLineTagEnabled; }
+	void SetNumericMacroArgumentsEnabled(bool b) { NumericMacroArgumentsEnabled = b; }
+	bool GetNumericMacroArgumentsEnabled() const { return NumericMacroArgumentsEnabled; }
+	tTJSVariant GetCurrentLocalVariables() { return LocalVariables.GetLast(); }
+	tTJSVariant GetPreviousLocalVariables() { return LocalVariables.GetPrev(); }
+	tTJSVariant GetParamMacros() { return ParamMacros; }
+};
+
+//---------------------------------------------------------------------------
+// tTJSNC_KAGParser
+//---------------------------------------------------------------------------
+class tTJSNC_ExtKAGParser : public tTJSNativeClass
+{
+    typedef tTJSNativeClass inherited;
+
+public:
+    tTJSNC_ExtKAGParser();
+
+    static tjs_uint32 ClassID;
+
+protected:
+    tTJSNativeInstance* CreateNativeInstance();
+};
+//---------------------------------------------------------------------------
+extern tTJSNativeClass* TVPCreateNativeClass_ExtKAGParser();
+
+#endif

--- a/cpp/plugins/extkagparser/ExttjsHashSearch.h
+++ b/cpp/plugins/extkagparser/ExttjsHashSearch.h
@@ -1,0 +1,623 @@
+//---------------------------------------------------------------------------
+/*
+        TJS2 Script Engine
+        Copyright (C) 2000 W.Dee <dee@kikyou.info> and contributors
+
+     See details of license at "license.txt"
+*/
+//---------------------------------------------------------------------------
+// An Implementation of Hash Searching
+//---------------------------------------------------------------------------
+#ifndef ExtHashSearchH
+#define ExtHashSearchH
+
+#include "tjsTypes.h"
+#define TJS_HS_DEFAULT_HASH_SIZE 64
+#define TJS_HS_HASH_USING	0x1
+#define TJS_HS_HASH_LV1	0x2
+
+// #define TJS_HS_DEBUG_CHAIN  // to debug chain algorithm
+
+namespace TJS
+{
+//---------------------------------------------------------------------------
+// tTJSHashFunc : Hash function object
+//---------------------------------------------------------------------------
+// the hash function used here is similar to one which used in perl 5.8,
+// see also http://burtleburtle.net/bob/hash/doobs.html (One-at-a-Time Hash)
+template <typename T>
+class ExttTJSHashFunc
+{
+public:
+    static tjs_uint32 Make(const T &val)
+    {
+        const char *p = (const char*)&val;
+        const char *plim = (const char*)&val + sizeof(T);
+        tjs_uint32 ret = 0;
+        while(p<plim)
+        {
+            ret += *p;
+            ret += (ret << 10);
+            ret ^= (ret >> 6);
+            p++;
+        }
+        ret += (ret << 3);
+        ret ^= (ret >> 11);
+        ret += (ret << 15);
+        if(!ret) ret = (tjs_uint32)-1;
+        return ret;
+    }
+};
+//---------------------------------------------------------------------------
+template <>
+class ExttTJSHashFunc<ttstr> // a specialized template of tTJSHashFunc for ttstr
+{
+public:
+    static tjs_uint32 Make(const ttstr &val)
+    {
+        if(val.IsEmpty()) return 0;
+        const tjs_char *str = val.c_str();
+        tjs_uint32 ret = 0;
+        while(*str)
+        {
+            ret += *str;
+            ret += (ret << 10);
+            ret ^= (ret >> 6);
+            str++;
+        }
+        ret += (ret << 3);
+        ret ^= (ret >> 11);
+        ret += (ret << 15);
+        if(!ret) ret = (tjs_uint32)-1;
+        return ret;
+    }
+};
+//---------------------------------------------------------------------------
+template <>
+class ExttTJSHashFunc<tjs_char *> // a specialized template of tTJSHashFunc for tjs_char
+{
+public:
+    static tjs_uint32 Make(const tjs_char *str)
+    {
+        if(!str) return 0;
+        tjs_uint32 ret = 0;
+        while(*str)
+        {
+            ret += *str;
+            ret += (ret << 10);
+            ret ^= (ret >> 6);
+            str++;
+        }
+        ret += (ret << 3);
+        ret ^= (ret >> 11);
+        ret += (ret << 15);
+        if(!ret) ret = (tjs_uint32)-1;
+        return ret;
+    }
+};
+//---------------------------------------------------------------------------
+// tTJSHashTable : a simple implementation of Chain Hash algorithm
+//---------------------------------------------------------------------------
+/*
+        Not that ValueT must implement both "operator =" and a copy constructor.
+*/
+template <typename KeyT, typename ValueT, typename HashFuncT = ExttTJSHashFunc<KeyT>,
+         tjs_int HashSize = TJS_HS_DEFAULT_HASH_SIZE>
+class ExttTJSHashTable
+{
+private:
+    struct element
+    {
+        tjs_uint32 Hash;
+        tjs_uint32 Flags; // management flag
+        char Key[sizeof(KeyT)];
+        char Value[sizeof(ValueT)];
+        element *Prev; // previous chain item
+        element *Next; // next chain item
+        element *NPrev; // previous item in the additional order
+        element *NNext; // next item in the additional order
+    } Elms[HashSize];
+
+    tjs_uint Count;
+
+    element *NFirst; // first item in the additional order
+    element *NLast;  // last item in the additional order
+
+public:
+
+    class tIterator // this differs a bit from STL's iterator
+    {
+        element * elm;
+    public:
+        tIterator() { elm = NULL; }
+
+        //		tIterator(const tIterator &ref)
+        //		{ elm = ref.elm; }
+
+        tIterator(element *r_elm)
+        { elm = r_elm; }
+
+        tIterator operator ++()
+        { elm = elm->NNext; return elm;}
+
+        tIterator operator --()
+        { elm = elm->NPrev; return elm;}
+
+        tIterator operator ++(int dummy)
+        { element *b_elm = elm; elm = elm->NNext; return b_elm; }
+
+        tIterator operator --(int dummy)
+        { element *b_elm = elm; elm = elm->NPrev; return b_elm; }
+
+        void operator +(tjs_int n)
+        { while(n--) elm = elm->NNext; }
+
+        void operator -(tjs_int n)
+        { while(n--) elm = elm->NPrev; }
+
+        bool operator ==(const tIterator & ref) const
+        { return elm == ref.elm; }
+
+        bool operator !=(const tIterator & ref) const
+        { return elm != ref.elm; }
+
+        KeyT & GetKey()
+        { return *(KeyT*)elm->Key; }
+
+        ValueT & GetValue()
+        { return *(ValueT*)elm->Value; }
+
+        bool IsNull() const { return elm == NULL; }
+    };
+
+    static tjs_uint32 MakeHash(const KeyT &key)
+    { return HashFuncT::Make(key); }
+
+    ExttTJSHashTable()
+    {
+        InternalInit();
+    }
+
+    ~ExttTJSHashTable()
+    {
+        InternalClear();
+    }
+
+    void Clear()
+    {
+        InternalClear();
+    }
+
+    tIterator GetFirst() const
+    {
+        return tIterator(NFirst);
+    }
+
+    tIterator GetLast() const
+    {
+        return tIterator(NLast);
+    }
+
+
+    void Add(const KeyT &key, const ValueT &value)
+    {
+        // add Key and Value
+        AddWithHash(key, HashFuncT::Make(key), value);
+    }
+
+    void AddWithHash(const KeyT &key, tjs_uint32 hash, const ValueT &value)
+    {
+      // add Key ( hash ) and Value
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        element *lv1 = Elms + hash % HashSize;
+        element *elm = lv1->Next;
+        while(elm)
+        {
+            if(hash == elm->Hash)
+            {
+                // same ?
+                if(key == *(KeyT*)elm->Key)
+                {
+                    // do copying instead of inserting if these are same
+                    CheckUpdateElementOrder(elm);
+                    *(ValueT*)elm->Value = value;
+                    return;
+                }
+            }
+            elm = elm->Next;
+        }
+
+               // lv1 used ?
+        if(!(lv1->Flags & TJS_HS_HASH_USING))
+        {
+            // lv1 is unused
+            Construct(*lv1, key, value);
+            lv1->Hash = hash;
+            lv1->Prev = NULL;
+            // not initialize lv1->Next here
+            CheckAddingElementOrder(lv1);
+            return;
+        }
+
+               // lv1 is used
+        if(hash == lv1->Hash)
+        {
+            // same?
+            if(key == *(KeyT*)lv1->Key)
+            {
+                // do copying instead of inserting if these are same
+                CheckUpdateElementOrder(lv1);
+                *(ValueT*)lv1->Value = value;
+                return;
+            }
+        }
+
+               // insert after lv1
+        element *newelm = new element;
+        newelm->Flags = 0;
+        Construct(*newelm, key, value);
+        newelm->Hash = hash;
+        if(lv1->Next) lv1->Next->Prev = newelm;
+        newelm->Next = lv1->Next;
+        newelm->Prev = lv1;
+        lv1->Next = newelm;
+        CheckAddingElementOrder(newelm);
+    }
+
+
+    ValueT * Find(const KeyT &key) const
+    {
+        // find key
+        // return   NULL  if not found
+        const element * elm = InternalFindWithHash(key, HashFuncT::Make(key));
+        if(!elm) return NULL;
+        return (ValueT*)elm->Value;
+    }
+
+    bool Find(const KeyT &key, const KeyT *& keyout, ValueT *& value) const
+    {
+        // find key
+        // return   false  if not found
+        return FindWithHash(key, HashFuncT::Make(key), keyout, value);
+    }
+
+    ValueT * FindWithHash(const KeyT &key, tjs_uint32 hash) const
+    {
+        // find key ( hash )
+        // return   NULL  if not found
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        const element * elm = InternalFindWithHash(key, hash);
+        if(!elm) return NULL;
+        return (ValueT*)elm->Value;
+    }
+
+    bool FindWithHash(const KeyT &key, tjs_uint32 hash, const KeyT *& keyout, ValueT *& value) const
+    {
+      // find key
+      // return   false  if not found
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        const element * elm = InternalFindWithHash(key, hash);
+        if(elm)
+        {
+            value = (ValueT*)elm->Value;
+            keyout = (const KeyT*)elm->Key;
+            return true;
+        }
+        return false;
+    }
+
+    ValueT * FindAndTouch(const KeyT &key)
+    {
+        // find key and move it first if found
+        const element * elm = InternalFindWithHash(key, HashFuncT::Make(key));
+        if(!elm) return NULL;
+        CheckUpdateElementOrder((element *)elm);
+        return (ValueT*)elm->Value;
+    }
+
+    bool FindAndTouch(const KeyT &key, const KeyT *& keyout, ValueT *& value)
+    {
+        // find key ( hash )
+        // return   false  if not found
+        return FindAndTouchWithHash(key, HashFuncT::Make(key), keyout, value);
+    }
+
+
+    ValueT * FindAndTouchWithHash(const KeyT &key, tjs_uint32 hash)
+    {
+      // find key ( hash ) and move it first if found
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        const element * elm = InternalFindWithHash(key, hash);
+        if(!elm) return NULL;
+        CheckUpdateElementOrder((element *)elm); // force casting
+        return (ValueT*)elm->Value;
+    }
+
+    bool FindAndTouchWithHash(const KeyT &key, tjs_uint32 hash, const KeyT *& keyout, ValueT *& value)
+    {
+        // find key
+        // return   false  if not found
+        const element * elm = InternalFindWithHash(key, hash);
+        if(elm)
+        {
+            CheckUpdateElementOrder((element *)elm);
+            value = (ValueT*)elm->Value;
+            keyout = (const KeyT*)elm->Key;
+            return true;
+        }
+        return false;
+    }
+
+    bool Delete(const KeyT &key)
+    {
+        // delete key and return true if successed
+        return DeleteWithHash(key, HashFuncT::Make(key));
+    }
+
+    bool DeleteWithHash(const KeyT &key, tjs_uint32 hash)
+    {
+      // delete key ( hash ) and return true if succeeded
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        element *lv1 = Elms + hash % HashSize;
+        if(lv1->Flags & TJS_HS_HASH_USING && hash == lv1->Hash)
+        {
+            if(key == *(KeyT*)lv1->Key)
+            {
+                // delete lv1
+                CheckDeletingElementOrder(lv1);
+                Destruct(*lv1);
+                return true;
+            }
+        }
+
+        element *prev = lv1;
+        element *elm = lv1->Next;
+        while(elm)
+        {
+            if(hash == elm->Hash)
+            {
+                if(key == *(KeyT*)elm->Key)
+                {
+                    CheckDeletingElementOrder(elm);
+                    Destruct(*elm);
+                    prev->Next = elm->Next; // sever from the chain
+                    if(elm->Next) elm->Next->Prev = prev;
+                    delete elm;
+                    return true;
+                }
+            }
+            prev = elm;
+            elm = elm->Next;
+        }
+        return false; // not found
+    }
+
+    tjs_int ChopLast(tjs_int count)
+    {
+        // chop items from last of additional order
+        tjs_int ret = 0;
+        while(count--)
+        {
+            if(!NLast) break;
+            DeleteByElement(NLast);
+            ret++;
+        }
+        return ret;
+    }
+
+    tjs_uint GetCount() { return Count; }
+
+private:
+    void InternalClear()
+    {
+        for(tjs_int i = 0; i < HashSize; i++)
+        {
+            // delete all items
+            element *elm = Elms[i].Next;
+            while(elm)
+            {
+                Destruct(*elm);
+                element *elmnext = elm->Next;
+                delete elm;
+                elm = elmnext;
+            }
+            if(Elms[i].Flags & TJS_HS_HASH_USING)
+            {
+                Destruct(Elms[i]);
+            }
+        }
+        InternalInit();
+    }
+
+    void InternalInit()
+    {
+        Count = 0;
+        NFirst = NULL;
+        NLast = NULL;
+        for(tjs_int i = 0; i < HashSize; i++)
+        {
+            Elms[i].Flags = TJS_HS_HASH_LV1;
+            Elms[i].Prev = NULL;
+            Elms[i].Next = NULL;
+        }
+    }
+
+
+    void DeleteByElement(element *elm)
+    {
+        CheckDeletingElementOrder(elm);
+        Destruct(*elm);
+        if(elm->Flags & TJS_HS_HASH_LV1)
+        {
+          // lv1 element
+          // nothing to do
+        }
+        else
+        {
+            // other elements
+            if(elm->Prev) elm->Prev->Next = elm->Next;
+            if(elm->Next) elm->Next->Prev = elm->Prev;
+        }
+        if(!(elm->Flags & TJS_HS_HASH_LV1)) delete elm;
+    }
+
+    const element * InternalFindWithHash(const KeyT &key, tjs_uint32 hash) const
+    {
+        // find key ( hash )
+#ifdef TJS_HS_DEBUG_CHAIN
+        hash = 0;
+#endif
+        const element *lv1 = Elms + hash % HashSize;
+        if(hash == lv1->Hash && lv1->Flags & TJS_HS_HASH_USING)
+        {
+            if(key == *(KeyT*)lv1->Key) return lv1;
+        }
+
+        element *elm = lv1->Next;
+        while(elm)
+        {
+            if(hash == elm->Hash)
+            {
+                if(key == *(KeyT*)elm->Key) return elm;
+            }
+            elm = elm->Next;
+        }
+        return NULL; // not found
+    }
+
+
+    void CheckAddingElementOrder(element *elm)
+    {
+        if(Count==0)
+        {
+            NLast = elm; // first addition
+            elm->NNext = NULL;
+        }
+        else
+        {
+            NFirst->NPrev = elm;
+            elm->NNext = NFirst;
+        }
+        NFirst = elm;
+        elm->NPrev = NULL;
+        Count ++;
+    }
+
+    void CheckDeletingElementOrder(element *elm)
+    {
+        Count --;
+        if(Count > 0)
+        {
+            if(elm == NFirst)
+            {
+                // deletion of first item
+                NFirst = elm->NNext;
+                NFirst->NPrev = NULL;
+            }
+            else if(elm == NLast)
+            {
+                // deletion of last item
+                NLast = elm->NPrev;
+                NLast->NNext = NULL;
+            }
+            else
+            {
+                // deletion of intermediate item
+                elm->NPrev->NNext = elm->NNext;
+                elm->NNext->NPrev = elm->NPrev;
+            }
+        }
+        else
+        {
+            // when the count becomes zero...
+            NFirst = NLast = NULL;
+        }
+    }
+
+    void CheckUpdateElementOrder(element *elm)
+    {
+        // move elm to the front of addtional order
+        if(elm != NFirst)
+        {
+            if(NLast == elm) NLast = elm->NPrev;
+            elm->NPrev->NNext = elm->NNext;
+            if(elm->NNext) elm->NNext->NPrev = elm->NPrev;
+            elm->NNext = NFirst;
+            elm->NPrev = NULL;
+            NFirst->NPrev = elm;
+            NFirst = elm;
+        }
+    }
+
+    static void Construct(element &elm, const KeyT &key, const ValueT &value)
+    {
+        ::new (&elm.Key) KeyT(key);
+        ::new (&elm.Value) ValueT(value);
+        elm.Flags |= TJS_HS_HASH_USING;
+    }
+
+    static void Destruct(element &elm)
+    {
+        ((KeyT*)(&elm.Key)) -> ~KeyT();
+        ((ValueT*)(&elm.Value)) -> ~ValueT();
+        elm.Flags &= ~TJS_HS_HASH_USING;
+    }
+};
+//---------------------------------------------------------------------------
+// tTJSHashCache : cache algorithm via tTJSHashTable
+//---------------------------------------------------------------------------
+template <typename KeyT, typename ValueT, typename HashFuncT = ExttTJSHashFunc<KeyT>,
+         tjs_int HashSize = TJS_HS_DEFAULT_HASH_SIZE >
+class ExttTJSHashCache : public ExttTJSHashTable<KeyT, ValueT, HashFuncT, HashSize>
+{
+    typedef ExttTJSHashTable<KeyT, ValueT, HashFuncT, HashSize> inherited;
+
+    tjs_uint MaxCount;
+
+public:
+    ExttTJSHashCache(tjs_uint maxcount) { MaxCount = maxcount; }
+
+    void Add(const KeyT &key, const ValueT &value)
+    {
+        inherited::Add(key, value);
+        if(inherited::GetCount() > MaxCount)
+        {
+            ChopLast(inherited::GetCount() - MaxCount);
+        }
+    }
+
+    void AddWithHash(const KeyT &key, tjs_uint32 hash, const ValueT &value)
+    {
+        inherited::AddWithHash(key, hash, value);
+        if(inherited::GetCount() > MaxCount)
+        {
+            ChopLast(inherited::GetCount() - MaxCount);
+        }
+    }
+
+    void SetMaxCount(tjs_uint maxcount)
+    {
+        MaxCount = maxcount;
+        if(inherited::GetCount() > MaxCount)
+        {
+            ChopLast(inherited::GetCount() - MaxCount);
+        }
+    }
+
+    tjs_uint GetMaxCount() { return MaxCount; }
+};
+//---------------------------------------------------------------------------
+} // namespace TJS
+//---------------------------------------------------------------------------
+
+#endif

--- a/cpp/plugins/extkagparser/README.md
+++ b/cpp/plugins/extkagparser/README.md
@@ -1,0 +1,11 @@
+# ExtKAGParser compatibility plugin
+
+This directory ports the `ExtKAGParser.dll` implementation from
+[`krkrsdl3`](https://github.com/krkrsdl3/krkrsdl3), whose implementation in
+turn derives from the KiriKiri/KAG parser by W.Dee and contributors.
+
+Aether-specific adaptations keep the original script contract while using
+Aether's UTF-16 `tjs_char`, portable storage/event headers, static plugin
+registration, and repeatable module teardown. The corresponding source and
+modifications are distributed here under the repository's documented
+KiriKiri/krkrsdl3 licensing terms.

--- a/cpp/plugins/extkagparser/TJSAry.cpp
+++ b/cpp/plugins/extkagparser/TJSAry.cpp
@@ -1,0 +1,195 @@
+#include "tjsCommHead.h"
+#include "TJSAry.h"
+#include "TJSDic.h"
+
+#include "MsgIntf.h"
+
+// constructors
+tTJSAry::tTJSAry() : tTJSVariant()
+{
+    //TVPAddLog(TJS_W("tTJSAry()"));
+    init_tTJSAry();
+}
+
+#if 0
+tTJSAry::tTJSAry(iTJSDispatch2 *srcary) : tTJSVariant()
+{
+//TVPAddLog(TJS_W("tTJSAry(iTJSDispatch2*)"));
+        if (srcary == NULL)
+                TVPThrowExceptionMessage(TJS_W("tTJSAry::tTJSAry() is invoked with NULL ary"));
+        init_tTJSAry();
+        Assign(srcary);
+}
+#endif
+
+tTJSAry::tTJSAry(tTJSVariant &srcary) : tTJSVariant()
+{
+    //TVPAddLog(TJS_W("tTJSAry(tTJSVariant&)"));
+    if (srcary.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::tTJSAry(tTJSVariant&) is invoked with non tvtObject"));
+    init_tTJSAry();
+    Assign(srcary);
+}
+
+tTJSAry::tTJSAry(tTJSAry &srcary) : tTJSVariant()
+{
+    //TVPAddLog(TJS_W("tTJSAry(tTJSAry&)"));
+    if (srcary.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::tTJSAry(tTJSAry&) is invoked with non tvtObject"));
+    init_tTJSAry();
+    Assign(srcary);
+}
+
+tTJSAry::tTJSAry(tTJSDic &srcdic) : tTJSVariant()
+{
+    //TVPAddLog(TJS_W("tTJSAry(tTJSDic&)"));
+    if (srcdic.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::tTJSAry(tTJSDic&) is invoked with non tvtObject"));
+    init_tTJSAry();
+    Assign(srcdic);
+}
+
+
+void tTJSAry::Empty()
+{
+    GetAryNoAddRef()->FuncCall(0, TJS_W("clear"), NULL, NULL, 0, NULL, GetAryNoAddRef());
+}
+
+tTJSAry& tTJSAry::Assign(iTJSDispatch2 *src)
+{
+    //TVPAddLog(TJS_W("tTJSAry::Assign(iTJSDispatch2*)"));
+    if (src == NULL)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::Assign(iTJSDispatch2*) is invoked with NULL"));
+
+    tTJSVariant srcary(src, src);
+    return Assign(srcary);
+}
+
+tTJSAry& tTJSAry::Assign(tTJSVariant &src)
+{
+    //TVPAddLog(TJS_W("tTJSAry::Assign(iTJSVariant&)"));
+    if (src.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::Assign(tTJSVariant&) is invoked with non tvtObject"));
+
+    iTJSDispatch2 *ary = GetAryNoAddRef();
+    tTJSVariant *psrc = &src;
+    ary->FuncCall(0, TJS_W("assign"), NULL, NULL, 1, &psrc, ary);
+    return *this;
+}
+
+tTJSAry& tTJSAry::Assign(tTJSAry &src)
+{
+    //TVPAddLog(TJS_W("tTJSAry::Assign(tTJSAry&)"));
+    if (src.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::Assign(tTJSAry&) is invoked with non tvtObject"));
+
+    return Assign(src.ToVariant());
+}
+
+tTJSAry& tTJSAry::Assign(tTJSDic &src)
+{
+    //TVPAddLog(TJS_W("tTJSAry::Assign(iTJSDic&)"));
+    if (src.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::Assign(tTJSDic&) is invoked with non tvtObject"));
+
+    return Assign(src.ToVariant());
+}
+
+
+void tTJSAry::SetProp(tjs_int index, tTJSVariant &value)
+{
+    iTJSDispatch2 *ary = GetAryNoAddRef();
+    ary->PropSetByNum(TJS_MEMBERENSURE, index, &value, ary);
+}
+
+tTJSVariant tTJSAry::GetProp(tjs_int index)
+{
+    if (index < 0 || GetSize() <= index) {
+        ttstr str = TJS_W("tTJSAry::GetProp(")+ttstr(index)+TJS_W(") is not in the range of 0-")+ttstr(GetSize()-1);
+        TVPThrowExceptionMessage(str.c_str());
+    }
+    iTJSDispatch2 *ary = GetAryNoAddRef();
+    tTJSVariant value;
+    ary->PropGetByNum(TJS_MEMBERENSURE, index, &value, ary);
+    return value;
+}
+
+tjs_int tTJSAry::GetSize() const
+{
+    iTJSDispatch2 *ary = GetAryNoAddRef();
+    tTJSVariant val;
+    ary->PropGet(0, TJS_W("count"), NULL, &val, ary);
+    return (tjs_int)val.AsInteger();
+}
+
+void tTJSAry::SetSize(tjs_int count)
+{
+    iTJSDispatch2 *ary = GetAryNoAddRef();
+    tTJSVariant val(count);
+    // I believe this can remove unnecessary elements
+    ary->PropSet(0, TJS_W("count"), NULL, &val, ary);
+}
+
+
+
+// for accessing array elements
+tTJSVariant tTJSAry::operator [](tjs_int index)
+{
+    return GetProp(index);
+}
+
+tTJSVariant tTJSAry::GetLast()
+{
+    return GetProp(GetSize()-1);
+}
+
+
+tTJSVariant tTJSAry::GetPrev()
+{
+    return GetProp(GetSize()-2);
+}
+
+void tTJSAry::Push(tTJSVariant &var)
+{
+    SetProp(GetSize(), var);
+}
+
+tTJSVariant tTJSAry::Pop()
+{
+    if (GetSize() <= 0)
+        TVPThrowExceptionMessage(TJS_W("tTJSAry::Pop() stack under run"));
+    tTJSVariant v = this[GetSize()-1];
+    SetSize(GetSize()-1);
+    return v;
+}
+
+
+// store this object onto "dic.ary_entry"
+void tTJSAry::Store(iTJSDispatch2 *savedic, const tjs_char *ary_entry)
+{
+    iTJSDispatch2 *tmpary = savedic;
+    if (ary_entry) {
+        tmpary = TJSCreateArrayObject();
+        tTJSVariant tmp(tmpary, tmpary);
+        tmpary->Release();
+        savedic->PropSet(TJS_MEMBERENSURE, ary_entry, NULL, &tmp, savedic);
+    }
+
+    tTJSVariant src(*this);
+    tTJSVariant *psrc = &src;
+    tmpary->FuncCall(0, TJS_W("assignStruct"), NULL, NULL, 1, &psrc, tmpary);
+}
+
+// restore this object from "dic.ary_entry"
+void tTJSAry::Restore(iTJSDispatch2 *loaddic, const tjs_char *ary_entry)
+{
+    iTJSDispatch2 *tmpary = loaddic;
+    if (ary_entry) {
+        tTJSVariant tmp;
+        loaddic->PropGet(TJS_MEMBERENSURE, ary_entry, NULL, &tmp, loaddic);
+        tmpary = tmp.AsObjectNoAddRef();
+    }
+    tTJSVariant src(tmpary, tmpary);
+    tTJSVariant *psrc = &src;
+    GetAryNoAddRef()->FuncCall(0, TJS_W("assignStruct"), NULL, NULL, 1, &psrc, GetAryNoAddRef());
+}

--- a/cpp/plugins/extkagparser/TJSAry.h
+++ b/cpp/plugins/extkagparser/TJSAry.h
@@ -1,0 +1,76 @@
+#ifndef ___TJSARY_H___
+#define ___TJSARY_H___
+
+class tTJSDic;
+
+#include "tjsArray.h"
+#include "DebugIntf.h"
+
+// TJSの配列をC++から簡単に使えるようにするクラス
+
+
+class tTJSAry : public tTJSVariant {
+	void init_tTJSAry() {
+		iTJSDispatch2 *ary = TJSCreateArrayObject();
+		SetObject(ary, ary);
+		ary->Release();
+	}
+	void printRef() { // test use only
+		if (Type() == tvtVoid || AsObjectNoAddRef() == NULL) {
+			TVPAddLog(TJS_W("(NULL)"));
+			return;
+		}
+		TVPAddLog(TJS_W("ref=")+ttstr((int)AsObjectNoAddRef()->AddRef()-1));
+		AsObjectNoAddRef()->Release();
+	}
+public:
+	iTJSDispatch2 *GetAry() { return AsObject(); }
+	iTJSDispatch2 *GetAryNoAddRef() const { return AsObjectNoAddRef(); }
+
+	// constructors
+	tTJSAry();
+	tTJSAry(tTJSVariant &srcary);
+	tTJSAry(tTJSAry &srcary);
+	// Note: tTJSAry(tTJSAry) (without &) is translated to tTJSAry(tTJSDispatch2*)
+	tTJSAry(tTJSDic &srcdic);
+	// tTJSAry(iTJSDispatch2 *srcary);
+	// Note: tTJSAry(iTJSDispatch2 *srcary) is removed as this could be
+	//       a cause of significant memory leak.
+	//       This class does not have a const-copy-constructor:
+	//       (tTJSAry(const tTJSAry&))
+	//       because of chainging refcount at assigning argument-array
+	//       onto itself. And this brings a translation from
+	//       "tTJSAry a(tTJSAry)" onto "tTJSAry a(iTJSDispatch2*)" at the
+	//       variable definition, which could increment refcount unexpectedly.
+
+	tTJSVariant& ToVariant() { return *this; }
+
+	// methods
+	void Empty(); // Clear() has been reserved by tTJSVariant
+
+	tTJSAry& Assign(iTJSDispatch2 *src);
+	tTJSAry& Assign(tTJSVariant &src);
+	tTJSAry& Assign(tTJSAry &src);
+	tTJSAry& Assign(tTJSDic &src);
+
+	void SetProp(tjs_int index, tTJSVariant &value);
+	tTJSVariant GetProp(tjs_int index);
+
+	tjs_int GetSize() const;
+	void SetSize(tjs_int count);
+
+	// for accessing array elements
+	tTJSVariant operator [](tjs_int index);
+	tTJSVariant GetLast();
+	tTJSVariant GetPrev();
+	void Push(tTJSVariant &var);
+	tTJSVariant Pop();
+
+	// store this object onto "dic.dic_entry"
+	void Store(iTJSDispatch2 *dic, const tjs_char *dic_entry=NULL);
+	// restore this object from "dic.dic_entry"
+        void Restore(iTJSDispatch2 *dic, const tjs_char *dic_entry=NULL);
+};
+
+
+#endif // ___TJSARY_H___

--- a/cpp/plugins/extkagparser/TJSDic.cpp
+++ b/cpp/plugins/extkagparser/TJSDic.cpp
@@ -1,0 +1,255 @@
+#include "tjsCommHead.h"
+#include "TJSDic.h"
+#include "TJSAry.h"
+#include "tjsDictionary.h"
+#include "ScriptMgnIntf.h"
+#include "MsgIntf.h"
+
+// =========================================================
+
+// these are the real definition of static member variables.
+iTJSDispatch2 *tTJSDic::DicAssign;
+iTJSDispatch2 *tTJSDic::DicAssignStruct;
+iTJSDispatch2 *tTJSDic::DicClear;
+
+// Function definitions below:
+
+
+// initialize DicClear/DicAssign, would be better to lock to avoid multi/overwriting
+void tTJSDic::init_tTJSDic() {
+    if (DicClear == NULL /* || DicAssign == NULL */) {
+        tTJSVariant dic;
+        TVPExecuteExpression(TJS_W("Dictionary"), &dic);
+        iTJSDispatch2 *dicclass = dic.AsObjectNoAddRef();
+
+        tjs_error err;
+        tTJSVariant val;
+
+        err = dicclass->PropGet(0, TJS_W("clear"), NULL, &val, dicclass);
+        if (TJS_FAILED(err))
+            TVPThrowExceptionMessage(TJS_W("tTJSDic: can not get 'clear' method of Dictionary"));
+        DicClear = val.AsObject();
+
+        err = dicclass->PropGet(0, TJS_W("assign"), NULL, &val, dicclass);
+        if (TJS_FAILED(err))
+            TVPThrowExceptionMessage(TJS_W("tTJSDic: can not get 'assign' method of Dictionary"));
+        DicAssign = val.AsObject();
+
+        err = dicclass->PropGet(0, TJS_W("assignStruct"), NULL, &val, dicclass);
+        if (TJS_FAILED(err))
+            TVPThrowExceptionMessage(TJS_W("tTJSDic: can not get 'assignStruct' method of Dictionary"));
+        DicAssignStruct = val.AsObject();
+    }
+
+    iTJSDispatch2 *dic = TJSCreateDictionaryObject();
+    SetObject(dic, dic);
+    dic->Release();
+}
+
+
+// constructors
+tTJSDic::tTJSDic() : tTJSVariant()
+{
+    init_tTJSDic();
+}
+
+tTJSDic::tTJSDic(tTJSVariant &srcdic) : tTJSVariant()
+{
+    if (srcdic.Type() == tvtVoid)
+        TVPThrowExceptionMessage(TJS_W("tTJSDic::tTJSDic(tTJSVariant&) is invoked with void dic"));
+    init_tTJSDic();
+    Assign(srcdic);
+}
+
+tTJSDic::tTJSDic(tTJSDic &srcdic) : tTJSVariant()
+{
+    if (srcdic.Type() == tvtVoid)
+        TVPThrowExceptionMessage(TJS_W("tTJSDic::tTJSDic(tTJSDic&) is invoked with void dic"));
+    init_tTJSDic();
+    Assign(srcdic);
+}
+
+
+// destructor
+//tTJSDic::~tTJSDic()
+//{
+// We need to release DicClear/DicAssign at the time all of
+// tTJSDic instances are destructed, however, currently
+// Ignore it...
+//
+// if (--RefCount <= 0) {
+//	RefCount = 0;
+//	if(DicClear)  DicClear->Release();
+//	if(DicAssign) DicAssign->Release();
+// }
+//}
+
+// methods
+void tTJSDic::Empty()
+{
+    DicClear->FuncCall(0, NULL, NULL, NULL, 0, NULL, GetDicNoAddRef());
+}
+
+tTJSDic& tTJSDic::Assign(iTJSDispatch2 *srcdic)
+{
+    if (srcdic == NULL)
+        TVPThrowExceptionMessage(TJS_W("tTJSDic::Assign(tTJSDispatch*) is invoked with NULL dic"));
+
+    tTJSVariant src(srcdic, srcdic);
+    return Assign(src);
+}
+
+tTJSDic& tTJSDic::Assign(tTJSVariant &srcdic)
+{
+    if (srcdic.Type() != tvtObject)
+        TVPThrowExceptionMessage(TJS_W("tTJSDic::Assign(tTJSVariant&) is invoked with non tvtObject"));
+
+    tTJSVariant *psrc = &srcdic;
+    DicAssign->FuncCall(0, NULL, NULL, NULL, 1, &psrc, GetDicNoAddRef());
+    return *this;
+}
+
+tTJSDic& tTJSDic::Assign(tTJSDic &srcdic)
+{
+    if (srcdic.Type() == tvtVoid)
+        TVPThrowExceptionMessage(TJS_W("tTJSDic::Assign(tTJSDic&) is invoked with non tvtObject"));
+
+    tTJSVariant *psrc = &srcdic;
+    DicAssign->FuncCall(0, NULL, NULL, NULL, 1, &psrc, GetDicNoAddRef());
+    return *this;
+}
+
+
+void tTJSDic::SetProp(const ttstr &name, tTJSVariant &value)
+{
+    iTJSDispatch2 *dic = GetDicNoAddRef();
+    dic->PropSetByVS(TJS_MEMBERENSURE, name.AsVariantStringNoAddRef(), &value, dic);
+}
+
+
+tTJSVariant tTJSDic::GetProp(const tjs_char *name)
+{
+    iTJSDispatch2 *dic = GetDicNoAddRef();
+    tTJSVariant val;
+    dic->PropGet(0, name, NULL, &val, dic);
+    return val;
+}
+
+tTJSVariant tTJSDic::GetProp(ttstr &name)
+{
+    iTJSDispatch2 *dic = GetDicNoAddRef();
+    tTJSVariant val;
+    dic->PropGet(0, name.c_str(), name.GetHint(), &val, dic);
+    return val;
+}
+
+
+tjs_error tTJSDic::DelProp(const tjs_char *name)
+{
+    iTJSDispatch2 *dic = GetDicNoAddRef();
+    return dic->DeleteMember(0, name, NULL, dic);
+}
+
+tjs_error tTJSDic::DelProp(ttstr &name)
+{
+    iTJSDispatch2 *dic = GetDicNoAddRef();
+    return dic->DeleteMember(0, name.c_str(), name.GetHint(), dic);
+}
+
+
+tTJSAry tTJSDic::GetKeys()
+{
+    tTJSAry ary(*this);
+    tTJSAry ret;
+    for (tjs_int i = 0; i < ary.GetSize()/2; i++) {
+        tTJSVariant v = ary.GetProp(i*2);
+        ret.SetProp(i, v);
+    }
+    return ret;
+}
+
+void tTJSDic::AddDic(tTJSDic &sdic)
+{
+    tTJSAry keyary(sdic.GetKeys());
+    for (tjs_int i = 0; i < keyary.GetSize(); i++)
+    {
+        ttstr key(keyary.GetProp(i));
+        tTJSVariant tmp = sdic.GetProp(key);
+        SetProp(key, tmp);
+    }
+}
+
+
+// store this object onto savedic
+void tTJSDic::Store(iTJSDispatch2 *savedic, const tjs_char *dic_entry)
+{
+    iTJSDispatch2 *tmpdic = savedic;
+    if (dic_entry) {
+        tmpdic = TJSCreateDictionaryObject();
+        tTJSVariant tmp(tmpdic, tmpdic);
+        tmpdic->Release();
+        savedic->PropSet(TJS_MEMBERENSURE, dic_entry, NULL, &tmp, savedic);
+    }
+
+    tTJSVariant src(*this);
+    tTJSVariant *psrc = &src;
+    DicAssignStruct->FuncCall(0, NULL, NULL, NULL, 1, &psrc, tmpdic);
+}
+
+// store this object onto saveary
+void tTJSDic::Store(iTJSDispatch2 *saveary, tjs_int index)
+{
+    iTJSDispatch2 *tmpdic = TJSCreateDictionaryObject();
+    tTJSVariant tmp(tmpdic, tmpdic);
+    tmpdic->Release();
+    saveary->PropSetByNum(TJS_MEMBERENSURE, index, &tmp, saveary);
+
+    tTJSVariant src(*this);
+    tTJSVariant *psrc = &src;
+    DicAssignStruct->FuncCall(0, NULL, NULL, NULL, 1, &psrc, tmpdic);
+}
+
+// restore this object from loaddic
+void tTJSDic::Restore(iTJSDispatch2 *loaddic, const tjs_char *dic_entry)
+{
+    if (dic_entry == NULL) {
+        tTJSVariant src(loaddic, loaddic);
+        tTJSVariant *psrc = &src;
+        DicAssignStruct->FuncCall(0, NULL, NULL, NULL, 1, &psrc, GetDicNoAddRef());
+        return;
+    }
+
+    tTJSVariant tmp;
+    loaddic->PropGet(TJS_MEMBERENSURE, dic_entry, NULL, &tmp, loaddic);
+    if (tmp.Type() == tvtVoid) {
+        // leave current one, do not clear it.
+        // this is necessary to handle the case
+        // "kag.conductor.macro === void", means "saveMacros=false"
+        return;
+    }
+    if (tmp.Type() != tvtObject) {
+        ttstr mes = TJS_W("tTJSDic::Restore(loaddic, \"")+ttstr(dic_entry)+TJS_W("\"): is not dictionary");
+        TVPThrowExceptionMessage(mes.c_str());
+    }
+    tTJSVariant *psrc = &tmp;
+    DicAssignStruct->FuncCall(0, NULL, NULL, NULL, 1, &psrc, GetDicNoAddRef());
+}
+
+// restore this object from loaddic
+void tTJSDic::Restore(iTJSDispatch2 *loadary, tjs_int index)
+{
+    tTJSVariant tmp;
+    loadary->PropGetByNum(TJS_MEMBERENSURE, index, &tmp, loadary);
+    if (tmp.Type() == tvtVoid) {
+        // leave current one.
+        // this is necessary to handle the case
+        // "kag.conductor.macro === void".
+        return;
+    }
+    if (tmp.Type() != tvtObject) {
+        ttstr mes = TJS_W("tTJSDic::Restore(loadary, \"")+ttstr(index)+TJS_W("\"): is not dictionary");
+        TVPThrowExceptionMessage(mes.c_str());
+    }
+    tTJSVariant *psrc = &tmp;
+    DicAssignStruct->FuncCall(0, NULL, NULL, NULL, 1, &psrc, GetDicNoAddRef());
+}

--- a/cpp/plugins/extkagparser/TJSDic.h
+++ b/cpp/plugins/extkagparser/TJSDic.h
@@ -1,0 +1,78 @@
+#ifndef ___TJSDIC_H___
+#define ___TJSDIC_H___
+
+class tTJSAry;
+
+#include "DebugIntf.h"
+
+// TJSの辞書をC++から簡単に使えるようにするクラス
+
+
+class tTJSDic : public tTJSVariant {
+	// link to Dictionary.Clear and Dictionary.Assign
+	// defined as static one, which are shared by all instances.
+	static iTJSDispatch2 *DicClear;
+	static iTJSDispatch2 *DicAssign;
+	static iTJSDispatch2 *DicAssignStruct;
+
+	// set DicClear/DicAssign in the constructors
+	void init_tTJSDic();
+
+	void printRef() { // test use only
+		if (Type() == tvtVoid || AsObjectNoAddRef() == NULL) {
+			TVPAddLog(TJS_W("(NULL)"));
+			return;
+		}
+		TVPAddLog(TJS_W("ref=")+ttstr((int)AsObjectNoAddRef()->AddRef()-1));
+		AsObjectNoAddRef()->Release();
+	}
+public:
+	iTJSDispatch2 *GetDic() { return AsObject(); }
+	iTJSDispatch2 *GetDicNoAddRef() const { return AsObjectNoAddRef(); }
+
+	// constructors
+	tTJSDic();
+//	tTJSDic(iTJSDispatch2 *srcdic);
+	tTJSDic(tTJSVariant &srcdic);
+	tTJSDic(tTJSDic &src);
+
+	// destructor
+	// ~tTJSDic();
+
+	tTJSVariant& ToVariant() { return *this; }
+
+	// methods
+	void Empty(); // Clear() has been reserved by tTJSVariant
+
+	tTJSDic& Assign(iTJSDispatch2 *srcdic);
+	tTJSDic& Assign(tTJSVariant &srcdic);
+	tTJSDic& Assign(tTJSDic &srcdic);
+
+	void SetProp(const ttstr &name, tTJSVariant &value);
+
+	// to access dic elements
+	tTJSVariant GetProp(const tjs_char *name);
+	tTJSVariant GetProp(ttstr &name);
+	tTJSVariant operator [](const tjs_char *name) { return GetProp(name); }
+	tTJSVariant operator [](ttstr &name)          { return GetProp(name); }
+
+	tjs_error DelProp(const tjs_char *name);
+	tjs_error DelProp(ttstr &name);
+
+	tTJSAry GetKeys(); // get keys of the dictionary, return tTJSAry
+
+	void AddDic(tTJSDic &sdic);
+
+	// store this object onto savedic
+        void Store(iTJSDispatch2 *savedic, const tjs_char *dic_entry=NULL);
+	// store this object onto saveary
+	void Store(iTJSDispatch2 *saveary, tjs_int index);
+	// restore this object from loaddic
+        void Restore(iTJSDispatch2 *loaddic, const tjs_char *dic_entry=NULL);
+	// restore this object from loadary
+	void Restore(iTJSDispatch2 *saveary, tjs_int index);
+
+};
+
+
+#endif // ___TJSDIC_TJSARY_H___

--- a/cpp/plugins/kagparserex/kagparserex_plugin.cpp
+++ b/cpp/plugins/kagparserex/kagparserex_plugin.cpp
@@ -97,20 +97,13 @@ static void UnlinkKAGParserCompatibility() {
     RestoreKAGParserClass();
 }
 
-// Register two compatibility module names:
-// - KAGParserEx.dll (wamsoft)
-// - ExtKAGParser.dll (older scripts)
+// KAGParserEx.dll compatibility uses Aether's extended core parser.  The
+// distinct ExtKAGParser.dll implementation is registered by extkagparser.
 static ncbCallbackAutoRegister g_kagparserex_cb(
     TJS_W("KAGParserEx.dll"), ncbAutoRegister::PreRegist,
     &LinkKAGParserCompatibility, nullptr);
 static ncbCallbackAutoRegister g_kagparserex_unload_cb(
     TJS_W("KAGParserEx.dll"), ncbAutoRegister::PostRegist, nullptr,
-    &UnlinkKAGParserCompatibility);
-static ncbCallbackAutoRegister g_extkagparser_cb(
-    TJS_W("ExtKAGParser.dll"), ncbAutoRegister::PreRegist,
-    &LinkKAGParserCompatibility, nullptr);
-static ncbCallbackAutoRegister g_extkagparser_unload_cb(
-    TJS_W("ExtKAGParser.dll"), ncbAutoRegister::PostRegist, nullptr,
     &UnlinkKAGParserCompatibility);
 
 extern "C" void TVPRegisterKAGParserExPluginAnchor() {}

--- a/cpp/plugins/motionplayer/PlayerUpdateLayers.cpp
+++ b/cpp/plugins/motionplayer/PlayerUpdateLayers.cpp
@@ -4447,6 +4447,18 @@ namespace motion {
                 continue;
             }
 
+            // Motion and particle nodes are structural containers. Their
+            // source is another Player (or a particle collection), so the
+            // container's own vertex is not rendered geometry. Including its
+            // default (0, 0) point expands child-only button bounds to the
+            // stage origin and makes unrelated clicks hit the button. Native
+            // Motion.Player_calcBounds obtains their extent exclusively from
+            // the child-player merge below.
+            if(node.nodeType == LayerTypeMotion ||
+               node.nodeType == LayerTypeParticle) {
+                continue;
+            }
+
             bool haveNodeBounds = false;
             double minX = 0.0;
             double minY = 0.0;

--- a/cpp/plugins/pluginAnchors.cpp
+++ b/cpp/plugins/pluginAnchors.cpp
@@ -1,10 +1,14 @@
 #include "ncbind.hpp"
 
 extern "C" void TVPRegisterKAGParserExPluginAnchor();
+extern "C" void TVPRegisterExtKAGParserPluginAnchor();
 
 namespace {
 
-void linkStaticPluginModules() { TVPRegisterKAGParserExPluginAnchor(); }
+void linkStaticPluginModules() {
+    TVPRegisterKAGParserExPluginAnchor();
+    TVPRegisterExtKAGParserPluginAnchor();
+}
 
 } // namespace
 

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -58,6 +58,21 @@ namespace motion {
         static void enableAutoProgress(Player &player, iTJSDispatch2 *dispatch) {
             player.enableAutoProgress(dispatch);
         }
+
+        static std::array<double, 4> calcSyntheticBounds(
+            Player &player,
+            std::vector<detail::MotionNode> nodes) {
+            player._runtime->activeMotion =
+                std::make_shared<detail::MotionSnapshot>();
+            player._runtime->activeMotion->path = "synthetic-bounds.psb";
+            player._runtime->nodes = std::move(nodes);
+            player._runtime->nodesBuilt = true;
+            player._layersDirty = false;
+            player._emoteDirty = false;
+            player.calcBounds();
+            return { player._boundsMinX, player._boundsMinY,
+                     player._boundsMaxX, player._boundsMaxY };
+        }
     };
 }
 
@@ -153,6 +168,42 @@ TEST_CASE("motionplayer optional E-mote extension matches build mode") {
 #else
     REQUIRE(extension == nullptr);
 #endif
+}
+
+TEST_CASE("motionplayer bounds ignore motion container origin") {
+    motion::detail::MotionNode container;
+    container.index = 0;
+    container.nodeType = motion::LayerTypeMotion;
+    container.hasSource = true;
+    container.drawFlag = true;
+    container.accumulated.active = true;
+    container.vertexPosX = 0.0;
+    container.vertexPosY = 0.0;
+
+    motion::detail::MotionNode image;
+    image.index = 1;
+    image.nodeType = motion::LayerTypeObj;
+    image.hasSource = true;
+    image.drawFlag = true;
+    image.accumulated.active = true;
+    image.clipW = 40.0;
+    image.clipH = 20.0;
+    image.vertices[0] = 752.0f;
+    image.vertices[1] = 678.0f;
+    image.vertices[2] = 792.0f;
+    image.vertices[3] = 678.0f;
+    image.vertices[4] = 792.0f;
+    image.vertices[5] = 698.0f;
+    image.vertices[6] = 752.0f;
+    image.vertices[7] = 698.0f;
+
+    motion::Player player;
+    const auto bounds = motion::PlayerTestAccess::calcSyntheticBounds(
+        player, {container, image});
+    REQUIRE(bounds[0] == 752.0);
+    REQUIRE(bounds[1] == 678.0);
+    REQUIRE(bounds[2] == 792.0);
+    REQUIRE(bounds[3] == 698.0);
 }
 
 TEST_CASE("motionplayer reuses effective-variable scratch across frames") {

--- a/tests/unit-tests/plugins/registry.cpp
+++ b/tests/unit-tests/plugins/registry.cpp
@@ -572,6 +572,70 @@ TEST_CASE("KAGParserEx preserves existing script KAGParser class") {
     global->Release();
 }
 
+TEST_CASE("ExtKAGParser provides local-variable extensions and restores the original class") {
+    ensurePluginRegistryRuntime();
+    ncbAutoRegister::UnloadModule(TJS_W("ExtKAGParser.dll"));
+
+    iTJSDispatch2 *global = TVPGetScriptDispatch();
+    REQUIRE(global != nullptr);
+
+    iTJSDispatch2 *original = TJSCreateDictionaryObject();
+    REQUIRE(original != nullptr);
+    const tTJSVariant originalValue(original, original);
+    setProp(global, TJS_W("KAGParser"), originalValue);
+    original->Release();
+
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("ExtKAGParser.dll")));
+    tTJSVariant parserClass = getGlobalProp(TJS_W("KAGParser"));
+    REQUIRE(parserClass.Type() == tvtObject);
+    CHECK(parserClass.AsObjectNoAddRef() != original);
+
+    iTJSDispatch2 *parser = nullptr;
+    tTJSVariantClosure parserClosure = parserClass.AsObjectClosureNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(parserClosure.CreateNew(0, nullptr, nullptr, &parser,
+                                                  0, nullptr, nullptr)));
+    REQUIRE(parser != nullptr);
+
+    const tTJSVariant parserValue(parser, parser);
+    CHECK(static_cast<tjs_int>(getProp(parserValue, TJS_W("localVariablesDepth"))) == 1);
+    CHECK(getProp(parserValue, TJS_W("lf")).Type() == tvtObject);
+    CHECK(getProp(parserValue, TJS_W("localVariables")).Type() == tvtObject);
+
+    ScenarioLoadCallback *callback = new ScenarioLoadCallback(
+        TJS_W("[pushlocalvar answer=42]\n"
+              "[probe value=&lf.answer]\n"
+              "[poplocalvar]\n"));
+    tTJSVariant callbackValue(callback, callback);
+    setProp(parser, TJS_W("onScenarioLoad"), callbackValue);
+    setProp(parser, TJS_W("ignoreCR"),
+            tTJSVariant(static_cast<tTVInteger>(1)));
+    callback->Release();
+
+    tTJSVariant storage(TJS_W("memory.ks"));
+    tTJSVariant *loadArgs[] = { &storage };
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(0, TJS_W("loadScenario"), nullptr,
+                                           nullptr, 1, loadArgs, parser)));
+
+    tTJSVariant tag;
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(0, TJS_W("getNextTag"), nullptr,
+                                           &tag, 0, nullptr, parser)));
+    REQUIRE(tag.Type() == tvtObject);
+    CHECK(ttstr(getProp(tag, TJS_W("tagname"))) == TJS_W("probe"));
+    CHECK(static_cast<tjs_int>(getProp(tag, TJS_W("value"))) == 42);
+    CHECK(static_cast<tjs_int>(getProp(parserValue, TJS_W("localVariablesDepth"))) == 2);
+
+    parser->Release();
+    parserClass.Clear();
+    REQUIRE(ncbAutoRegister::UnloadModule(TJS_W("ExtKAGParser.dll")));
+
+    const tTJSVariant restored = getGlobalProp(TJS_W("KAGParser"));
+    REQUIRE(restored.Type() == tvtObject);
+    CHECK(restored.AsObjectNoAddRef() == original);
+
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+    global->Release();
+}
+
 TEST_CASE("extrans registers precise wave transition provider") {
     ensurePluginRegistryRuntime();
     ncbAutoRegister::UnloadModule(TJS_W("extrans.dll"));

--- a/tests/unit-tests/tjs2/missing.cpp
+++ b/tests/unit-tests/tjs2/missing.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "tjs.h"
+#include "tjsError.h"
+#include "tjsInterCodeGen.h"
 
 #include <memory>
 
@@ -107,4 +109,30 @@ TEST_CASE("integer pseudo-property remains scoped to KAG layer conversion") {
         TJS_W("function convLayerType(value) { return value.type; }\n"
               "return convLayerType(29);"),
         &result, nullptr, TJS_W("world.tjs")));
+}
+
+TEST_CASE(
+    "exceptions from cached expression functions survive orphaned source blocks") {
+    std::unique_ptr<tTJS, TJSReleaser> engine(new tTJS());
+    tTJSVariant function;
+
+    REQUIRE_NOTHROW(engine->EvalExpression(
+        TJS_W("(function() { return 1; })"),
+        &function));
+    REQUIRE(function.Type() == tvtObject);
+
+    tTJSVariantClosure closure = function.AsObjectClosureNoAddRef();
+    REQUIRE(closure.Object != nullptr);
+    auto *context = dynamic_cast<TJS::tTJSInterCodeContext *>(closure.Object);
+    REQUIRE(context != nullptr);
+    engine->CompactScriptCache(3);
+    REQUIRE(context->GetBlock() == nullptr);
+    try {
+        TJS::TJS_eTJSScriptError(TJS_W("orphaned source"), context, 0);
+        FAIL("the script error helper did not throw");
+    } catch(const TJS::eTJSScriptError &error) {
+        CHECK(error.GetBlockNoAddRef() == nullptr);
+        CHECK(TJS_strlen(error.GetBlockName()) == 0);
+        CHECK(error.GetSourceLine() == 0);
+    }
 }


### PR DESCRIPTION
## Summary

- integrate the ExtKAGParser compatibility plugin and registry hooks
- correct container-origin motion hit bounds and orphaned TJS error contexts
- pin merged AetherInternal support for PF validation, BGM persistence, save/load skip normalization, transition state, and input=1 wait behavior

## Validation

- AetherInternal: 153/153 Artemis runtime tests passed
- exact save/Continue regression remained idle for 180 frames without unintended progression
- macOS Debug application build passed
- strict application codesign verification passed

## Dependency

- Merged private implementation: https://github.com/AetherKiri/AetherInternal/pull/13
- Pinned Internal main SHA: 7a2d44fdfade406af3cff9886324ae4cfc0bffe8

The public diff contains only public compatibility code and the private-package gitlink. Private source is not included, while same-repository CI logs and downloadable debug binaries may expose compiled private behavior.