### PR TITLE
Fix KAG dialogue rendering and font-switch stalls

### DIFF
--- a/apps/godot_app/scripts/gpu_blend_self_test.gd
+++ b/apps/godot_app/scripts/gpu_blend_self_test.gd
@@ -4,7 +4,7 @@ func _initialize() -> void:
     var player = ClassDB.instantiate("AetherRuntimePlayer")
     root.add_child(player as Node)
 
-    var modes := ["AlphaBlend", "AlphaBlend_d", "AlphaBlend_a", "CopyColor", "FillARGB", "RemoveConstOpacity", "ConstAlphaBlend_d", "PsScreenBlend", "PsMulBlend", "PsAddBlend", "PsSubBlend"]
+    var modes := ["AlphaBlend", "AlphaBlend_d", "AlphaBlend_a", "CopyColor", "FillARGB", "ApplyColorMap_a", "AdditiveAlphaBlend", "AdditiveAlphaBlend_a", "RemoveConstOpacity", "ConstAlphaBlend_d", "PsScreenBlend", "PsMulBlend", "PsAddBlend", "PsSubBlend"]
     var failed := false
     for mode in modes:
         var opacities := [255, 192, 96]

--- a/bridge/godot_extension/src/aether_runtime_player.cpp
+++ b/bridge/godot_extension/src/aether_runtime_player.cpp
@@ -1742,6 +1742,56 @@ uint ps_sub_blend(uint d, uint s, uint opa) {
     return (d & 0xff000000u) | r | (g << 8) | (b << 16);
 }
 
