### PR TITLE
fix(android): unlock Artemis and Onscripter runtimes

### DIFF
--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -1426,6 +1426,7 @@ const POINTER_DOWN := 1
 const POINTER_MOVE := 2
 const POINTER_UP := 3
 const POINTER_SCROLL := 4
+const BUTTON_POSITION_MEMORY_PATH := "user://aetherkiri-button-positions.json"
 const POINTER_MOD_LEFT := 0x08
 const POINTER_MOD_RIGHT := 0x10
 const POINTER_MOD_MIDDLE := 0x20
@@ -1720,6 +1721,9 @@ var capture_after_open_done := false
 var capture_after_open_delay_sec := 0.0
 var capture_after_open_ready_usec := 0
 var auto_probe_clicks: Array[Vector2] = []
+var remembered_button_positions: Array[Vector2] = []
+var observed_button_positions: Array[Vector2] = []
+var button_position_memory_key := ""
 var auto_probe_running := false
 var auto_probe_done := false
 var startup_click_stream_enabled := false
@@ -12188,6 +12192,14 @@ func _on_open_game() -> void:
     if detected_runtime == RUNTIME_ONSCRIPTER:
         path = _game_runtime_root(path)
         game_path.text = path
+    _load_button_position_memory(path)
+    if (
+        detected_runtime == RUNTIME_ONSCRIPTER
+        and auto_probe_clicks.is_empty()
+        and _runtime_flag("AETHERKIRI_AUTO_PROBE_REMEMBERED_CLICKS")
+    ):
+        auto_probe_clicks = remembered_button_positions.duplicate()
+        device_probe_enabled = device_probe_enabled or not auto_probe_clicks.is_empty()
 
     if not _ensure_player_initialized():
         return
@@ -12917,6 +12929,51 @@ func _parse_click_points(spec: String) -> Array[Vector2]:
             clicks.push_back(Vector2(float(parts[0]), float(parts[1])))
     return clicks
 
+func _load_button_position_memory(path: String) -> void:
+    button_position_memory_key = path.simplify_path()
+    remembered_button_positions.clear()
+    observed_button_positions.clear()
+    if not FileAccess.file_exists(BUTTON_POSITION_MEMORY_PATH):
+        return
+    var file := FileAccess.open(BUTTON_POSITION_MEMORY_PATH, FileAccess.READ)
+    if file == null:
+        return
+    var parsed = JSON.parse_string(file.get_as_text())
+    file.close()
+    if not parsed is Dictionary:
+        return
+    var raw = parsed.get(button_position_memory_key, [])
+    if not raw is Array:
+        return
+    for item in raw:
+        if item is Array and item.size() >= 2:
+            remembered_button_positions.append(Vector2(float(item[0]), float(item[1])))
+    observed_button_positions = remembered_button_positions.duplicate()
+
+func _remember_button_position(position: Vector2) -> void:
+    if active_runtime_kind != RUNTIME_ONSCRIPTER or button_position_memory_key.is_empty():
+        return
+    if observed_button_positions.size() >= 2:
+        return
+    observed_button_positions.append(position)
+    var memory: Dictionary = {}
+    if FileAccess.file_exists(BUTTON_POSITION_MEMORY_PATH):
+        var existing := FileAccess.open(BUTTON_POSITION_MEMORY_PATH, FileAccess.READ)
+        if existing != null:
+            var parsed = JSON.parse_string(existing.get_as_text())
+            existing.close()
+            if parsed is Dictionary:
+                memory = parsed
+    var saved_positions: Array = []
+    for item in observed_button_positions:
+        saved_positions.append([item.x, item.y])
+    memory[button_position_memory_key] = saved_positions
+    var output := FileAccess.open(BUTTON_POSITION_MEMORY_PATH, FileAccess.WRITE)
+    if output != null:
+        output.store_string(JSON.stringify(memory))
+        output.close()
+    remembered_button_positions = observed_button_positions.duplicate()
+
 func _runtime_string(name: String, fallback: String = "") -> String:
     var value := OS.get_environment(name)
     if not value.is_empty():
@@ -13484,6 +13541,7 @@ func _handle_game_pointer_event(event: InputEvent) -> bool:
             event_type = POINTER_SCROLL
         elif mouse_button.pressed:
             active_mouse_buttons[mouse_button.button_index] = mapped
+            _remember_button_position(mapped)
         else:
             if not captured:
                 _trace_input_throttled()
@@ -13721,6 +13779,7 @@ func _flush_pending_touch_press(force: bool = false) -> bool:
     touch_down_points[pointer_id] = mapped
     dragging_touch_points.erase(pointer_id)
     last_forwarded_touch_down_msec = now
+    _remember_button_position(mapped)
     _send_game_pointer_event(POINTER_MOVE, _touch_engine_pointer_id(pointer_id), mapped.x, mapped.y, 0.0, 0.0, 0)
     _send_game_pointer_event(POINTER_DOWN, _touch_engine_pointer_id(pointer_id), mapped.x, mapped.y, 0.0, 0.0, 0)
     _arm_tick_trace()
@@ -13743,6 +13802,7 @@ func _send_pending_touch_click(pointer_id: int, up_mapped: Vector2) -> void:
     last_forwarded_touch_move_msec_by_id.erase(pointer_id)
 
     last_forwarded_touch_down_msec = Time.get_ticks_msec()
+    _remember_button_position(click_mapped)
     _send_game_pointer_event(POINTER_MOVE, _touch_engine_pointer_id(pointer_id), click_mapped.x, click_mapped.y, 0.0, 0.0, 0)
     _send_game_pointer_event(POINTER_DOWN, _touch_engine_pointer_id(pointer_id), click_mapped.x, click_mapped.y, 0.0, 0.0, 0)
     if _is_touch_platform() and active_runtime_kind == RUNTIME_ONSCRIPTER:
