### PR TITLE
fix(ci): package x64 macOS releases

### DIFF
--- a/.github/scripts/package-macos-app-store.sh
+++ b/.github/scripts/package-macos-app-store.sh
@@ -10,6 +10,7 @@ source_app="$1"
 output_dir="$2"
 bundle_id="${AETHER_APP_BUNDLE_ID:-com.liuyu.aether.aether}"
 team_id="${AETHER_APPLE_TEAM_ID:-3JL7FE9XQT}"
+target_arch="${AETHERKIRI_MACOS_ARCH:-x86_64}"
 marketing_version="${AETHER_APPLE_VERSION:?AETHER_APPLE_VERSION is required}"
 build_number="${AETHER_BUILD_NUMBER:?AETHER_BUILD_NUMBER is required}"
 application_certificate_base64="${IOS_DISTRIBUTION_CERTIFICATE_BASE64:?IOS_DISTRIBUTION_CERTIFICATE_BASE64 is required}"
@@ -17,6 +18,11 @@ application_certificate_password="${IOS_DISTRIBUTION_CERTIFICATE_PASSWORD:?IOS_D
 installer_certificate_base64="${MACOS_INSTALLER_CERTIFICATE_BASE64:?MACOS_INSTALLER_CERTIFICATE_BASE64 is required}"
 installer_certificate_password="${MACOS_INSTALLER_CERTIFICATE_PASSWORD:?MACOS_INSTALLER_CERTIFICATE_PASSWORD is required}"
 profile_base64="${MACOS_PROVISIONING_PROFILE_BASE64:?MACOS_PROVISIONING_PROFILE_BASE64 is required}"
+
+if [[ "$target_arch" != "arm64" && "$target_arch" != "x86_64" ]]; then
+    echo "Unsupported macOS App Store architecture: $target_arch" >&2
+    exit 1
+fi
 
 if [[ ! -d "$source_app" ]]; then
     echo "macOS app bundle not found: $source_app" >&2
@@ -161,15 +167,14 @@ if [[ "$uses_non_exempt_encryption" != "false" ]]; then
 fi
 
 # Godot currently exports only LSMinimumSystemVersionByArchitecture. App Store
-# Connect also requires the scalar LSMinimumSystemVersion key, even when the
-# application is intentionally arm64-only. Keep both values aligned with the
-# exported arm64 deployment target before sealing the bundle.
+# Connect also requires the scalar LSMinimumSystemVersion key. Keep it aligned
+# with the selected runtime architecture before sealing the bundle.
 minimum_system_version="$(
-    plutil -extract LSMinimumSystemVersionByArchitecture.arm64 raw \
+    plutil -extract "LSMinimumSystemVersionByArchitecture.$target_arch" raw \
         "$app_store_app/Contents/Info.plist"
 )"
 if [[ -z "$minimum_system_version" ]]; then
-    echo "The macOS application is missing its arm64 deployment target." >&2
+    echo "The macOS application is missing its $target_arch deployment target." >&2
     exit 1
 fi
 /usr/libexec/PlistBuddy \
@@ -183,7 +188,7 @@ scalar_system_version="$(
         "$app_store_app/Contents/Info.plist"
 )"
 if [[ "$scalar_system_version" != "$minimum_system_version" ]]; then
-    echo "The macOS scalar deployment target does not match the arm64 target." >&2
+    echo "The macOS scalar deployment target does not match the $target_arch target." >&2
     exit 1
 fi
 
@@ -206,8 +211,8 @@ plutil -create xml1 "$entitlements_path"
 while IFS= read -r -d '' runtime_binary; do
     if file -b "$runtime_binary" | grep -q 'Mach-O'; then
         runtime_architectures="$(lipo -archs "$runtime_binary")"
-        if [[ " $runtime_architectures " != *" arm64 "* ]]; then
-            echo "Mac App Store runtime is missing arm64: $runtime_binary ($runtime_architectures)" >&2
+        if [[ " $runtime_architectures " != *" $target_arch "* ]]; then
+            echo "Mac App Store runtime is missing $target_arch: $runtime_binary ($runtime_architectures)" >&2
             exit 1
         fi
         codesign --force \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -632,6 +632,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       GODOT_RELEASE: 4.7-stable
       GODOT_TEMPLATE_VERSION: 4.7.stable
+      AETHERKIRI_MACOS_ARCH: x86_64
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Fixes the macOS release packaging failure introduced when the build moved to the x86_64 output path. The workflow now declares the selected macOS architecture explicitly, and the App Store packaging script validates runtime slices and deployment metadata against that same architecture.

Validation:
- bash syntax checks pass
- workflow YAML parses successfully
- invalid and valid architecture preflight paths behave as expected
- git diff --check passes