+uint additive_alpha_blend_hda(uint d, uint s, uint opa) {
+    if (opa != 255u) {
+        uint sr = ((s & 0xffu) * opa) >> 8;
+        uint sg = (((s >> 8) & 0xffu) * opa) >> 8;
+        uint sb = (((s >> 16) & 0xffu) * opa) >> 8;
+        uint sa = (((s >> 24) & 0xffu) * opa) >> 8;
+        s = sr | (sg << 8) | (sb << 16) | (sa << 24);
+    }
+    uint inverse_alpha = ((~s) >> 24) & 0xffu;
+    uint r = min((((d & 0xffu) * inverse_alpha) >> 8) + (s & 0xffu), 255u);
+    uint g = min(((((d >> 8) & 0xffu) * inverse_alpha) >> 8) +
+                 ((s >> 8) & 0xffu), 255u);
+    uint b = min(((((d >> 16) & 0xffu) * inverse_alpha) >> 8) +
+                 ((s >> 16) & 0xffu), 255u);
+    return (d & 0xff000000u) | r | (g << 8) | (b << 16);
+}
+
+uint additive_alpha_blend_a(uint d, uint s, uint opa) {
+    if (opa != 255u) {
+        uint sr = ((s & 0xffu) * opa) >> 8;
+        uint sg = (((s >> 8) & 0xffu) * opa) >> 8;
+        uint sb = (((s >> 16) & 0xffu) * opa) >> 8;
+        uint sa = (((s >> 24) & 0xffu) * opa) >> 8;
+        s = sr | (sg << 8) | (sb << 16) | (sa << 24);
+    }
+    uint da = (d >> 24) & 0xffu;
+    uint sa = (s >> 24) & 0xffu;
+    uint out_alpha = da + sa - ((da * sa) >> 8);
+    out_alpha -= out_alpha >> 8;
+    return (additive_alpha_blend_hda(d, s, 255u) & 0x00ffffffu) |
+           (out_alpha << 24);
+}
+
+uint apply_color_map_a(uint d, uint mask, uint opa, uvec3 color) {
+    uint source_alpha = opa == 255u ? mask : ((mask * opa) >> 8);
+    source_alpha -= source_alpha >> 8;
+    uint inverse_alpha = source_alpha ^ 0xffu;
+    uint dest_alpha = (d >> 24) & 0xffu;
+    uint out_alpha = dest_alpha + source_alpha -
+                     ((dest_alpha * source_alpha) >> 8);
+    out_alpha -= out_alpha >> 8;
+    uint r = min((((d & 0xffu) * inverse_alpha) >> 8) +
+                 ((source_alpha * color.r) >> 8), 255u);
+    uint g = min(((((d >> 8) & 0xffu) * inverse_alpha) >> 8) +
+                 ((source_alpha * color.g) >> 8), 255u);
+    uint b = min(((((d >> 16) & 0xffu) * inverse_alpha) >> 8) +
+                 ((source_alpha * color.b) >> 8), 255u);
+    return (out_alpha << 24) | r | (g << 8) | (b << 16);
+}
+
 uint remove_const_opacity(uint d, uint strength) {
     uint inv_strength = 255u - clamp(strength, 0u, 255u);
     uint a = (((d >> 24) & 0xffu) * inv_strength) >> 8;
@@ -1809,6 +1859,14 @@ void main() {
         out_color = ps_add_blend(d, s, opa);
         } else if (pc.rect1.z == 17) {
         out_color = ps_sub_blend(d, s, opa);
+        } else if (pc.rect1.z == 23) {
+        out_color = apply_color_map_a(
+            d, s & 0xffu, opa,
+            uvec3(uint(pc.color0.x), uint(pc.color0.y), uint(pc.color0.z)));
+        } else if (pc.rect1.z == 24) {
+        out_color = additive_alpha_blend_hda(d, s, opa);
+        } else if (pc.rect1.z == 25) {
+        out_color = additive_alpha_blend_a(d, s, opa);
         } else if (pc.rect1.z == 8) {
         out_color = remove_const_opacity(d, opa);
         }
@@ -7507,6 +7565,51 @@ uint32_t CpuPsSubBlend(uint32_t d, uint32_t s, int opacity) {
     return (d & 0xff000000u) | r | (g << 8) | (b << 16);
 }
 
+uint32_t CpuAdditiveAlphaBlendHda(uint32_t d, uint32_t s, int opacity) {
+    const uint32_t opa = static_cast<uint32_t>(std::clamp(opacity, 0, 255));
+    if(opa != 255u) {
+        const uint32_t rb = ((s & 0x00ff00ffu) * opa >> 8) & 0x00ff00ffu;
+        const uint32_t ga = ((s >> 8 & 0x00ff00ffu) * opa) & 0xff00ff00u;
+        s = rb | ga;
+    }
+    const uint32_t inverse_alpha = (~s) >> 24;
+    const uint32_t r = std::min(
+        (((d & 0xffu) * inverse_alpha) >> 8) + (s & 0xffu), 255u);
+    const uint32_t g = std::min(
+        (((d >> 8 & 0xffu) * inverse_alpha) >> 8) +
+            (s >> 8 & 0xffu),
+        255u);
+    const uint32_t b = std::min(
+        (((d >> 16 & 0xffu) * inverse_alpha) >> 8) +
+            (s >> 16 & 0xffu),
+        255u);
+    return (d & 0xff000000u) | r | (g << 8) | (b << 16);
+}
+
+uint32_t CpuApplyColorMapA(uint32_t d, uint32_t mask, int opacity,
+                           uint32_t color) {
+    const uint32_t opa = static_cast<uint32_t>(std::clamp(opacity, 0, 255));
+    uint32_t source_alpha = opa == 255u ? mask : ((mask * opa) >> 8);
+    source_alpha -= source_alpha >> 8;
+    const uint32_t inverse_alpha = source_alpha ^ 0xffu;
+    uint32_t out_alpha = ((d >> 24) & 0xffu) + source_alpha -
+                         ((((d >> 24) & 0xffu) * source_alpha) >> 8);
+    out_alpha -= out_alpha >> 8;
+    const uint32_t r = std::min(
+        (((d & 0xffu) * inverse_alpha) >> 8) +
+            ((source_alpha * (color & 0xffu)) >> 8),
+        255u);
+    const uint32_t g = std::min(
+        (((d >> 8 & 0xffu) * inverse_alpha) >> 8) +
+            ((source_alpha * (color >> 8 & 0xffu)) >> 8),
+        255u);
+    const uint32_t b = std::min(
+        (((d >> 16 & 0xffu) * inverse_alpha) >> 8) +
+            ((source_alpha * (color >> 16 & 0xffu)) >> 8),
+        255u);
+    return (out_alpha << 24) | r | (g << 8) | (b << 16);
+}
+
 uint32_t CpuBlendReference(uint32_t mode, uint32_t d, uint32_t s,
                            int opacity, uint32_t color) {
     switch (mode) {
@@ -7537,6 +7640,27 @@ uint32_t CpuBlendReference(uint32_t mode, uint32_t d, uint32_t s,
             return CpuPsAddBlend(d, s, opacity);
         case TVP_GODOT_GPU_BLEND_PS_SUBTRACT:
             return CpuPsSubBlend(d, s, opacity);
+        case TVP_GODOT_GPU_BLEND_APPLY_COLOR_MAP_A:
+            return CpuApplyColorMapA(d, s & 0xffu, opacity, color);
+        case TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA:
+            return CpuAdditiveAlphaBlendHda(d, s, opacity);
+        case TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA_A: {
+            const uint32_t opa =
+                static_cast<uint32_t>(std::clamp(opacity, 0, 255));
+            if(opa != 255u) {
+                const uint32_t rb =
+                    ((s & 0x00ff00ffu) * opa >> 8) & 0x00ff00ffu;
+                const uint32_t ga =
+                    ((s >> 8 & 0x00ff00ffu) * opa) & 0xff00ff00u;
+                s = rb | ga;
+            }
+            const uint32_t da = d >> 24;
+            const uint32_t sa = s >> 24;
+            uint32_t out_alpha = da + sa - ((da * sa) >> 8);
+            out_alpha -= out_alpha >> 8;
+            return (CpuAdditiveAlphaBlendHda(d, s, 255) & 0x00ffffffu) |
+                (out_alpha << 24);
+        }
         default:
             return s;
     }
@@ -7608,6 +7732,16 @@ uint32_t BlendModeFromName(const String &mode_name) {
     if (lower == "alphablend_d_mask_threshold" ||
         lower == "alpha_blend_d_mask_threshold") {
         return TVP_GODOT_GPU_BLEND_ALPHA_D_MASK_THRESHOLD;
+    }
+    if (lower == "additivealphablend_a" ||
+        lower == "additive_alpha_blend_a") {
+        return TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA_A;
+    }
+    if (lower == "additivealphablend" || lower == "additive_alpha_blend") {
+        return TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA;
+    }
+    if (lower == "applycolormap_a" || lower == "apply_color_map_a") {
+        return TVP_GODOT_GPU_BLEND_APPLY_COLOR_MAP_A;
     }
     if (lower == "psscreenblend" || lower == "ps_screen_blend") {
         return TVP_GODOT_GPU_BLEND_PS_SCREEN;

--- a/cpp/core/sound/win32/WaveMixer.cpp
+++ b/cpp/core/sound/win32/WaveMixer.cpp
@@ -1168,13 +1168,13 @@ static iTVPAudioRenderer *CreateAudioRenderer() {
     }
     spdlog::warn("iOS SDL audio renderer unavailable; falling back to OpenAL");
     delete renderer;
-#else
+#elif defined(__linux__)
     renderer = new tTVPAudioRendererSDL;
     if(renderer->Init()) {
-        spdlog::info("desktop audio renderer selected: SDL");
+        spdlog::info("Linux audio renderer selected: SDL");
         return renderer;
     }
-    spdlog::warn("desktop SDL audio renderer unavailable; falling back to OpenAL");
+    spdlog::warn("Linux SDL audio renderer unavailable; falling back to OpenAL");
     delete renderer;
 #endif
     renderer = new tTVPAudioRendererAL;

--- a/cpp/core/sound/win32/WaveMixer.cpp
+++ b/cpp/core/sound/win32/WaveMixer.cpp
@@ -1168,6 +1168,14 @@ static iTVPAudioRenderer *CreateAudioRenderer() {
     }
     spdlog::warn("iOS SDL audio renderer unavailable; falling back to OpenAL");
     delete renderer;
+#else
+    renderer = new tTVPAudioRendererSDL;
+    if(renderer->Init()) {
+        spdlog::info("desktop audio renderer selected: SDL");
+        return renderer;
+    }
+    spdlog::warn("desktop SDL audio renderer unavailable; falling back to OpenAL");
+    delete renderer;
 #endif
     renderer = new tTVPAudioRendererAL;
     renderer->Init();

--- a/cpp/core/visual/FreeTypeFontRasterizer.cpp
+++ b/cpp/core/visual/FreeTypeFontRasterizer.cpp
@@ -81,10 +81,20 @@ void FreeTypeFontRasterizer::ApplyFaceOptions(tFreeTypeFace *face) {
 }
 
 void FreeTypeFontRasterizer::ClearFallbackFaces() {
-    for(auto *face : FaceFallbacks) {
-        delete face;
-    }
     FaceFallbacks.clear();
+}
+
+class tFreeTypeFace *FreeTypeFontRasterizer::GetOrCreateFace(
+    const ttstr &name, tjs_uint32 options) {
+    const std::string key = name.AsStdString() + "|" +
+        std::to_string(options);
+    auto found = FaceCache.find(key);
+    if(found != FaceCache.end())
+        return found->second.get();
+    auto face = std::make_unique<tFreeTypeFace>(name, options);
+    auto *result = face.get();
+    FaceCache.emplace(key, std::move(face));
+    return result;
 }
 
 void FreeTypeFontRasterizer::ApplyFallbackFaces() {
@@ -112,7 +122,7 @@ void FreeTypeFontRasterizer::ApplyFallbackFaces() {
     }
 
     for(const auto &name : candidates) {
-        auto *fallback = new tFreeTypeFace(name, 0);
+        auto *fallback = GetOrCreateFace(name, 0);
         ApplyFaceOptions(fallback);
         FaceFallbacks.emplace_back(fallback);
     }
@@ -125,9 +135,9 @@ FreeTypeFontRasterizer::FreeTypeFontRasterizer() :
 FreeTypeFontRasterizer::~FreeTypeFontRasterizer() {
     std::lock_guard<std::recursive_mutex> stateLock(Mutex);
 
-    delete Face;
     Face = nullptr;
     ClearFallbackFaces();
+    FaceCache.clear();
 }
 void FreeTypeFontRasterizer::AddRef() { RefCount++; }
 //---------------------------------------------------------------------------
@@ -136,9 +146,9 @@ void FreeTypeFontRasterizer::Release() {
     LastBitmap = nullptr;
     if(RefCount == 0) {
 
-        delete Face;
         Face = nullptr;
         ClearFallbackFaces();
+        FaceCache.clear();
         delete this;
     }
 }
@@ -168,14 +178,12 @@ void FreeTypeFontRasterizer::ApplyFont(const tTVPFont &font) {
     bool recreate = false;
     if(Face) {
         if(Face->GetFontName() != stdname) {
-            delete Face;
-            Face = nullptr;
             ClearFallbackFaces();
-            Face = new tFreeTypeFace(stdname, opt);
+            Face = GetOrCreateFace(stdname, opt);
             recreate = true;
         }
     } else {
-        Face = new tFreeTypeFace(stdname, opt);
+        Face = GetOrCreateFace(stdname, opt);
         ClearFallbackFaces();
         recreate = true;
     }

--- a/cpp/core/visual/FreeTypeFontRasterizer.h
+++ b/cpp/core/visual/FreeTypeFontRasterizer.h
@@ -5,20 +5,26 @@
 #include "tjsCommHead.h"
 #include "CharacterData.h"
 #include "FontRasterizer.h"
+#include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class FreeTypeFontRasterizer : public FontRasterizer {
     tjs_int RefCount;
-    class tFreeTypeFace *Face; //!< Faceオブジェクト
+    class tFreeTypeFace *Face; //!< Non-owning current face
     std::vector<class tFreeTypeFace *> FaceFallbacks;
+    std::unordered_map<std::string, std::unique_ptr<class tFreeTypeFace>>
+        FaceCache;
     class tTVPNativeBaseBitmap *LastBitmap;
     tTVPFont CurrentFont;
     std::string CurrentExtentCacheFontKey;
     std::recursive_mutex Mutex;
     void ApplyFallbackFaces();
     void ClearFallbackFaces();
+    class tFreeTypeFace *GetOrCreateFace(const ttstr &name,
+                                         tjs_uint32 options);
     void ApplyFaceOptions(class tFreeTypeFace *face);
 
 public:

--- a/cpp/core/visual/godot/GodotGpuBridge.h
+++ b/cpp/core/visual/godot/GodotGpuBridge.h
@@ -153,6 +153,11 @@ enum TVPGodotGpuBlendMode : uint32_t {
     TVP_GODOT_GPU_BLEND_ALPHA_D_MASK_MULTIPLY = 21,
     // Threshold-mask src1 at alpha 64, then AlphaBlend_d it into dst.
     TVP_GODOT_GPU_BLEND_ALPHA_D_MASK_THRESHOLD = 22,
+    // Apply an 8-bit glyph mask using KiriKiri additive-alpha color mapping.
+    TVP_GODOT_GPU_BLEND_APPLY_COLOR_MAP_A = 23,
+    // Composite an additive-alpha source while preserving destination alpha.
+    TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA = 24,
+    TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA_A = 25,
     // draw_triangles is shared by Cubism (whose low bits describe Cubism
     // colour/alpha modes) and KiriKiri (whose low bits are the modes above).
     // Tag the latter so AlphaBlend/AlphaBlend_d are not mistaken for Cubism

--- a/cpp/core/visual/godot/GodotRenderManager.cpp
+++ b/cpp/core/visual/godot/GodotRenderManager.cpp
@@ -146,6 +146,9 @@ bool IsGpuRectFastPathEnabled(const char *name) {
                std::strcmp(name, "UnivTransBlend_d") == 0 ||
                std::strcmp(name, "UnivTransBlend_a") == 0 ||
                std::strcmp(name, "CopyColor") == 0 ||
+               std::strcmp(name, "ApplyColorMap_a") == 0 ||
+               std::strcmp(name, "AdditiveAlphaBlend") == 0 ||
+               std::strcmp(name, "AdditiveAlphaBlend_a") == 0 ||
                std::strcmp(name, "PsAddBlend") == 0 ||
                std::strcmp(name, "PsSubBlend") == 0 ||
                std::strcmp(name, "PsScreenBlend") == 0 ||
@@ -520,7 +523,8 @@ void GodotTexture2D::CreateGpuHandle(const void *pixel, int pitch) {
     }
     gpu_dirty_ = false;
     cpu_dirty_ = false;
-    if(format_ == TVPTextureFormat::RGBA) DiscardCpuStorage();
+    if(format_ == TVPTextureFormat::RGBA && !retain_cpu_shadow_)
+        DiscardCpuStorage();
 }
 
 bool GodotTexture2D::EnsureGpuHandle() {
@@ -529,17 +533,38 @@ bool GodotTexture2D::EnsureGpuHandle() {
     } else if (cpu_dirty_) {
         const auto *bridge = TVPGodotGpuBridgeGet();
         if (bridge == nullptr || bridge->update_rgba == nullptr ||
-            format_ != TVPTextureFormat::RGBA || pixels_.empty()) {
+            pixels_.empty()) {
+            return false;
+        }
+        const void *upload_pixels = pixels_.data();
+        uint32_t upload_pitch = static_cast<uint32_t>(pitch_);
+        std::vector<uint32_t> expanded_gray;
+        if(format_ == TVPTextureFormat::Gray) {
+            expanded_gray.resize(static_cast<size_t>(Width) * Height);
+            for(int y = 0; y < Height; ++y) {
+                const auto *source = pixels_.data() +
+                    static_cast<size_t>(y) * pitch_;
+                auto *destination = expanded_gray.data() +
+                    static_cast<size_t>(y) * Width;
+                for(int x = 0; x < Width; ++x) {
+                    const uint32_t value = source[x];
+                    destination[x] =
+                        value | (value << 8) | (value << 16) | 0xff000000u;
+                }
+            }
+            upload_pixels = expanded_gray.data();
+            upload_pitch = static_cast<uint32_t>(Width) * 4u;
+        } else if(format_ != TVPTextureFormat::RGBA) {
             return false;
         }
         const tTVPRect full_rect(0, 0, Width, Height);
-        if (!bridge->update_rgba(gpu_handle_, pixels_.data(),
-                                 static_cast<uint32_t>(pitch_), &full_rect)) {
+        if (!bridge->update_rgba(gpu_handle_, upload_pixels,
+                                 upload_pitch, &full_rect)) {
             return false;
         }
         gpu_dirty_ = false;
         cpu_dirty_ = false;
-        DiscardCpuStorage();
+        if(!retain_cpu_shadow_) DiscardCpuStorage();
     }
     return gpu_handle_ != 0;
 }
@@ -632,6 +657,7 @@ const void *GodotTexture2D::GetScanLineForRead(tjs_uint l) {
 void *GodotTexture2D::GetScanLineForWrite(tjs_uint l) {
     EnsureCpuReadable();
     if (l >= static_cast<tjs_uint>(Height) || pixels_.empty()) return nullptr;
+    retain_cpu_shadow_ = true;
     MarkOpacityUnknown();
     MarkCpuDirty();
     return pixels_.data() + static_cast<size_t>(l) * pitch_;
@@ -978,7 +1004,7 @@ bool GodotTexture2D::UploadCpuToGpu(bool flush_pending_gpu_writes) {
     }
     gpu_dirty_ = false;
     cpu_dirty_ = false;
-    DiscardCpuStorage();
+    if(!retain_cpu_shadow_) DiscardCpuStorage();
     return true;
 }
 
@@ -1267,6 +1293,39 @@ void GodotRenderManager::OperateRect(iTVPRenderMethod *method, iTVPTexture2D *ta
         src->UploadCpuToGpu(!DeferredGodotGpuDrainEnabled()) &&
         dst->BlendGpuFrom(src, rctar, textures[0].second,
                           TVP_GODOT_GPU_BLEND_COPY_COLOR, 255, 0)) {
+        CountGpuFastPath(method_name);
+        return;
+    }
+
+    if (method_name == "ApplyColorMap_a" && dst != nullptr && src != nullptr &&
+        IsGpuRectFastPathEnabled("ApplyColorMap_a") &&
+        RectAbsSizeMatches(rctar, textures[0].second) &&
+        RectBoundsInsideTexture(textures[0].second, src) &&
+        dst->EnsureGpuHandle() && src->EnsureGpuHandle() &&
+        src->UploadCpuToGpu(!DeferredGodotGpuDrainEnabled()) &&
+        dst->BlendGpuFrom(
+            src, rctar, textures[0].second,
+            TVP_GODOT_GPU_BLEND_APPLY_COLOR_MAP_A,
+            godot_method != nullptr ? godot_method->Opacity() : 255,
+            godot_method != nullptr ? godot_method->Color() : 0)) {
+        CountGpuFastPath(method_name);
+        return;
+    }
+
+    if ((method_name == "AdditiveAlphaBlend" ||
+         method_name == "AdditiveAlphaBlend_a") &&
+        dst != nullptr && src != nullptr &&
+        IsGpuRectFastPathEnabled(method_name.c_str()) &&
+        RectAbsSizeMatches(rctar, textures[0].second) &&
+        RectBoundsInsideTexture(textures[0].second, src) &&
+        dst->EnsureGpuHandle() && src->EnsureGpuHandle() &&
+        src->UploadCpuToGpu(!DeferredGodotGpuDrainEnabled()) &&
+        dst->BlendGpuFrom(
+            src, rctar, textures[0].second,
+            method_name == "AdditiveAlphaBlend_a"
+                ? TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA_A
+                : TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA,
+            godot_method != nullptr ? godot_method->Opacity() : 255, 0)) {
         CountGpuFastPath(method_name);
         return;
     }

--- a/cpp/core/visual/godot/GodotRenderManager.h
+++ b/cpp/core/visual/godot/GodotRenderManager.h
@@ -62,7 +62,7 @@ public:
     bool HasGodotGpuHandle() const { return gpu_handle_ != 0; }
     bool HasPendingGpuWrites() const { return gpu_dirty_ && !cpu_dirty_; }
     bool RequiresGpuReadback() const {
-        return gpu_handle_ != 0 && !cpu_dirty_ && pixels_.empty();
+        return gpu_handle_ != 0 && gpu_dirty_ && !cpu_dirty_;
     }
     uint64_t BeginGpuReadback() const;
     bool PollGpuReadback(uint64_t request, void *out_pixels,
@@ -133,6 +133,7 @@ private:
     bool cpu_dirty_ = false;
     bool opacity_known_ = false;
     bool opaque_ = false;
+    bool retain_cpu_shadow_ = false;
     bool discard_unwritten_on_partial_update_ = false;
 };
 

--- a/cpp/plugins/compatLegacyPlugins.cpp
+++ b/cpp/plugins/compatLegacyPlugins.cpp
@@ -509,6 +509,22 @@ static void wuopusInit() {
 NCB_PRE_REGIST_CALLBACK(wuopusInit);
 
 #undef NCB_MODULE_NAME
+#define NCB_MODULE_NAME TJS_W("kropus.dll")
+static void kropusInit() {
+    logOnce(TJS_W("kropus.dll"),
+            TJS_W("Opus streams are handled by the built-in Opus decoder"));
+}
+NCB_PRE_REGIST_CALLBACK(kropusInit);
+
+#undef NCB_MODULE_NAME
+#define NCB_MODULE_NAME TJS_W("KaichoTrans.dll")
+static void kaichoTransInit() {
+    logOnce(TJS_W("KaichoTrans.dll"),
+            TJS_W("Kaicho transition plug-in load is accepted"));
+}
+NCB_PRE_REGIST_CALLBACK(kaichoTransInit);
+
+#undef NCB_MODULE_NAME
 #define NCB_MODULE_NAME TJS_W("wuflac.dll")
 static void wuflacInit() {
     logOnce(TJS_W("wuflac.dll"),

--- a/cpp/plugins/compatLegacyPlugins.cpp
+++ b/cpp/plugins/compatLegacyPlugins.cpp
@@ -517,14 +517,6 @@ static void kropusInit() {
 NCB_PRE_REGIST_CALLBACK(kropusInit);
 
 #undef NCB_MODULE_NAME
-#define NCB_MODULE_NAME TJS_W("KaichoTrans.dll")
-static void kaichoTransInit() {
-    logOnce(TJS_W("KaichoTrans.dll"),
-            TJS_W("Kaicho transition plug-in load is accepted"));
-}
-NCB_PRE_REGIST_CALLBACK(kaichoTransInit);
-
-#undef NCB_MODULE_NAME
 #define NCB_MODULE_NAME TJS_W("wuflac.dll")
 static void wuflacInit() {
     logOnce(TJS_W("wuflac.dll"),

--- a/doc/verified_games.md
+++ b/doc/verified_games.md
@@ -2,7 +2,7 @@
 
 [简体中文](verified_games.zh-CN.md)
 
-Last updated: 2026-08-11
+Last updated: 2026-08-19
 
 This document tracks games that have been manually smoke-tested with
 AetherKiri. It is a compatibility notebook, not a guarantee that every route,
@@ -50,6 +50,7 @@ movie, plugin path, or save state in a title has been exhaustively validated.
 | 淫母マンション～ママは、性処理肉便器～ | macOS debug and release apps; iOS/iPadOS release app build on iPad | Startup, title/menu rendering, scene/text rendering, audio playback, basic input, and frame-enhanced 4:3 continue/menu flow with aligned hover and back-button input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | 天色＊アイルノーツ | macOS debug app | Startup, title/menu rendering, continue/load flow, background and character rendering, SD CG transition stability, scene/text rendering, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | GINKA | Windows x64 debug app | Import, startup, title/menu rendering, game-data loading, background and character rendering, and basic input | Smoke verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
+| 恋爱、初邂逅 | Linux x64 debug app | Import, startup, title/menu rendering, new-game transition, scene and dialogue rendering, Opus playback, and basic input | Smoke verified | [@KYoiRyi](https://github.com/KYoiRyi) | Original native plug-ins and local game files are not committed. |
 | NEKOPARA Vol. 1 | macOS debug app | Startup, title/menu rendering, data-load and first-save flow, scene/text rendering, E-mote character rendering and animation, rapid dialogue input, and character-layer click forwarding | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | ネコぱら After ラ・ヴレ・ファミーユ | macOS debug app | Startup, title/menu rendering, new-game flow, scene/text rendering, E-mote character rendering and animation, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |
 | ネコぱらExtra 仔ネコの日の約束 | macOS debug app; iOS/iPadOS debug app build on iPad | Import, startup, title/menu rendering, start-game flow, scene/text rendering, tear-free E-mote character rendering and animation, 420-frame no-input stability, and basic mouse/touch input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |

--- a/doc/verified_games.zh-CN.md
+++ b/doc/verified_games.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](verified_games.md)
 
-最后更新：2026-08-11
+最后更新：2026-08-19
 
 本文档记录已经用 AetherKiri 手动 smoke test 或 flow test 过的游戏。它是兼容性记录，
 不代表每条路线、每个视频、每个插件路径或每个存档状态都已经完整验证。
@@ -49,6 +49,7 @@
 | 淫母マンション～ママは、性処理肉便器～ | macOS debug 和 release app；iOS/iPadOS iPad release app build | 启动、标题/菜单渲染、场景/文字渲染、音频播放、基础输入，以及开启画面增强后的 4:3 继续/菜单流程、悬停和返回按钮坐标对齐 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | 天色＊アイルノーツ | macOS debug app | 启动、标题/菜单渲染、继续/读档流程、背景与角色立绘渲染、SD CG 切换稳定性、场景/文字渲染和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | GINKA | Windows x64 debug app | 导入、启动、标题/菜单渲染、游戏数据加载、背景与角色渲染，以及基础输入 | 冒烟验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
+| 恋爱、初邂逅 | Linux x64 debug app | 导入、启动、标题/菜单渲染、开始游戏转场、场景与对话渲染、Opus 播放和基础输入 | 冒烟验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 原始 native 插件和本地游戏文件不提交到仓库。 |
 | NEKOPARA Vol. 1 | macOS debug app | 启动、标题/菜单渲染、Data Load 与首个存档读取流程、场景/文字渲染、E-mote 角色立绘与动画、快速推进对话，以及立绘区域点击事件转发 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | ネコぱら After ラ・ヴレ・ファミーユ | macOS debug app | 启动、标题/菜单渲染、开始游戏流程、场景/文字渲染、E-mote 角色立绘与动画，以及基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |
 | ネコぱらExtra 仔ネコの日の約束 | macOS debug app；iOS/iPadOS iPad debug app build | 导入、启动、标题/菜单渲染、开始游戏流程、场景/文字渲染、无撕裂的 E-mote 角色立绘与动画、420 帧零输入稳定性，以及基础鼠标/触控输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |

--- a/tests/unit-tests/plugins/godot-texture.cpp
+++ b/tests/unit-tests/plugins/godot-texture.cpp
@@ -35,6 +35,11 @@ enum class GpuCall {
 
 TriangleDrawCall g_triangle_draw_call;
 int g_blend_rect_calls = 0;
+int g_read_rgba_calls = 0;
+int g_update_rgba_calls = 0;
+uint32_t g_last_blend_mode = 0;
+uint32_t g_last_blend_color = 0;
+int g_last_blend_opacity = 0;
 uint64_t g_next_texture_handle = 1;
 uint64_t g_next_readback_handle = 101;
 uint64_t g_last_discarded_readback = 0;
@@ -52,6 +57,7 @@ void ReleaseTestTexture(uint64_t) {}
 
 bool ReadTestGrayTexture(uint64_t, void *out_pixels, size_t out_pixels_size,
                          uint32_t stride_bytes) {
+    ++g_read_rgba_calls;
     if(out_pixels == nullptr || out_pixels_size < 24 || stride_bytes != 12)
         return false;
 
@@ -60,6 +66,12 @@ bool ReadTestGrayTexture(uint64_t, void *out_pixels, size_t out_pixels_size,
         44, 44, 44, 255, 55, 55, 55, 255, 66, 66, 66, 255,
     };
     std::memcpy(out_pixels, rgba.data(), rgba.size());
+    return true;
+}
+
+bool UpdateTestTexture(uint64_t, const void *, uint32_t,
+                       const tTVPRect *) {
+    ++g_update_rgba_calls;
     return true;
 }
 
@@ -100,9 +112,12 @@ bool DrawTestTriangles(uint64_t dst, uint64_t src, uint32_t triangle_count,
 }
 
 bool BlendTestRect(uint64_t, uint64_t, const tTVPRect *, const tTVPRect *,
-                   uint32_t, int, uint32_t) {
+                   uint32_t mode, int opacity, uint32_t color) {
     g_gpu_calls.push_back(GpuCall::Blend);
     ++g_blend_rect_calls;
+    g_last_blend_mode = mode;
+    g_last_blend_color = color;
+    g_last_blend_opacity = opacity;
     return true;
 }
 
@@ -130,6 +145,11 @@ public:
     TestGpuBridge() {
         g_triangle_draw_call = {};
         g_blend_rect_calls = 0;
+        g_read_rgba_calls = 0;
+        g_update_rgba_calls = 0;
+        g_last_blend_mode = 0;
+        g_last_blend_color = 0;
+        g_last_blend_opacity = 0;
         g_next_texture_handle = 1;
         g_next_readback_handle = 101;
         g_last_discarded_readback = 0;
@@ -141,6 +161,7 @@ public:
         TVPGodotGpuBridgeCallbacks callbacks{};
         callbacks.create_rgba = CreateTestTexture;
         callbacks.release_texture = ReleaseTestTexture;
+        callbacks.update_rgba = UpdateTestTexture;
         callbacks.draw_triangles = DrawTestTriangles;
         callbacks.blend_rect = BlendTestRect;
         callbacks.read_rgba = ReadTestGrayTexture;
@@ -611,6 +632,47 @@ TEST_CASE("Godot Gray textures extract province pixels after GPU writes") {
     CHECK(row[3] == 0xee);
 }
 
+TEST_CASE("Godot textures retain CPU shadows after script writes") {
+    TestGpuBridge bridge;
+    const std::array<std::uint8_t, 8> pixels = {
+        1, 2, 3, 255, 4, 5, 6, 255,
+    };
+    GodotTexture2D texture(pixels.data(), 8, 2, 1,
+                           TVPTextureFormat::RGBA);
+    REQUIRE(texture.EnsureGpuHandle());
+
+    auto *first = static_cast<std::uint8_t *>(texture.GetScanLineForWrite(0));
+    REQUIRE(first != nullptr);
+    const int reads_after_first_write = g_read_rgba_calls;
+    first[0] = 9;
+    REQUIRE(texture.UploadCpuToGpu());
+    REQUIRE(g_update_rgba_calls == 1);
+
+    auto *second = static_cast<std::uint8_t *>(texture.GetScanLineForWrite(0));
+    REQUIRE(second != nullptr);
+    CHECK(g_read_rgba_calls == reads_after_first_write);
+    CHECK(second[0] == 9);
+}
+
+TEST_CASE("Godot Gray textures update reused GPU glyph masks") {
+    TestGpuBridge bridge;
+    const std::array<std::uint8_t, 6> pixels = {1, 2, 3, 4, 5, 6};
+    GodotTexture2D texture(pixels.data(), 3, 3, 2,
+                           TVPTextureFormat::Gray);
+    REQUIRE(texture.EnsureGpuHandle());
+
+    auto *row = static_cast<std::uint8_t *>(texture.GetScanLineForWrite(0));
+    REQUIRE(row != nullptr);
+    row[1] = 99;
+    REQUIRE(texture.EnsureGpuHandle());
+
+    CHECK(g_update_rgba_calls == 1);
+    const auto *retained = static_cast<const std::uint8_t *>(
+        texture.GetScanLineForRead(0));
+    REQUIRE(retained != nullptr);
+    CHECK(retained[1] == 99);
+}
+
 TEST_CASE("Godot texture updates clip off-texture rectangles") {
     GodotTexture2D texture(nullptr, 0, 2, 2, TVPTextureFormat::RGBA);
     const std::array<std::uint8_t, 16> pixels = {
@@ -638,6 +700,91 @@ TEST_CASE("Godot texture updates reallocate when the pixel format changes") {
     CHECK(texture.GetFormat() == TVPTextureFormat::RGBA);
     CHECK(texture.GetPitch() == 8);
     CHECK(texture.GetPoint(1, 0) == 0xff060504u);
+}
+
+TEST_CASE("Godot render manager applies glyph color maps on the GPU") {
+    TestGpuBridge bridge;
+    const std::array<std::uint8_t, 8> mask = {0, 64, 128, 255, 0, 0, 0, 0};
+    const std::array<std::uint8_t, 16> destination = {
+        1, 2, 3, 4, 5, 6, 7, 8,
+        9, 10, 11, 12, 13, 14, 15, 16,
+    };
+    GodotTexture2D src(mask.data(), 4, 4, 1, TVPTextureFormat::Gray);
+    GodotTexture2D dst(destination.data(), 16, 4, 1,
+                       TVPTextureFormat::RGBA);
+    GodotRenderMethod method(nullptr);
+    method.SetName("ApplyColorMap_a");
+    method.SetParameterColor4B(-1, 0x00112233u);
+    method.SetParameterOpa(-1, 192);
+    const tTVPRect rect(0, 0, 4, 1);
+    std::pair<iTVPTexture2D *, tTVPRect> source(&src, rect);
+    const tRenderTexRectArray textures(&source, 1);
+    GodotRenderManager manager;
+
+    manager.OperateRect(&method, &dst, nullptr, rect, textures);
+
+    CHECK(g_blend_rect_calls == 1);
+    CHECK(g_last_blend_mode == TVP_GODOT_GPU_BLEND_APPLY_COLOR_MAP_A);
+    CHECK(g_last_blend_color == 0x00112233u);
+    CHECK(g_last_blend_opacity == 192);
+}
+
+TEST_CASE("Godot render manager composites additive-alpha layers on the GPU") {
+    TestGpuBridge bridge;
+    const std::array<std::uint8_t, 16> source_pixels = {
+        1, 2, 3, 4, 5, 6, 7, 8,
+        9, 10, 11, 12, 13, 14, 15, 16,
+    };
+    const std::array<std::uint8_t, 16> destination_pixels = {
+        16, 15, 14, 13, 12, 11, 10, 9,
+        8, 7, 6, 5, 4, 3, 2, 1,
+    };
+    GodotTexture2D src(source_pixels.data(), 16, 4, 1,
+                       TVPTextureFormat::RGBA);
+    GodotTexture2D dst(destination_pixels.data(), 16, 4, 1,
+                       TVPTextureFormat::RGBA);
+    GodotRenderMethod method(nullptr);
+    method.SetName("AdditiveAlphaBlend");
+    method.SetParameterOpa(-1, 192);
+    const tTVPRect rect(0, 0, 4, 1);
+    std::pair<iTVPTexture2D *, tTVPRect> source(&src, rect);
+    const tRenderTexRectArray textures(&source, 1);
+    GodotRenderManager manager;
+
+    manager.OperateRect(&method, &dst, nullptr, rect, textures);
+
+    CHECK(g_blend_rect_calls == 1);
+    CHECK(g_last_blend_mode == TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA);
+    CHECK(g_last_blend_opacity == 192);
+}
+
+TEST_CASE("Godot render manager composites additive-alpha destination layers on the GPU") {
+    TestGpuBridge bridge;
+    const std::array<std::uint8_t, 16> source_pixels = {
+        1, 2, 3, 4, 5, 6, 7, 8,
+        9, 10, 11, 12, 13, 14, 15, 16,
+    };
+    const std::array<std::uint8_t, 16> destination_pixels = {
+        16, 15, 14, 13, 12, 11, 10, 9,
+        8, 7, 6, 5, 4, 3, 2, 1,
+    };
+    GodotTexture2D src(source_pixels.data(), 16, 4, 1,
+                       TVPTextureFormat::RGBA);
+    GodotTexture2D dst(destination_pixels.data(), 16, 4, 1,
+                       TVPTextureFormat::RGBA);
+    GodotRenderMethod method(nullptr);
+    method.SetName("AdditiveAlphaBlend_a");
+    method.SetParameterOpa(-1, 192);
+    const tTVPRect rect(0, 0, 4, 1);
+    std::pair<iTVPTexture2D *, tTVPRect> source(&src, rect);
+    const tRenderTexRectArray textures(&source, 1);
+    GodotRenderManager manager;
+
+    manager.OperateRect(&method, &dst, nullptr, rect, textures);
+
+    CHECK(g_blend_rect_calls == 1);
+    CHECK(g_last_blend_mode == TVP_GODOT_GPU_BLEND_ADDITIVE_ALPHA_A);
+    CHECK(g_last_blend_opacity == 192);
 }
 
 TEST_CASE("Godot textures tag Kirikiri triangle blend modes") {


### PR DESCRIPTION
## Summary

- keep script-written texture shadows and incrementally upload reused Gray glyph masks
- add verified Godot GPU paths for `ApplyColorMap_a`, `AdditiveAlphaBlend`, and `AdditiveAlphaBlend_a`
- cache FreeType faces per rasterizer so alternating fonts do not repeatedly decompress XP3 font streams and call `FT_Open_Face`
- use the existing SDL mixer on Linux with OpenAL fallback and map `kropus.dll` to the built-in Opus decoder
- document Linux smoke verification for `恋爱、初邂逅`

## Validation

- normal Aether GUI, Godot Native Vulkan, 20 consecutive dialogue advances
  - before face cache: 0.4-1.7 s `app_us` stalls, observed minimum 7 FPS
  - after face cache: median 143 ms, maximum 335 ms, observed minimum 45 FPS, returning to 60 FPS after each line
- `perf record -F 999 -g` before/after on the same flow
  - before: top self hotspot was `inflate_fast`, called through XP3 stream reads and `FT_Open_Face`
  - after: no `inflate_fast` or `OpenFaceByIndex` samples in the report
- 5 related C++ tests: 23 assertions passed
- real Vulkan blend self-test: 9 opacity/mode combinations, 0 mismatches
- full plugin suite: 155/157 cases passed
  - isolated native-randomness test passes (full-suite random-order state leak)
  - existing GBK/EUC-JP expectation still fails with the available `AetherInternal` checkout

## Scope notes

- `KaichoTrans.dll` was reverse engineered as `blur`/`dim` transition providers, but this title does not reference those methods; no empty compatibility stub is included.
- SDL-first audio selection is restricted to Linux and does not alter Windows, macOS, iOS, or Android selection.
- Original native plug-ins and game files are not committed.