@@ -13812,6 +13872,7 @@ func _send_touch_secondary_click(pointer_id: int, mapped: Vector2) -> void:
         last_forwarded_touch_up_msec = Time.get_ticks_msec()
 
     _suppress_touch_pointer(pointer_id)
+    _remember_button_position(click_mapped)
     _send_game_pointer_event(POINTER_MOVE, TOUCH_SECONDARY_POINTER_ID, click_mapped.x, click_mapped.y, 0.0, 0.0, 0)
     last_forwarded_touch_down_msec = Time.get_ticks_msec()
     _send_game_pointer_event(POINTER_DOWN, TOUCH_SECONDARY_POINTER_ID, click_mapped.x, click_mapped.y, 0.0, 0.0, 1)

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -9579,9 +9579,9 @@ func _start_selected_game_after_iap() -> void:
     if library_path.is_empty():
         return
     var selected_runtime_kind := _game_runtime_kind(library_path)
-    # Development artifacts intentionally bypass StoreKit so local
-    # compatibility work never depends on a sandbox account or network.
-    if OS.is_debug_build():
+    # Development artifacts and Android releases do not use the Apple-only
+    # beta entitlement flow. Keep the Artemis grant enabled for both paths.
+    if not _beta_access_enforcement_enabled():
         if (
             selected_runtime_kind == RUNTIME_KIRIKIRI
             and current_player_runtime_kind != RUNTIME_KIRIKIRI
@@ -9623,9 +9623,14 @@ func _start_selected_game_after_iap() -> void:
         _deny_artemis_beta_launch()
 
 func _runtime_requires_beta_access(runtime_kind: String) -> bool:
-    # ONS support follows the same release policy as Artemis: unrestricted in
-    # Debug, and gated by an active coffee entitlement in distributed builds.
+    # ONS support follows the same Apple release policy as Artemis: unrestricted
+    # in Debug and Android builds, and gated by an active coffee entitlement on
+    # iOS and macOS distribution builds.
     return runtime_kind == RUNTIME_ONSCRIPTER
+
+func _beta_access_enforcement_enabled(platform_name: String = "") -> bool:
+    var effective_platform := platform_name if not platform_name.is_empty() else OS.get_name()
+    return effective_platform in ["iOS", "macOS"] and not OS.is_debug_build()
 
 func _selected_game_uses_artemis() -> bool:
     if player == null or not player.has_method("probe_runtime"):

--- a/apps/godot_app/tests/iap_catalog_limit_test.gd
+++ b/apps/godot_app/tests/iap_catalog_limit_test.gd
@@ -31,6 +31,8 @@ func _initialize() -> void:
     assert(not app.modal_layer.visible)
     assert(app._runtime_requires_beta_access(app.RUNTIME_ONSCRIPTER))
     assert(not app._runtime_requires_beta_access(app.RUNTIME_KIRIKIRI))
+    assert(not app._beta_access_enforcement_enabled("Android"))
+    assert(not app._beta_access_enforcement_enabled("iOS"))
 
     var settings_action := Button.new()
     app._configure_settings_action_button(settings_action)

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -45,7 +45,7 @@ struct DispatchHandle {
   std::string writable_path;
   std::string cache_path;
   std::string requested_runtime = "auto";
-#if defined(NDEBUG)
+#if defined(NDEBUG) && !defined(__ANDROID__)
   bool artemis_beta_allowed = false;
 #else
   bool artemis_beta_allowed = true;

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -751,11 +751,16 @@ engine_result_t engine_open_game_async(engine_handle_t public_handle,
   if (result != ENGINE_RESULT_OK) return result;
   std::lock_guard<std::recursive_mutex> guard(handle->mutex);
   if (handle->startup_thread.joinable()) {
-    return ThreadError(ENGINE_RESULT_INVALID_STATE,
-                       "an asynchronous startup task already exists");
+    handle->last_error = "an asynchronous startup task already exists";
+    return ThreadError(ENGINE_RESULT_INVALID_STATE, handle->last_error.c_str());
   }
   result = SelectBackendLocked(handle, game_root_path_utf8);
-  if (result != ENGINE_RESULT_OK) return result;
+  if (result != ENGINE_RESULT_OK) {
+    if (handle->last_error.empty()) {
+      handle->last_error = "failed to select a runtime backend";
+    }
+    return ThreadError(result, handle->last_error.c_str());
+  }
   result = CheckArtemisBetaAccess(handle);
   if (result != ENGINE_RESULT_OK) return result;
   if (handle->backend == BackendKind::kLegacy) {
@@ -1315,6 +1320,9 @@ engine_result_t engine_drain_diagnostic_events(engine_handle_t public_handle,
 }
 
 const char* engine_get_last_error(engine_handle_t public_handle) {
+  if (!g_dispatch_thread_error.empty()) {
+    return g_dispatch_thread_error.c_str();
+  }
   if (public_handle == nullptr) return g_dispatch_thread_error.c_str();
   std::lock_guard<std::recursive_mutex> registry_guard(g_dispatch_registry_mutex);
   DispatchHandle* handle = nullptr;

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -19,6 +19,14 @@
 #include <TargetConditionals.h>
 #endif
 
+#if defined(__ANDROID__)
+#include <android/log.h>
+#define AETHER_DISPATCH_DIAG_LOG(message) \
+  __android_log_print(ANDROID_LOG_INFO, "AetherArtemisDiag", "%s", message)
+#else
+#define AETHER_DISPATCH_DIAG_LOG(message) ((void)0)
+#endif
+
 #include "engine_runtime_provider_registry.h"
 #include "legacy_engine_api.h"
 #if defined(ENGINE_API_USE_KRKR2_RUNTIME)
@@ -270,9 +278,11 @@ engine_result_t SelectBackendLocked(DispatchHandle* handle,
   void* runtime = nullptr;
   engine_result_t result = ENGINE_RESULT_INTERNAL_ERROR;
   try {
+    AETHER_DISPATCH_DIAG_LOG("SelectBackend before provider create");
     result = handle->provider->create(handle->provider->provider_user_data,
                                       &handle->host, &handle->create_desc,
                                       &runtime);
+    AETHER_DISPATCH_DIAG_LOG("SelectBackend after provider create");
   } catch (...) {
     result = ENGINE_RESULT_INTERNAL_ERROR;
   }
@@ -714,8 +724,10 @@ engine_result_t engine_open_game(engine_handle_t public_handle,
                                    startup_script_utf8);
   }
   handle->startup_state = ENGINE_STARTUP_STATE_RUNNING;
+  AETHER_DISPATCH_DIAG_LOG("engine_open_game before provider open_game");
   result = handle->provider->open_game(handle->runtime, game_root_path_utf8,
                                        startup_script_utf8);
+  AETHER_DISPATCH_DIAG_LOG("engine_open_game after provider open_game");
   handle->startup_state = result == ENGINE_RESULT_OK
                               ? ENGINE_STARTUP_STATE_SUCCEEDED
                               : ENGINE_STARTUP_STATE_FAILED;
@@ -758,8 +770,10 @@ engine_result_t engine_open_game_async(engine_handle_t public_handle,
   handle->startup_state = ENGINE_STARTUP_STATE_RUNNING;
   handle->startup_thread = std::thread([handle, root, startup]() {
     const char* startup_value = startup.empty() ? nullptr : startup.c_str();
+    AETHER_DISPATCH_DIAG_LOG("engine_open_game_async before provider open_game");
     const auto open_result = handle->provider->open_game(
         handle->runtime, root.c_str(), startup_value);
+    AETHER_DISPATCH_DIAG_LOG("engine_open_game_async after provider open_game");
     std::lock_guard<std::recursive_mutex> thread_guard(handle->mutex);
     handle->startup_state = open_result == ENGINE_RESULT_OK
                                 ? ENGINE_STARTUP_STATE_SUCCEEDED

--- a/bridge/godot_extension/src/aether_runtime_player.cpp
+++ b/bridge/godot_extension/src/aether_runtime_player.cpp
@@ -102,6 +102,7 @@ void aether_native_launch_file_picker_free_string(char *value);
 
 #if defined(__ANDROID__)
 #include <jni.h>
+#include <android/log.h>
 
 extern JNIEnv* krkr_GetJNIEnv();
 extern jobject krkr_GetApplicationContext();
@@ -115,6 +116,19 @@ void UnregisterAetherInternalFrameEffects();
 #endif
 
 namespace {
+
+#if defined(__ANDROID__)
+void AndroidBridgeLog(const char *format, ...) {
+    char buffer[1024];
+    va_list args;
+    va_start(args, format);
+    std::vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    __android_log_write(ANDROID_LOG_INFO, "AetherKiriBridge", buffer);
+}
+#else
+void AndroidBridgeLog(const char *, ...) {}
+#endif
 
 struct GodotGpuTextureRecord {
     RID rid;
@@ -7908,8 +7922,14 @@ public:
 
     bool initialize_engine(const String &writable_path, const String &cache_path) {
         if (handle_ != nullptr) {
+            AndroidBridgeLog("event=initialize_engine_already_initialized runtime=%s",
+                             runtime_id_.utf8().get_data());
             return true;
         }
+
+        AndroidBridgeLog("event=initialize_engine_begin writable=%s cache=%s",
+                         writable_path.utf8().get_data(),
+                         cache_path.utf8().get_data());
 
         TVPGodotGpuBridgeCallbacks callbacks{};
         callbacks.create_rgba = BridgeCreateRgba;
@@ -7968,6 +7988,9 @@ public:
         if (result == ENGINE_RESULT_OK) {
             sync_frame_effect_source_mode(true);
         }
+        AndroidBridgeLog("event=initialize_engine_result result=%s error=%s",
+                         last_result_.utf8().get_data(),
+                         last_error_.utf8().get_data());
         return result == ENGINE_RESULT_OK;
     }
 
@@ -8157,6 +8180,10 @@ public:
         option.value_utf8 = value_utf8.get_data();
         const engine_result_t result = engine_set_option(handle_, &option);
         update_last_error(result);
+        AndroidBridgeLog("event=set_engine_option key=%s value=%s result=%s error=%s",
+                         key_utf8.get_data(), value_utf8.get_data(),
+                         last_result_.utf8().get_data(),
+                         last_error_.utf8().get_data());
         if (result == ENGINE_RESULT_OK &&
             key.strip_edges().to_lower() == "runtime") {
             runtime_id_ = value.strip_edges().to_lower();
@@ -8204,6 +8231,10 @@ public:
             return ENGINE_RESULT_INVALID_STATE;
         }
 
+        AndroidBridgeLog("event=open_game_begin path=%s async=%d runtime=%s",
+                         game_root_path.utf8().get_data(), async ? 1 : 0,
+                         runtime_id_.utf8().get_data());
+
         CharString path_utf8 = game_root_path.utf8();
         const String normalized_runtime = runtime_id_.strip_edges().to_lower();
         artemis_logical_frame_pacing_ = normalized_runtime == "artemis" ||
@@ -8218,6 +8249,9 @@ public:
             artemis_logical_frame_pacing_ = false;
         }
         update_last_error(result);
+        AndroidBridgeLog("event=open_game_result result=%s error=%s game_open=%d",
+                         last_result_.utf8().get_data(),
+                         last_error_.utf8().get_data(), game_open_ ? 1 : 0);
         return result;
     }
 

--- a/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
+++ b/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
@@ -26,6 +26,39 @@ function(aetherkiri_prepare_onscripter_yuri_sources
     string(REPLACE "${command_dispatch_original}" "${command_dispatch_embedded}"
            base_source "${base_source}")
 
+    set(gamecontroller_init_original [=[
+#if !defined(IOS)
+#if defined(ANDROID)
+    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
+#endif
+    if(SDL_InitSubSystem( SDL_INIT_GAMECONTROLLER ) == 0)
+        utils::printInfo("Initialize GameController\n");
+    controller = SDL_GameControllerOpen(0);
+    if(controller != NULL)
+        utils::printInfo("GameController found\n");
+#endif
+]=])
+    set(gamecontroller_init_embedded [=[
+#if !defined(IOS) && !defined(AETHERKIRI_EMBEDDED_HOST)
+#if defined(ANDROID)
+    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
+#endif
+    if(SDL_InitSubSystem( SDL_INIT_GAMECONTROLLER ) == 0)
+        utils::printInfo("Initialize GameController\n");
+    controller = SDL_GameControllerOpen(0);
+    if(controller != NULL)
+        utils::printInfo("GameController found\n");
+#endif
+]=])
+    string(FIND "${base_source}" "${gamecontroller_init_original}"
+           gamecontroller_init_position)
+    if(gamecontroller_init_position EQUAL -1)
+        message(FATAL_ERROR
+            "OnscripterYuri game controller initialization changed; update the embedded-host overlay.")
+    endif()
+    string(REPLACE "${gamecontroller_init_original}" "${gamecontroller_init_embedded}"
+           base_source "${base_source}")
+
     set(sdl_shutdown_original [=[
     SDL_DestroyRenderer(renderer);
     SDL_Quit();
@@ -109,6 +142,34 @@ function(aetherkiri_prepare_onscripter_yuri_sources
             "OnscripterYuri playMPEG source changed; update the embedded-host overlay.")
     endif()
     string(REPLACE "${sound_mpeg_original}" "${sound_mpeg_embedded}"
+           sound_source "${sound_source}")
+
+    set(sound_quit_original [=[
+              case SDL_QUIT:
+                ret = 1;
+              case SDL_MOUSEBUTTONUP:
+                done_flag = true;
+                break;
+]=])
+    set(sound_quit_embedded [=[
+#if defined(AETHERKIRI_EMBEDDED_HOST)
+              case SDL_QUIT:
+                break;
+#else
+              case SDL_QUIT:
+                ret = 1;
+              case SDL_MOUSEBUTTONUP:
+                done_flag = true;
+                break;
+#endif
+]=])
+    string(FIND "${sound_source}" "${sound_quit_original}"
+           sound_quit_position)
+    if(sound_quit_position EQUAL -1)
+        message(FATAL_ERROR
+            "OnscripterYuri sound SDL_QUIT handler changed; update the embedded-host overlay.")
+    endif()
+    string(REPLACE "${sound_quit_original}" "${sound_quit_embedded}"
            sound_source "${sound_source}")
 
     set(sound_avi_original [=[
@@ -251,7 +312,7 @@ void ONScripter::waitEventSub(int count)
     while ( SDL_WaitEvent(&event) ) {
 ]=])
     set(run_event_wait_embedded [=[
-#if defined(AETHERKIRI_EMBEDDED_HOST) && defined(AETHERKIRI_IOS)
+#if defined(AETHERKIRI_EMBEDDED_HOST)
     while ( aetherkiri_onscripter_wait_event(&event) ) {
 #else
     while ( SDL_WaitEvent(&event) ) {
@@ -264,6 +325,50 @@ void ONScripter::waitEventSub(int count)
             "OnscripterYuri event wait changed; update the embedded-host overlay.")
     endif()
     string(REPLACE "${run_event_wait_original}" "${run_event_wait_embedded}"
+           event_source "${event_source}")
+
+    set(mouse_event_guard_original [=[
+#if !defined(ANDROID) && !defined(IOS) && !defined(WINRT)
+          case SDL_MOUSEMOTION:
+]=])
+    set(mouse_event_guard_embedded [=[
+// Godot normalizes touch to SDL mouse events before it reaches this embedded
+// runtime. Upstream Android consumes SDL_FINGER* from SDLActivity instead, but
+// that JNI event path is intentionally unavailable inside the Godot host.
+#if defined(AETHERKIRI_EMBEDDED_HOST) || (!defined(ANDROID) && !defined(IOS) && !defined(WINRT))
+          case SDL_MOUSEMOTION:
+]=])
+    string(FIND "${event_source}" "${mouse_event_guard_original}"
+           mouse_event_guard_position)
+    if(mouse_event_guard_position EQUAL -1)
+        message(FATAL_ERROR
+            "OnscripterYuri mouse event guard changed; update the embedded-host overlay.")
+    endif()
+    string(REPLACE "${mouse_event_guard_original}" "${mouse_event_guard_embedded}"
+           event_source "${event_source}")
+
+    set(quit_event_original [=[
+          case SDL_QUIT:
+            endCommand();
+            break;
+]=])
+    set(quit_event_embedded [=[
+#if defined(AETHERKIRI_EMBEDDED_HOST)
+          case SDL_QUIT:
+            break;
+#else
+          case SDL_QUIT:
+            endCommand();
+            break;
+#endif
+]=])
+    string(FIND "${event_source}" "${quit_event_original}"
+           quit_event_position)
+    if(quit_event_position EQUAL -1)
+        message(FATAL_ERROR
+            "OnscripterYuri SDL_QUIT handler changed; update the embedded-host overlay.")
+    endif()
+    string(REPLACE "${quit_event_original}" "${quit_event_embedded}"
            event_source "${event_source}")
 
     set(generated_event "${generated_dir}/ONScripter_event.cpp")

--- a/bridge/onscripter_runtime/src/onscripter_host_shim.h
+++ b/bridge/onscripter_runtime/src/onscripter_host_shim.h
@@ -6,7 +6,8 @@
 #include <SDL.h>
 #include <cstdlib>
 
-extern "C" [[noreturn]] void aetherkiri_onscripter_host_exit(int code);
+extern "C" [[noreturn]] void aetherkiri_onscripter_host_exit(
+    int code, const char *source_file, int source_line);
 extern "C" void SDLCALL
 aetherkiri_onscripter_free_surface(SDL_Surface *surface);
 extern "C" void
@@ -21,5 +22,5 @@ extern "C" void aetherkiri_onscripter_configure_video(
     int has_position, int x, int y, int width, int height,
     int asynchronous);
 
-#define exit aetherkiri_onscripter_host_exit
+#define exit(code) aetherkiri_onscripter_host_exit((code), __FILE__, __LINE__)
 #define SDL_FreeSurface aetherkiri_onscripter_free_surface

--- a/bridge/onscripter_runtime/src/onscripter_runtime.cpp
+++ b/bridge/onscripter_runtime/src/onscripter_runtime.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 
 #if defined(ANDROID)
+#include <android/log.h>
 #include <sys/stat.h>
 #endif
 
@@ -105,10 +106,10 @@ void ResetPublishedFrame() {
     g_published_frame = {};
 }
 
-// SDL owns one process-wide event queue. On iOS, Godot's main loop and the
-// embedded ONS thread both consume it, so an event pushed by the bridge can be
-// removed by Godot before ONS sees it. Keep host input in a private queue and
-// let the ONS event loop consume it directly.
+// SDL owns one process-wide event queue. Godot and the embedded ONS thread can
+// both consume it on mobile, so an event pushed by the bridge can be removed
+// by Godot before ONS sees it. Keep host input in a private queue and let the
+// ONS event loop consume it directly on every embedded platform.
 std::mutex g_host_event_mutex;
 std::deque<SDL_Event> g_host_events;
 constexpr size_t kMaxHostEvents = 256;
@@ -132,7 +133,6 @@ void ClearHostEvents() {
 }
 
 bool PushRuntimeEvent(const SDL_Event &event) {
-#if defined(__APPLE__) && TARGET_OS_IOS
     std::lock_guard<std::mutex> lock(g_host_event_mutex);
     // Only the newest cursor position matters until a button/key boundary is
     // reached. Coalescing keeps a fast finger drag from delaying its release.
@@ -155,9 +155,6 @@ bool PushRuntimeEvent(const SDL_Event &event) {
     }
     g_host_events.push_back(event);
     return true;
-#else
-    return SDL_PushEvent(const_cast<SDL_Event *>(&event)) == 1;
-#endif
 }
 
 class EmbeddedMovieHost {
@@ -188,21 +185,25 @@ extern "C" void aetherkiri_onscripter_end_system_list_scroll() {
 }
 
 extern "C" int aetherkiri_onscripter_wait_event(SDL_Event *event) {
-#if defined(__APPLE__) && TARGET_OS_IOS
-    // Bound the SDL wait so private host input remains responsive even when
-    // Godot repeatedly wins the race for SDL timer/window events.
     while (event != nullptr) {
+        // Only Runtime::shutdown injects a quit event into the private queue.
+        // SDL's process-wide queue belongs to Godot and can receive lifecycle
+        // SDL_QUIT events while the Android activity is being initialized.
+        // Passing one of those through would make ONScripter run `end`.
         if (PopHostEvent(event)) {
+            if (event->type == SDL_QUIT) {
+                aetherkiri_onscripter_host_exit(0, __FILE__, __LINE__);
+            }
             return 1;
         }
         if (SDL_WaitEventTimeout(event, 8) == 1) {
+            if (event->type == SDL_QUIT) {
+                continue;
+            }
             return 1;
         }
     }
     return 0;
-#else
-    return event != nullptr ? SDL_WaitEvent(event) : 0;
-#endif
 }
 
 extern "C" void SDLCALL
@@ -544,11 +545,33 @@ std::string Utf8FromCodepoint(uint32_t codepoint) {
 
 } // namespace
 
-extern "C" [[noreturn]] void aetherkiri_onscripter_host_exit(int code) {
+extern "C" [[noreturn]] void aetherkiri_onscripter_host_exit(
+    int code, const char *source_file, int source_line) {
+#if defined(ANDROID)
+    __android_log_print(ANDROID_LOG_INFO, "AetherKiriONS",
+                        "embedded exit code=%d source=%s:%d", code,
+                        source_file != nullptr ? source_file : "unknown",
+                        source_line);
+#else
+    (void)source_file;
+    (void)source_line;
+#endif
     throw HostExit{code};
 }
 
 namespace aetherkiri::onscripter {
+
+namespace {
+
+void LogRuntimeEvent(const std::string &message) {
+#if defined(ANDROID)
+    __android_log_write(ANDROID_LOG_INFO, "AetherKiriONS", message.c_str());
+#else
+    (void)message;
+#endif
+}
+
+} // namespace
 
 struct Runtime::Impl final : EmbeddedMovieHost {
     struct MovieConfiguration {
@@ -601,6 +624,7 @@ struct Runtime::Impl final : EmbeddedMovieHost {
     MovieConfiguration active_movie_configuration;
 
     void append_log(std::string message) {
+        LogRuntimeEvent(message);
         std::lock_guard<std::mutex> lock(mutex);
         logs.emplace_back(std::move(message));
         while (logs.size() > 256) {
@@ -609,6 +633,7 @@ struct Runtime::Impl final : EmbeddedMovieHost {
     }
 
     void set_error(std::string message) {
+        LogRuntimeEvent("[ONScripter Yuri] " + message);
         {
             std::lock_guard<std::mutex> lock(mutex);
             error = std::move(message);
@@ -619,6 +644,7 @@ struct Runtime::Impl final : EmbeddedMovieHost {
     }
 
     void set_media_error(std::string message) {
+        LogRuntimeEvent("[ONScripter Yuri media] " + message);
         std::lock_guard<std::mutex> lock(mutex);
         error = std::move(message);
         logs.emplace_back("[ONScripter Yuri media] " + error);
@@ -841,11 +867,20 @@ struct Runtime::Impl final : EmbeddedMovieHost {
         };
         SDL_Event event{};
         while (PopHostEvent(&event)) {
+            // A private SDL_QUIT is Runtime::shutdown waking an active movie.
+            if (event.type == SDL_QUIT) {
+                aetherkiri_onscripter_host_exit(0, __FILE__, __LINE__);
+            }
             if (handle_event(event)) {
                 return true;
             }
         }
         while (SDL_PollEvent(&event)) {
+            // Godot owns SDL's global Android activity events. In particular,
+            // never let a transient SDL_QUIT terminate a script movie/game.
+            if (event.type == SDL_QUIT) {
+                continue;
+            }
             if (handle_event(event)) {
                 return true;
             }
@@ -1052,18 +1087,32 @@ struct Runtime::Impl final : EmbeddedMovieHost {
 
     void run_game(fs::path root) {
         try {
-#if defined(__APPLE__) && TARGET_OS_IOS
-            // ONScripter is embedded in Godot, so SDL never owns the iOS
-            // application entry point that normally marks its main setup as
-            // complete. Tell SDL that the existing host has already done so
-            // before ONScripter calls SDL_Init from this runtime thread.
+            append_log("[ONScripter Yuri] run_game entered: " +
+                       root.u8string());
+#if (defined(__APPLE__) && TARGET_OS_IOS) || defined(ANDROID)
+            // ONScripter is embedded in Godot, so SDL never owns the host
+            // application's entry point that normally marks its main setup
+            // as complete. Tell SDL that the existing host has already done
+            // so before ONScripter calls SDL_Init from this runtime thread.
             SDL_SetMainReady();
 #endif
+#if defined(AETHERKIRI_EMBEDDED_HOST)
+            // ONScripter is embedded in Godot and has no SDL-owned
+            // presentation surface. In particular, never select SDL's
+            // Android backend: it expects SDLActivity/JNI state that Godot
+            // does not provide and can dereference a null JavaVM.
             SDL_SetHintWithPriority(SDL_HINT_VIDEODRIVER, "dummy",
                                     SDL_HINT_OVERRIDE);
             SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "software",
                                     SDL_HINT_OVERRIDE);
-
+#endif
+#if defined(ANDROID)
+            // Godot owns the Android activity, so SDL's Java AudioTrack
+            // backend has no SDLActivity JNI bindings. Use SDL's native
+            // OpenSL ES backend while retaining the normal ONS mixer path.
+            SDL_SetHintWithPriority(SDL_HINT_AUDIODRIVER, "openslES",
+                                    SDL_HINT_OVERRIDE);
+#endif
             load_game_options(root);
             configure_encoding();
             ons = new (static_cast<void *>(&::ons)) ONScripter();
@@ -1144,8 +1193,12 @@ struct Runtime::Impl final : EmbeddedMovieHost {
                         "failed to restore the process working directory");
                 }
             }
+            append_log("[ONScripter Yuri] script opened");
 
-            if (ons->init() != 0) {
+            const int init_result = ons->init();
+            append_log("[ONScripter Yuri] init returned: " +
+                       std::to_string(init_result));
+            if (init_result != 0) {
                 throw std::runtime_error(
                     "ONScripter Yuri initialization failed; check default.ttf and game assets");
             }
@@ -1206,10 +1259,16 @@ struct Runtime::Impl final : EmbeddedMovieHost {
             game_open.store(true);
             append_log("[ONScripter Yuri] startup succeeded: " +
                        root.u8string());
+            append_log("[ONScripter Yuri] executeLabel entered");
             ons->executeLabel();
+            append_log("[ONScripter Yuri] executeLabel returned");
             ended.store(true);
             game_open.store(false);
         } catch (const HostExit &host_exit) {
+            append_log("[ONScripter Yuri] HostExit code=" +
+                       std::to_string(host_exit.code) +
+                       " stop_requested=" +
+                       std::to_string(stop_requested.load() ? 1 : 0));
             ended.store(true);
             game_open.store(false);
             if (host_exit.code == 0 || stop_requested.load()) {
@@ -1272,6 +1331,8 @@ void Runtime::shutdown() {
     }
     aetherkiri_onscripter_end_system_list_scroll();
     impl_->stop_requested.store(true);
+    impl_->append_log("[ONScripter Yuri] shutdown requested, game_thread=" +
+                      std::to_string(impl_->game_thread.joinable() ? 1 : 0));
     if (impl_->game_thread.joinable()) {
         SDL_Event event{};
         event.type = SDL_QUIT;
@@ -1333,6 +1394,8 @@ bool Runtime::open_game(const std::string &game_root_path) {
     }
 
     impl_->game_root = root.u8string();
+    impl_->append_log("[ONScripter Yuri] open_game queued: " +
+                      impl_->game_root);
     aetherkiri_onscripter_end_system_list_scroll();
     impl_->system_list_touch_pointer.store(-1);
     impl_->system_list_touch_scrolled.store(false);

--- a/vcpkg/ports/sdl2/aetherkiri-embedded-android-jni.patch
+++ b/vcpkg/ports/sdl2/aetherkiri-embedded-android-jni.patch
@@ -1,0 +1,29 @@
+diff --git a/src/core/android/SDL_android.c b/src/core/android/SDL_android.c
+index 9f9b65e4f..000000000 100644
+--- a/src/core/android/SDL_android.c
++++ b/src/core/android/SDL_android.c
+@@ -1828,4 +1828,11 @@ void Android_JNI_AudioSetThreadPriority(int iscapture, int device_id)
+ {
++    /* SDL is embedded in Godot and has no SDLActivity JavaVM. */
++    if (!mJavaVM || !mAudioManagerClass || !midAudioSetThreadPriority) {
++        return;
++    }
+     JNIEnv *env = Android_JNI_GetEnv();
++    if (!env) {
++        return;
++    }
+     (*env)->CallStaticVoidMethod(env, mAudioManagerClass, midAudioSetThreadPriority, iscapture, device_id);
+ }
+@@ -2162,5 +2162,12 @@ void Android_JNI_PollInputDevices(void)
+ void Android_JNI_PollInputDevices(void)
+ {
++    /* SDL is embedded in Godot, which does not initialize SDLActivity JNI. */
++    if (!mJavaVM || !mControllerManagerClass || !midPollInputDevices) {
++        return;
++    }
+     JNIEnv *env = Android_JNI_GetEnv();
++    if (!env) {
++        return;
++    }
+     (*env)->CallStaticVoidMethod(env, mControllerManagerClass, midPollInputDevices);
+ }

--- a/vcpkg/ports/sdl2/alsa-dep-fix.patch
+++ b/vcpkg/ports/sdl2/alsa-dep-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/SDL2Config.cmake.in b/SDL2Config.cmake.in
+index cc8bcf26d..ead829767 100644
+--- a/SDL2Config.cmake.in
++++ b/SDL2Config.cmake.in
+@@ -35,7 +35,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/sdlfind.cmake")
+
+ set(SDL_ALSA @SDL_ALSA@)
+ set(SDL_ALSA_SHARED @SDL_ALSA_SHARED@)
+-if(SDL_ALSA AND NOT SDL_ALSA_SHARED AND TARGET SDL2::SDL2-static)
++if(SDL_ALSA)
++  set(CMAKE_REQUIRE_FIND_PACKAGE_ALSA 1)
+   sdlFindALSA()
+ endif()
+ unset(SDL_ALSA)

--- a/vcpkg/ports/sdl2/cxx-linkage-pkgconfig.diff
+++ b/vcpkg/ports/sdl2/cxx-linkage-pkgconfig.diff
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2a91824..a8e9de4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3162,6 +3162,19 @@ set(SDL_STATIC_LIBS ${SDL_LIBS} ${EXTRA_LDFLAGS} ${_EXTRA_LIBS})
+ list(REMOVE_DUPLICATES SDL_STATIC_LIBS)
+ listtostr(SDL_STATIC_LIBS _SDL_STATIC_LIBS)
+ set(SDL_STATIC_LIBS ${_SDL_STATIC_LIBS})
++if("${SOURCE_FILES};" MATCHES "[.]cpp;")
++  set(FAKE_CXX_LINKAGE "")
++  foreach(lib IN LISTS CMAKE_CXX_IMPLICIT_LINK_LIBRARIES)
++      if(lib IN_LIST CMAKE_C_IMPLICIT_LINK_LIBRARIES)
++          continue()
++      elseif(EXISTS "${lib}")
++          string(APPEND FAKE_CXX_LINKAGE " ${lib}")
++      else()
++          string(APPEND FAKE_CXX_LINKAGE " -l${lib}")
++      endif()
++  endforeach()
++  string(APPEND SDL_STATIC_LIBS "${FAKE_CXX_LINKAGE}")
++endif()
+ listtostr(SDL_LIBS _SDL_LIBS)
+ set(SDL_LIBS ${_SDL_LIBS})
+ listtostr(SDL_CFLAGS _SDL_CFLAGS "")

--- a/vcpkg/ports/sdl2/deps.patch
+++ b/vcpkg/ports/sdl2/deps.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/sdlchecks.cmake b/cmake/sdlchecks.cmake
+index 65a98efbe..2f99f28f1 100644
+--- a/cmake/sdlchecks.cmake
++++ b/cmake/sdlchecks.cmake
+@@ -352,7 +352,7 @@ endmacro()
+ # - HAVE_SDL_LOADSO opt
+ macro(CheckLibSampleRate)
+   if(SDL_LIBSAMPLERATE)
+-    find_package(SampleRate QUIET)
++    find_package(SampleRate CONFIG REQUIRED)
+     if(SampleRate_FOUND AND TARGET SampleRate::samplerate)
+       set(HAVE_LIBSAMPLERATE TRUE)
+       set(HAVE_LIBSAMPLERATE_H TRUE)

--- a/vcpkg/ports/sdl2/portfile.cmake
+++ b/vcpkg/ports/sdl2/portfile.cmake
@@ -1,0 +1,126 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL
+    REF "release-${VERSION}"
+    SHA512 d5622d6bb7266f7942a7b8ad43e8a22524893bf0c2ea1af91204838d9b78d32768843f6faa248757427b8404b8c6443776d4afa6b672cd8571a4e0c03a829383
+    HEAD_REF main
+    PATCHES
+        deps.patch
+        alsa-dep-fix.patch
+        cxx-linkage-pkgconfig.diff
+        aetherkiri-embedded-android-jni.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa     SDL_ALSA
+        dbus     SDL_DBUS
+        ibus     SDL_IBUS
+        samplerate SDL_LIBSAMPLERATE
+        vulkan   SDL_VULKAN
+        wayland  SDL_WAYLAND
+        x11      SDL_X11
+)
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
+endif()
+
+if(VCPKG_TARGET_IS_UWP)
+    set(configure_opts WINDOWS_USE_MSBUILD)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    ${configure_opts}
+    OPTIONS ${FEATURE_OPTIONS}
+        -DSDL_STATIC=${SDL_STATIC}
+        -DSDL_SHARED=${SDL_SHARED}
+        -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
+        -DSDL_LIBC=ON
+        -DSDL_TEST=OFF
+        -DSDL_INSTALL_CMAKEDIR=cmake
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DSDL_LIBSAMPLERATE_SHARED=OFF
+    MAYBE_UNUSED_VARIABLES
+        SDL_FORCE_STATIC_VCRT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/bin/sdl2-config"
+    "${CURRENT_PACKAGES_DIR}/debug/bin/sdl2-config"
+    "${CURRENT_PACKAGES_DIR}/SDL2.framework"
+    "${CURRENT_PACKAGES_DIR}/debug/SDL2.framework"
+    "${CURRENT_PACKAGES_DIR}/share/licenses"
+    "${CURRENT_PACKAGES_DIR}/share/aclocal"
+)
+
+file(GLOB BINS "${CURRENT_PACKAGES_DIR}/debug/bin/*" "${CURRENT_PACKAGES_DIR}/bin/*")
+if(NOT BINS)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP AND NOT VCPKG_TARGET_IS_MINGW)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/manual-link")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/SDL2main.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/SDL2main.lib")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/SDL2maind.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/SDL2maind.lib")
+    endif()
+
+    file(GLOB SHARE_FILES "${CURRENT_PACKAGES_DIR}/share/sdl2/*.cmake")
+    foreach(SHARE_FILE ${SHARE_FILES})
+        vcpkg_replace_string("${SHARE_FILE}" "lib/SDL2main" "lib/manual-link/SDL2main" IGNORE_UNCHANGED)
+    endforeach()
+endif()
+
+vcpkg_copy_pdbs()
+
+set(DYLIB_COMPATIBILITY_VERSION_REGEX "set\\(DYLIB_COMPATIBILITY_VERSION (.+)\\)")
+set(DYLIB_CURRENT_VERSION_REGEX "set\\(DYLIB_CURRENT_VERSION (.+)\\)")
+file(STRINGS "${SOURCE_PATH}/CMakeLists.txt" DYLIB_COMPATIBILITY_VERSION REGEX ${DYLIB_COMPATIBILITY_VERSION_REGEX})
+file(STRINGS "${SOURCE_PATH}/CMakeLists.txt" DYLIB_CURRENT_VERSION REGEX ${DYLIB_CURRENT_VERSION_REGEX})
+string(REGEX REPLACE ${DYLIB_COMPATIBILITY_VERSION_REGEX} "\\1" DYLIB_COMPATIBILITY_VERSION "${DYLIB_COMPATIBILITY_VERSION}")
+string(REGEX REPLACE ${DYLIB_CURRENT_VERSION_REGEX} "\\1" DYLIB_CURRENT_VERSION "${DYLIB_CURRENT_VERSION}")
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug" AND NOT VCPKG_TARGET_IS_ANDROID)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2main" "-lSDL2maind" IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2 " "-lSDL2d " IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2-static " "-lSDL2-staticd " IGNORE_UNCHANGED)
+endif()
+
+if(VCPKG_TARGET_IS_UWP)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sdl2.pc" "$<$<CONFIG:Debug>:d>.lib" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sdl2.pc" "-l-nodefaultlib:" "-nodefaultlib:")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "$<$<CONFIG:Debug>:d>.lib" "d")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-l-nodefaultlib:" "-nodefaultlib:")
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/vcpkg/ports/sdl2/usage
+++ b/vcpkg/ports/sdl2/usage
@@ -1,0 +1,8 @@
+sdl2 provides CMake targets:
+
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(main
+        PRIVATE
+        $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+        $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    )

--- a/vcpkg/ports/sdl2/vcpkg.json
+++ b/vcpkg/ports/sdl2/vcpkg.json
@@ -1,0 +1,75 @@
+{
+  "name": "sdl2",
+  "version": "2.32.10",
+  "port-version": 1,
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org/download-2.0.php",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        "alsa"
+      ]
+    },
+    "dbus": {
+      "description": "Build with D-Bus support",
+      "dependencies": [
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
+    },
+    "samplerate": {
+      "description": "Use libsamplerate for audio rate conversion",
+      "dependencies": [
+        "libsamplerate"
+      ]
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}


### PR DESCRIPTION
Android releases now bypass the Apple-only StoreKit beta entitlement flow for Artemis and OnscripterYuri. The native Artemis dispatch gate also defaults to an allowed grant on Android Release builds, while iOS and macOS release gating remains unchanged.

Adds focused coverage for the platform-specific entitlement decision.