### PR TITLE
feat: add native local-model translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if(AETHERKIRI_ENABLE_INTERNAL)
     find_package(AetherInternal CONFIG QUIET
         NO_DEFAULT_PATH)
     if(AetherInternal_FOUND)
-        if(NOT AETHERINTERNAL_PACKAGE_API_VERSION EQUAL 6 OR
+        if(NOT AETHERINTERNAL_PACKAGE_API_VERSION EQUAL 7 OR
            NOT AETHERINTERNAL_REQUIRED_MOTIONPLAYER_API_VERSION EQUAL
                AETHERKIRI_MOTIONPLAYER_BACKEND_API_VERSION OR
            NOT AETHERINTERNAL_REQUIRED_LIVE2D_HOST_API_VERSION EQUAL
@@ -124,6 +124,7 @@ if(AETHERKIRI_ENABLE_INTERNAL)
            NOT COMMAND aetherinternal_extend_legacy_plugins OR
            NOT COMMAND aetherinternal_extend_live2d OR
            NOT COMMAND aetherinternal_extend_artemis OR
+           NOT COMMAND aetherinternal_extend_text_translation OR
            NOT COMMAND aetherinternal_extend_godot_extension OR
            NOT COMMAND aetherinternal_extend_krkr2plugin OR
            NOT COMMAND aetherinternal_extend_krkr2plugin_tests)

--- a/apps/godot_app/scripts/game_virtual_controls.gd
+++ b/apps/godot_app/scripts/game_virtual_controls.gd
@@ -83,6 +83,7 @@ var _panel_controls: Array[Control] = []
 var _interactive_controls: Array[Control] = []
 var _cursor_touch_index := -1
 var _cursor_mouse_dragging := false
+var _cursor_initialized := false
 var _cursor_drag_has_position := false
 var _cursor_drag_last_screen_position := Vector2.ZERO
 var _menu_touch_index := -1
@@ -393,12 +394,14 @@ func layout(_window_size: Vector2, safe_rect: Rect2) -> void:
     scroll_down_button.position = Vector2(scroll_x, scroll_top + diameter + gap)
     scroll_down_button.size = key_size
 
-    if (
-        cursor_handle.position == Vector2.ZERO
-        or not safe_rect.has_point(cursor_handle.position + CURSOR_HOTSPOT)
-    ):
+    if not _cursor_initialized:
         cursor_handle.position = safe_rect.get_center() - CURSOR_HOTSPOT
+        _cursor_initialized = true
     cursor_handle.size = Vector2.ONE * CURSOR_SIZE
+    # Preserve the pointer across repeated safe-area layouts. Rect2.has_point()
+    # excludes its right and bottom edges, so using it here used to recenter a
+    # cursor whose hotspot was correctly clamped exactly onto either edge.
+    # _clamp_cursor() constrains the hotspot itself and keeps the arrow there.
     _clamp_cursor()
 
 func owns_viewport_pointer(event: InputEvent) -> bool:

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -159,6 +159,12 @@ const UI_TEXT := {
         "settings.section.purchases": "内购项目",
         "settings.language": "语言",
         "settings.language_desc": "默认跟随系统；也可以固定为简体中文、繁体中文、英语、日语或韩语",
+        "settings.translation_model": "本地翻译模型",
+        "settings.translation_model_desc": "选择外部 GGUF 模型。游戏启动时加载；检测到文本不是当前界面语言时自动翻译",
+        "settings.translation_model_select": "选择 GGUF 模型",
+        "settings.translation_model_selected": "已选模型",
+        "settings.translation_model_clear": "停用本地翻译",
+        "settings.translation_model_clear_desc": "清除模型路径；不会删除磁盘上的模型文件",
         "settings.style": "风格",
         "settings.style_desc": "可在当前深色风格和旧版原始浅色风格之间切换",
         "settings.ui_scale": "界面比例",
@@ -370,7 +376,9 @@ const UI_TEXT := {
         "alert.warning_title": "Aether 警告",
         "alert.runtime_class_missing": "运行时扩展加载失败：AetherRuntimePlayer 不可用",
         "alert.runtime_create_failed": "运行时扩展加载失败：无法创建 AetherRuntimePlayer",
-        "loading.title": "正在启动视觉小说..."
+        "loading.title": "正在启动视觉小说...",
+        "loading.translation_model": "正在加载本地翻译模型...",
+        "loading.translation_model_detail": "首次加载可能出现短暂卡顿，请耐心等待。"
     },
     LANG_ZH_HANT: {
         "home.subtitle": "多功能媒體播放器",
@@ -426,6 +434,12 @@ const UI_TEXT := {
         "settings.section.purchases": "App 內購買",
         "settings.language": "語言",
         "settings.language_desc": "預設跟隨系統；也可以固定為簡體中文、繁體中文、英語、日語或韓語",
+        "settings.translation_model": "本機翻譯模型",
+        "settings.translation_model_desc": "選擇外部 GGUF 模型。遊戲啟動時載入；偵測到文字不是目前介面語言時自動翻譯",
+        "settings.translation_model_select": "選擇 GGUF 模型",
+        "settings.translation_model_selected": "已選模型",
+        "settings.translation_model_clear": "停用本機翻譯",
+        "settings.translation_model_clear_desc": "清除模型路徑；不會刪除磁碟上的模型檔案",
         "settings.style": "風格",
         "settings.style_desc": "可在目前深色風格和舊版原始淺色風格之間切換",
         "settings.ui_scale": "介面比例",
@@ -637,7 +651,9 @@ const UI_TEXT := {
         "alert.warning_title": "Aether 警告",
         "alert.runtime_class_missing": "執行時擴充載入失敗：AetherRuntimePlayer 不可用",
         "alert.runtime_create_failed": "執行時擴充載入失敗：無法建立 AetherRuntimePlayer",
-        "loading.title": "正在啟動視覺小說..."
+        "loading.title": "正在啟動視覺小說...",
+        "loading.translation_model": "正在載入本機翻譯模型...",
+        "loading.translation_model_detail": "首次載入可能會短暫停頓，請耐心等候。"
     },
     LANG_EN: {
         "home.subtitle": "Multifunction Media Player",
@@ -693,6 +709,12 @@ const UI_TEXT := {
         "settings.section.purchases": "In-App Purchases",
         "settings.language": "Language",
         "settings.language_desc": "Defaults to the system language; you can pin Simplified Chinese, Traditional Chinese, English, Japanese, or Korean",
+        "settings.translation_model": "Local Translation Model",
+        "settings.translation_model_desc": "Choose an external GGUF model. It loads when a game starts and translates text that does not match the interface language",
+        "settings.translation_model_select": "Choose GGUF Model",
+        "settings.translation_model_selected": "Selected Model",
+        "settings.translation_model_clear": "Disable Local Translation",
+        "settings.translation_model_clear_desc": "Clear the model path without deleting the model file from disk",
         "settings.style": "Style",
         "settings.style_desc": "Switch between the current dark style and the original classic light style",
         "settings.ui_scale": "Interface Scale",
@@ -904,7 +926,9 @@ const UI_TEXT := {
         "alert.warning_title": "Aether Warning",
         "alert.runtime_class_missing": "Runtime extension failed to load: AetherRuntimePlayer is unavailable",
         "alert.runtime_create_failed": "Runtime extension failed to load: could not create AetherRuntimePlayer",
-        "loading.title": "Launching visual novel..."
+        "loading.title": "Launching visual novel...",
+        "loading.translation_model": "Loading local translation model...",
+        "loading.translation_model_detail": "The first load may pause briefly. Please wait."
     },
     LANG_JA: {
         "home.subtitle": "多機能メディアプレーヤー",
@@ -960,6 +984,12 @@ const UI_TEXT := {
         "settings.section.purchases": "アプリ内課金",
         "settings.language": "言語",
         "settings.language_desc": "既定ではシステムに従います。簡体字中国語、繁体字中国語、英語、日本語、韓国語に固定できます",
+        "settings.translation_model": "ローカル翻訳モデル",
+        "settings.translation_model_desc": "外部 GGUF モデルを選択します。ゲーム開始時に読み込み、UI 言語と異なるテキストを自動翻訳します",
+        "settings.translation_model_select": "GGUF モデルを選択",
+        "settings.translation_model_selected": "選択中のモデル",
+        "settings.translation_model_clear": "ローカル翻訳を無効化",
+        "settings.translation_model_clear_desc": "モデルファイルを削除せず、設定済みのパスだけを消去します",
         "settings.style": "スタイル",
         "settings.style_desc": "現在のダークスタイルと旧来のクラシックライトスタイルを切り替えます",
         "settings.ui_scale": "UI スケール",
@@ -1171,7 +1201,9 @@ const UI_TEXT := {
         "alert.warning_title": "Aether 警告",
         "alert.runtime_class_missing": "ランタイム拡張の読み込みに失敗しました：AetherRuntimePlayer は利用できません",
         "alert.runtime_create_failed": "ランタイム拡張の読み込みに失敗しました：AetherRuntimePlayer を作成できません",
-        "loading.title": "ビジュアルノベルを起動中..."
+        "loading.title": "ビジュアルノベルを起動中...",
+        "loading.translation_model": "ローカル翻訳モデルを読み込み中...",
+        "loading.translation_model_detail": "初回の読み込みは一時的に停止することがあります。しばらくお待ちください。"
     },
     LANG_KO: {
         "home.subtitle": "다기능 미디어 플레이어",
@@ -1227,6 +1259,12 @@ const UI_TEXT := {
         "settings.section.purchases": "앱 내 구입",
         "settings.language": "언어",
         "settings.language_desc": "기본값은 시스템 언어입니다. 중국어 간체, 중국어 번체, 영어, 일본어, 한국어로 고정할 수 있습니다",
+        "settings.translation_model": "로컬 번역 모델",
+        "settings.translation_model_desc": "외부 GGUF 모델을 선택합니다. 게임 시작 시 불러오며 UI 언어와 다른 텍스트를 자동 번역합니다",
+        "settings.translation_model_select": "GGUF 모델 선택",
+        "settings.translation_model_selected": "선택한 모델",
+        "settings.translation_model_clear": "로컬 번역 사용 안 함",
+        "settings.translation_model_clear_desc": "디스크의 모델 파일은 삭제하지 않고 설정된 경로만 지웁니다",
         "settings.style": "스타일",
         "settings.style_desc": "현재 다크 스타일과 기존 클래식 라이트 스타일을 전환합니다",
         "settings.ui_scale": "인터페이스 크기",
@@ -1438,7 +1476,9 @@ const UI_TEXT := {
         "alert.warning_title": "Aether 경고",
         "alert.runtime_class_missing": "런타임 확장 로드 실패: AetherRuntimePlayer를 사용할 수 없습니다",
         "alert.runtime_create_failed": "런타임 확장 로드 실패: AetherRuntimePlayer를 만들 수 없습니다",
-        "loading.title": "비주얼 노벨 실행 중..."
+        "loading.title": "비주얼 노벨 실행 중...",
+        "loading.translation_model": "로컬 번역 모델을 불러오는 중...",
+        "loading.translation_model_detail": "처음 불러올 때 잠시 멈출 수 있습니다. 기다려 주세요."
     }
 }
 
@@ -1455,6 +1495,10 @@ const STARTUP_IDLE := 0
 const STARTUP_RUNNING := 1
 const STARTUP_SUCCEEDED := 2
 const STARTUP_FAILED := 3
+const TEXT_TRANSLATION_DISABLED := 0
+const TEXT_TRANSLATION_LOADING := 1
+const TEXT_TRANSLATION_READY := 2
+const TEXT_TRANSLATION_FAILED := 3
 
 const POINTER_DOWN := 1
 const POINTER_MOVE := 2
@@ -1511,6 +1555,7 @@ const SETTINGS_DRAFT_KEYS := [
     "plugin_load_mode",
     "mock_enabled",
     "error_dialog_logs",
+    "text_translation_model_path",
 ]
 const DIAGNOSTIC_PROFILES := ["off", "baseline", "input", "render", "storage", "script", "audio", "video", "plugin", "system", "full"]
 const DEBUG_OVERLAY_MODES := ["off", "summary", "detail"]
@@ -1594,6 +1639,8 @@ var home_layout_initialized := false
 var home_header_compact := false
 var home_header_layout_initialized := false
 var loading_title_label: Label
+var loading_detail_label: Label
+var translation_loading_notice_active := false
 var selected_game := {}
 var detail_hero_cover: Control
 var hero_source_rect := Rect2()
@@ -1628,6 +1675,7 @@ var console_log_file := false
 var trace_log := false
 var export_scripts := false
 var error_dialog_logs := OS.is_debug_build()
+var text_translation_model_path := ""
 var advanced_tool_expanded := false
 var advanced_expiry_msec := {}
 var diagnostic_env_originals := {}
@@ -1675,6 +1723,7 @@ var native_launch_file_picker_pending := false
 var native_launch_file_picker_library_path := ""
 var native_cover_file_picker_pending := false
 var native_cover_file_picker_library_path := ""
+var native_translation_model_file_picker_pending := false
 var active_game_path := ""
 var active_game_started_msec := 0
 var active_runtime_kind := RUNTIME_KIRIKIRI
@@ -3046,6 +3095,9 @@ func _layout_shell(window_size: Vector2) -> void:
 func _load_shell_settings() -> void:
     var cfg := ConfigFile.new()
     var env_style := _runtime_string("AETHERKIRI_STYLE_MODE", "")
+    var env_translation_model_path := _runtime_string(
+        "AETHERKIRI_TRANSLATION_MODEL", ""
+    )
     var env_frame_enhancement_kind := _runtime_string(
         "AETHERKIRI_FRAME_ENHANCEMENT_KIND",
         ""
@@ -3055,6 +3107,7 @@ func _load_shell_settings() -> void:
         ""
     )
     if cfg.load(SETTINGS_FILE) != OK:
+        text_translation_model_path = env_translation_model_path
         var env_surface_mode := _runtime_string("AETHERKIRI_SURFACE_MODE", "")
         if not env_surface_mode.is_empty():
             _select_config_surface_mode(env_surface_mode)
@@ -3077,6 +3130,11 @@ func _load_shell_settings() -> void:
         _apply_style_mode()
         return
     language_mode = _normalize_language_mode(String(cfg.get_value("interface", "language", language_mode)))
+    text_translation_model_path = String(cfg.get_value(
+        "translation", "model_path", text_translation_model_path
+    ))
+    if not env_translation_model_path.is_empty():
+        text_translation_model_path = env_translation_model_path
     _apply_language_mode()
     style_mode = _normalize_style_mode(String(cfg.get_value("interface", "style", style_mode)))
     ios_ui_scale_mode = String(cfg.get_value("interface", "ios_ui_scale_mode", ios_ui_scale_mode))
@@ -3202,6 +3260,7 @@ func _save_shell_settings() -> void:
     cfg.set_value("interface", "language", language_mode)
     cfg.set_value("interface", "style", style_mode)
     cfg.set_value("interface", "ios_ui_scale_mode", ios_ui_scale_mode)
+    cfg.set_value("translation", "model_path", text_translation_model_path)
     cfg.set_value("rendering", "backend", selected_backend)
     cfg.set_value("rendering", "upscale_algorithm", upscale_algorithm)
     cfg.set_value("rendering", "output_resolution", output_resolution)
@@ -3270,6 +3329,7 @@ func _current_settings_snapshot() -> Dictionary:
         "plugin_load_mode": plugin_load_mode,
         "mock_enabled": mock_enabled,
         "error_dialog_logs": error_dialog_logs,
+        "text_translation_model_path": text_translation_model_path,
     }
 
 func _settings_snapshots_equal(left: Dictionary, right: Dictionary) -> bool:
@@ -3442,6 +3502,9 @@ func _apply_settings_snapshot(snapshot: Dictionary) -> void:
         plugin_load_mode = "krkrsdl3"
     mock_enabled = bool(snapshot.get("mock_enabled", mock_enabled))
     error_dialog_logs = bool(snapshot.get("error_dialog_logs", error_dialog_logs))
+    text_translation_model_path = String(snapshot.get(
+        "text_translation_model_path", text_translation_model_path
+    ))
 
 func _save_settings_draft() -> void:
     if settings_draft.is_empty() or not dirty_settings:
@@ -3513,6 +3576,18 @@ func _apply_engine_options() -> void:
     player.set_engine_option("console_log_file", "1" if console_log_file else "0")
     player.set_engine_option("trace_log", "1" if effective_trace_log else "0")
     player.set_engine_option("input_trace", "1" if effective_input_trace else "0")
+    if player.has_method("is_text_translation_available") and player.is_text_translation_available():
+        _restore_native_translation_model_access()
+        player.set_engine_option(
+            "text_translation.model_path", text_translation_model_path
+        )
+        player.set_engine_option(
+            "text_translation.target_language", active_language
+        )
+        player.set_engine_option(
+            "text_translation.enabled",
+            "0" if text_translation_model_path.is_empty() else "1"
+        )
     # A synchronous Artemis resource load can make the next Godot frame carry
     # hundreds of milliseconds. Keep visual evolution incremental so authored
     # E-mote expressions and fades cannot collapse into a one-frame flash.
@@ -3891,9 +3966,10 @@ func _layout_perf_overlay(safe_rect: Rect2) -> void:
         return
     var horizontal_margin := 16.0
     perf_panel.position = safe_rect.position + Vector2(horizontal_margin, 12.0)
+    var translation_height := 36.0 if _translation_model_configured() else 0.0
     perf_panel.size = Vector2(
         maxf(240.0, safe_rect.size.x - horizontal_margin * 2.0),
-        136.0 if debug_overlay_mode == "detail" else 104.0
+        (136.0 if debug_overlay_mode == "detail" else 104.0) + translation_height
     )
 
 func _set_perf_visible(visible: bool) -> void:
@@ -4606,6 +4682,27 @@ func _rebuild_settings_view() -> void:
     var compatibility_group := _settings_group(secondary_column, _t("settings.section.compatibility"), ICON_PLUGIN, animate_page, 0.105)
     _add_settings_row(compatibility_group, _settings_block(_t("settings.plugin_load_mode"), _t("settings.plugin_load_mode_desc"), _plugin_load_mode_select(), stack_settings_controls))
     _add_settings_row(compatibility_group, _settings_toggle_row(_t("settings.mock"), _t("settings.mock_desc"), _settings_draft_bool("mock_enabled", mock_enabled), "mock"))
+    if player != null and player.has_method("is_text_translation_available") and player.is_text_translation_available():
+        _add_settings_row(compatibility_group, _settings_action_row(
+            _t("settings.translation_model"),
+            _t("settings.translation_model_desc"),
+            _t("settings.translation_model_select"),
+            _choose_translation_model
+        ))
+        var draft_model_path := _settings_draft_string(
+            "text_translation_model_path", text_translation_model_path
+        )
+        if not draft_model_path.is_empty():
+            _add_settings_row(compatibility_group, _settings_value_row(
+                _t("settings.translation_model_selected"),
+                draft_model_path.get_file()
+            ))
+            _add_settings_row(compatibility_group, _settings_action_row(
+                _t("settings.translation_model_clear"),
+                _t("settings.translation_model_clear_desc"),
+                _t("settings.translation_model_clear"),
+                _clear_translation_model
+            ))
 
     var advanced_group := _settings_group(secondary_column, _t("settings.section.advanced"), ICON_PLUGIN, animate_page, 0.13)
     var advanced_disclosure = AetherDisclosure.new()
@@ -5127,6 +5224,14 @@ func _build_loading_panel() -> void:
     loading_title_label.add_theme_font_size_override("font_size", 18)
     loading_title_label.add_theme_color_override("font_color", ui_tokens.text_primary)
     loading_labels.add_child(loading_title_label)
+
+    loading_detail_label = Label.new()
+    loading_detail_label.text = ""
+    loading_detail_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    loading_detail_label.add_theme_font_size_override("font_size", 13)
+    loading_detail_label.add_theme_color_override("font_color", ui_tokens.text_secondary)
+    loading_detail_label.visible = false
+    loading_labels.add_child(loading_detail_label)
     if not ui_motion.reduced_motion:
         var spinner_tween := loading_spinner.create_tween().set_loops()
         # Mirror the counter-clockwise refresh glyph so it follows this
@@ -5153,6 +5258,26 @@ func _show_loading_overlay(immediate: bool = false) -> void:
     loading_panel.move_to_front()
     if loading_card != null:
         ui_motion.loading_in(loading_panel, loading_card, immediate)
+
+func _translation_model_configured() -> bool:
+    return (
+        not text_translation_model_path.is_empty()
+        and player != null
+        and player.has_method("is_text_translation_available")
+        and player.is_text_translation_available()
+    )
+
+func _set_translation_loading_notice(active: bool) -> void:
+    translation_loading_notice_active = active
+    if is_instance_valid(loading_title_label):
+        loading_title_label.text = _t(
+            "loading.translation_model" if active else "loading.title"
+        )
+    if is_instance_valid(loading_detail_label):
+        loading_detail_label.text = (
+            _t("loading.translation_model_detail") if active else ""
+        )
+        loading_detail_label.visible = active
 
 func _hide_loading_overlay(finished: Callable = Callable()) -> void:
     if loading_panel == null or not loading_panel.visible:
@@ -6774,7 +6899,7 @@ func _refresh_language_texts() -> void:
         _set_pill_button_text(empty_primary_button, _t("home.refresh") if OS.get_name() == "iOS" else _t("home.import"))
     _sync_home_action_labels()
     if is_instance_valid(loading_title_label):
-        loading_title_label.text = _t("loading.title")
+        _set_translation_loading_notice(translation_loading_notice_active)
 
 func _empty_help_text() -> String:
     if OS.get_name() == "iOS":
@@ -7839,6 +7964,58 @@ func _create_file_dialog(title: String, file_mode: int, filters: PackedStringArr
     dialog.files_selected.connect(func(_paths: PackedStringArray): call_deferred("_release_file_dialog", dialog))
     return dialog
 
+func _choose_translation_model() -> void:
+    _finish_hero_overlay()
+    var current_path := _settings_draft_string(
+        "text_translation_model_path", text_translation_model_path
+    )
+    var initial_directory := (
+        current_path.get_base_dir() if not current_path.is_empty() else ""
+    )
+    if player != null \
+            and player.has_method("native_translation_model_file_picker_open") \
+            and bool(player.native_translation_model_file_picker_open(
+                _t("settings.translation_model_select"), initial_directory
+            )):
+        native_translation_model_file_picker_pending = true
+        return
+    _show_translation_model_native_dialog(current_path)
+
+func _show_translation_model_native_dialog(current_path: String) -> void:
+    var dialog := _create_file_dialog(
+        _t("settings.translation_model_select"),
+        FileDialog.FILE_MODE_OPEN_FILE,
+        PackedStringArray(["*.gguf ; GGUF model"])
+    )
+    if not current_path.is_empty():
+        dialog.current_dir = current_path.get_base_dir()
+        dialog.current_file = current_path.get_file()
+    dialog.file_selected.connect(func(path: String):
+        _set_settings_draft_value("text_translation_model_path", path)
+        call_deferred("_rebuild_settings_view")
+    )
+    add_child(dialog)
+    dialog.popup_centered(Vector2i(900, 640))
+
+func _restore_native_translation_model_access() -> void:
+    if OS.get_name() not in ["iOS", "macOS"] \
+            or text_translation_model_path.is_empty() \
+            or not _runtime_string("AETHERKIRI_TRANSLATION_MODEL", "").is_empty() \
+            or player == null \
+            or not player.has_method("native_translation_model_restore_path"):
+        return
+    var restored_path := String(player.native_translation_model_restore_path(
+        text_translation_model_path
+    ))
+    if restored_path.is_empty() or restored_path == text_translation_model_path:
+        return
+    text_translation_model_path = restored_path
+    _save_shell_settings()
+
+func _clear_translation_model() -> void:
+    _set_settings_draft_value("text_translation_model_path", "")
+    call_deferred("_rebuild_settings_view")
+
 func _release_file_dialog(dialog: FileDialog) -> void:
     if dialog != null and is_instance_valid(dialog):
         dialog.queue_free()
@@ -8026,6 +8203,39 @@ func _poll_native_cover_file_picker() -> void:
     match String(result.get("status", "error")):
         "selected":
             _apply_selected_cover(library_path, String(result.get("path", "")))
+        "cancelled":
+            pass
+        _:
+            _show_system_alert(
+                String(result.get("error", "System file picker failed")),
+                _t("alert.warning_title")
+            )
+
+func _poll_native_translation_model_file_picker() -> void:
+    if not native_translation_model_file_picker_pending \
+            or player == null \
+            or not player.has_method("native_launch_file_picker_take_result_json"):
+        return
+    var result_json := String(player.native_launch_file_picker_take_result_json())
+    if result_json.is_empty():
+        return
+    native_translation_model_file_picker_pending = false
+    var parsed = JSON.parse_string(result_json)
+    if typeof(parsed) != TYPE_DICTIONARY:
+        _show_system_alert(result_json, _t("alert.warning_title"))
+        return
+    var result: Dictionary = parsed
+    match String(result.get("status", "error")):
+        "selected":
+            var path := String(result.get("path", ""))
+            if path.get_extension().to_lower() != "gguf":
+                _show_system_alert(
+                    "The selected file is not a GGUF model.",
+                    _t("alert.warning_title")
+                )
+                return
+            _set_settings_draft_value("text_translation_model_path", path)
+            call_deferred("_rebuild_settings_view")
         "cancelled":
             pass
         _:
@@ -10101,6 +10311,7 @@ func _start_selected_game_after_entitlements() -> void:
     # expose its black/empty first surface. Diagnostics stay hidden until the
     # first successful game frame replaces this overlay.
     _set_perf_visible(false)
+    _set_translation_loading_notice(_translation_model_configured())
     _show_loading_overlay(true)
     restart_notice.visible = true
     _on_open_game()
@@ -10247,6 +10458,7 @@ func _ready() -> void:
 
     if not _create_runtime_player():
         return
+    _restore_native_translation_model_access()
     _initialize_iap()
 
     diagnostic_session = DiagnosticSession.new()
@@ -12193,6 +12405,7 @@ func _process(delta: float) -> void:
     _poll_android_storage_permission_request()
     _poll_native_launch_file_picker()
     _poll_native_cover_file_picker()
+    _poll_native_translation_model_file_picker()
     _fit_full_rects()
     _sync_game_virtual_controls()
     _process_iap(delta)
@@ -12221,6 +12434,23 @@ func _process(delta: float) -> void:
             startup_state = cached_startup_state
             _sync_game_virtual_controls()
         if startup_state == STARTUP_SUCCEEDED:
+            if (
+                _translation_model_configured()
+                and player.has_method("get_text_translation_state")
+            ):
+                var translation_state := int(player.get_text_translation_state())
+                if translation_state == TEXT_TRANSLATION_LOADING:
+                    _set_translation_loading_notice(true)
+                    return
+                # A failed optional model remains fail-open: the runtime keeps
+                # running with authored text and its error is available in the
+                # startup log instead of trapping the user behind this overlay.
+                if translation_state in [
+                    TEXT_TRANSLATION_READY,
+                    TEXT_TRANSLATION_FAILED,
+                    TEXT_TRANSLATION_DISABLED,
+                ]:
+                    _set_translation_loading_notice(false)
             restart_notice.text = ""
             if loading_panel != null and loading_panel.visible:
                 _hide_loading_overlay(func():
@@ -12322,6 +12552,7 @@ func _process(delta: float) -> void:
                 _return_to_library_after_runtime_exit()
                 return
             restart_notice.text = "Game startup failed."
+            _set_translation_loading_notice(false)
             _hide_loading_overlay()
             _set_game_background(false)
             shell_root.visible = true
@@ -12417,6 +12648,46 @@ func _process(delta: float) -> void:
             _format_monitor_bytes(int(memory.get("gpu_buffer_bytes", 0))),
             _format_monitor_bytes(int(memory.get("cache_bytes", 0))),
         ]
+        if player.has_method("get_text_translation_stats"):
+            var translation: Dictionary = player.get_text_translation_stats()
+            var translation_state := int(translation.get("state", TEXT_TRANSLATION_DISABLED))
+            if translation_state != TEXT_TRANSLATION_DISABLED or _translation_model_configured():
+                var state_label := String({
+                    TEXT_TRANSLATION_DISABLED: "Off",
+                    TEXT_TRANSLATION_LOADING: "Loading",
+                    TEXT_TRANSLATION_READY: "Ready",
+                    TEXT_TRANSLATION_FAILED: "Failed",
+                }.get(translation_state, "Unknown"))
+                var backend_label := String({
+                    0: "-",
+                    1: "CPU",
+                    2: "GPU",
+                }.get(int(translation.get("backend", 0)), "Unknown"))
+                var model_bytes := int(translation.get(
+                    "model_tensor_bytes",
+                    int(translation.get("model_file_bytes", 0))
+                ))
+                var cache_hits := int(translation.get("cache_hits", 0))
+                var cache_misses := int(translation.get("cache_misses", 0))
+                var cache_requests := cache_hits + cache_misses
+                var hit_percent := (
+                    float(cache_hits) * 100.0 / float(cache_requests)
+                    if cache_requests > 0 else 0.0
+                )
+                summary_text += "\nTranslation: %s/%s | Model %s | Context %s | Resident(est.) %s | Work %d+%d/%d | Cache %d (hit %.0f%%) | Wait/Infer %.0f/%.0f ms" % [
+                    state_label,
+                    backend_label,
+                    _format_monitor_bytes(model_bytes),
+                    _format_monitor_bytes(int(translation.get("context_state_bytes", 0))),
+                    _format_monitor_bytes(int(translation.get("model_resident_bytes_estimate", 0))),
+                    int(translation.get("active_jobs", 0)),
+                    int(translation.get("priority_queue_entries", 0)),
+                    int(translation.get("prefetch_queue_entries", 0)),
+                    int(translation.get("cache_entries", 0)),
+                    hit_percent,
+                    float(translation.get("last_synchronous_wait_us", 0)) / 1000.0,
+                    float(translation.get("last_inference_us", 0)) / 1000.0,
+                ]
         if debug_overlay_mode == "detail" and diagnostic_session != null:
             var frame_summary: Dictionary = diagnostic_session.latest_frame_summary
             summary_text += "\nTick: %.2f ms | Update: %.2f ms | P50/P95/P99/Max: %.2f / %.2f / %.2f / %.2f ms | Dropped: %d" % [

--- a/apps/godot_app/tests/game_virtual_controls_test.gd
+++ b/apps/godot_app/tests/game_virtual_controls_test.gd
@@ -390,6 +390,29 @@ func _run() -> void:
         _fail("cursor pointer position is not anchored to the arrow tip")
         return
 
+    controls._move_cursor_by(Vector2(0.0, safe_rect.size.y * 2.0))
+    var cursor_at_bottom := controls.cursor_screen_position()
+    if (
+        not is_equal_approx(cursor_at_bottom.y, safe_rect.end.y)
+        or controls.cursor_handle.get_global_rect().end.y <= safe_rect.end.y
+    ):
+        _fail("cursor bottom limit must use the arrow hotspot, not the image edge")
+        return
+    var bottom_move_count := _pointer_moves.size()
+    controls._move_cursor_by(Vector2(0.0, 80.0))
+    if (
+        not controls.cursor_screen_position().is_equal_approx(cursor_at_bottom)
+        or _pointer_moves.size() != bottom_move_count
+    ):
+        _fail("cursor kept moving after its hotspot reached the bottom edge")
+        return
+    controls.layout(Vector2(844, 390), safe_rect)
+    if not controls.cursor_screen_position().is_equal_approx(cursor_at_bottom):
+        _fail("bottom-edge cursor was recentered during safe-area layout")
+        return
+    controls._move_cursor_by(safe_rect.get_center() - cursor_at_bottom)
+    _pointer_moves.clear()
+
     var cursor_before_full_screen_drag := controls.cursor_screen_position()
     var emulated_down := InputEventMouseButton.new()
     # Touch ownership must not depend on recognizing a particular device id.

--- a/bridge/engine_api/CMakeLists.txt
+++ b/bridge/engine_api/CMakeLists.txt
@@ -78,6 +78,11 @@ if(AETHERKIRI_INTERNAL_ENABLED AND COMMAND aetherinternal_extend_artemis)
     aetherinternal_extend_artemis(engine_api)
 endif()
 
+if(AETHERKIRI_INTERNAL_ENABLED AND
+   COMMAND aetherinternal_extend_text_translation)
+    aetherinternal_extend_text_translation(engine_api)
+endif()
+
 if(TARGET aetherinternal_artemis_lua)
     set(AETHERKIRI_ARTEMIS_LUA_PREFIX_HEADER
         "${CMAKE_CURRENT_SOURCE_DIR}/src/artemis_lua_symbol_prefix.h")

--- a/bridge/engine_api/include/engine_api.h
+++ b/bridge/engine_api/include/engine_api.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /* ABI version: major(8bit), minor(8bit), patch(16bit). */
-#define ENGINE_API_VERSION 0x01050000u
+#define ENGINE_API_VERSION 0x01060000u
 #define ENGINE_API_MAKE_VERSION(major, minor, patch) \
   ((((uint32_t)(major)&0xFFu) << 24u) | (((uint32_t)(minor)&0xFFu) << 16u) | \
    ((uint32_t)(patch)&0xFFFFu))
@@ -344,6 +344,84 @@ ENGINE_API_EXPORT engine_result_t engine_resume(engine_handle_t handle);
  */
 ENGINE_API_EXPORT engine_result_t engine_set_option(engine_handle_t handle,
                                                     const engine_option_t* option);
+
+/* Returns 1 when the private local-model text transformer is linked. */
+ENGINE_API_EXPORT uint32_t engine_is_text_translation_available(void);
+
+typedef enum engine_text_translation_state_t {
+  ENGINE_TEXT_TRANSLATION_DISABLED = 0,
+  ENGINE_TEXT_TRANSLATION_LOADING = 1,
+  ENGINE_TEXT_TRANSLATION_READY = 2,
+  ENGINE_TEXT_TRANSLATION_FAILED = 3,
+} engine_text_translation_state_t;
+
+typedef enum engine_text_translation_backend_t {
+  ENGINE_TEXT_TRANSLATION_BACKEND_NONE = 0,
+  ENGINE_TEXT_TRANSLATION_BACKEND_CPU = 1,
+  ENGINE_TEXT_TRANSLATION_BACKEND_GPU = 2,
+} engine_text_translation_backend_t;
+
+/*
+ * Process-wide local translation model statistics. Model tensor/file sizes
+ * describe the logical model storage, while model_resident_bytes_estimate is
+ * the observed process-memory increase during model/context initialization.
+ */
+typedef struct engine_text_translation_stats_t {
+  uint32_t struct_size;
+  uint32_t state;
+  uint32_t backend;
+  uint32_t active_jobs;
+
+  uint64_t model_file_bytes;
+  uint64_t model_tensor_bytes;
+  uint64_t context_state_bytes;
+  uint64_t model_resident_bytes_estimate;
+
+  uint32_t priority_queue_entries;
+  uint32_t prefetch_queue_entries;
+  uint32_t cache_entries;
+  uint32_t failed_entries;
+
+  uint64_t cache_hits;
+  uint64_t cache_misses;
+  uint64_t translations_started;
+  uint64_t translations_completed;
+  uint64_t translations_failed;
+  uint64_t translations_cancelled;
+
+  uint64_t model_load_us;
+  uint64_t last_inference_us;
+  uint64_t max_inference_us;
+  uint64_t last_synchronous_wait_us;
+  uint64_t total_synchronous_wait_us;
+
+  uint64_t reserved_u64[4];
+  void* reserved_ptr[4];
+} engine_text_translation_stats_t;
+
+/* Returns the process-wide state of the optional external translation model. */
+ENGINE_API_EXPORT uint32_t engine_get_text_translation_state(void);
+
+/* Gets a process-wide snapshot of local translation resource usage/timing. */
+ENGINE_API_EXPORT engine_result_t engine_get_text_translation_stats(
+    engine_text_translation_stats_t* out_stats);
+
+/*
+ * Applies the configured text transformer to one UTF-8 runtime string.
+ * out_required_size includes the trailing NUL.  A null/short buffer is a
+ * successful size query and leaves the buffer untouched.
+ */
+ENGINE_API_EXPORT engine_result_t engine_transform_text_utf8(
+    const char* runtime_id_utf8, const char* input_utf8, char* out_buffer,
+    uint32_t buffer_size, uint32_t* out_required_size);
+
+/* Queues a low-priority translation without waiting for inference. */
+ENGINE_API_EXPORT engine_result_t engine_prefetch_text_utf8(
+    const char* runtime_id_utf8, const char* input_utf8);
+
+/* Cancels/suppresses queued translation work while a runtime is skipping. */
+ENGINE_API_EXPORT engine_result_t engine_set_text_translation_skipping(
+    const char* runtime_id_utf8, uint32_t skipping);
 
 /*
  * Sets the host presentation surface size in pixels. Runtime-specific game

--- a/bridge/engine_api/include/engine_options.h
+++ b/bridge/engine_api/include/engine_options.h
@@ -81,6 +81,15 @@
 /** Internal plugin startup policy ("krkrsdl3" / "aether_all"). */
 #define ENGINE_OPTION_PLUGIN_LOAD_MODE "plugin_load_mode"
 
+/** External GGUF-backed text translation.  These generic options are handled
+ *  only when the private translation provider is linked. */
+#define ENGINE_OPTION_TEXT_TRANSLATION_ENABLED \
+  "text_translation.enabled"
+#define ENGINE_OPTION_TEXT_TRANSLATION_MODEL_PATH \
+  "text_translation.model_path"
+#define ENGINE_OPTION_TEXT_TRANSLATION_TARGET_LANGUAGE \
+  "text_translation.target_language"
+
 /** Enable/disable appending recent engine logs to fatal error dialogs
  *  ("0"/"1", default "0"). */
 #define ENGINE_OPTION_ERROR_DIALOG_LOGS "error_dialog_logs"

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -1,4 +1,5 @@
 #include "engine_api.h"
+#include "engine_options.h"
 
 #include <algorithm>
 #include <chrono>
@@ -29,9 +30,27 @@
 
 #include "engine_runtime_provider_registry.h"
 #include "legacy_engine_api.h"
+#include "TextTransform.h"
 #if defined(ENGINE_API_USE_KRKR2_RUNTIME)
 #include "environ/Platform.h"
 #include "visual/RenderManager.h"
+#endif
+
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+extern "C" bool AetherInternalConfigureTextTranslation(
+    const char* key_utf8, const char* value_utf8, char* error_buffer,
+    uint32_t error_buffer_size);
+extern "C" bool AetherInternalPrepareTextTranslation(
+    char* error_buffer, uint32_t error_buffer_size);
+extern "C" void AetherInternalReleaseTextTranslation(void);
+extern "C" uint32_t AetherInternalGetTextTranslationState(void);
+extern "C" bool AetherInternalGetTextTranslationStats(
+    engine_text_translation_stats_t* out_stats);
+extern "C" void AetherInternalStartTextTranslationLoading(void);
+extern "C" void AetherInternalPrefetchTextTranslation(
+    const char* runtime_id_utf8, const char* input_utf8);
+extern "C" void AetherInternalSetTextTranslationSkipping(
+    const char* runtime_id_utf8, uint32_t skipping);
 #endif
 
 #if defined(AETHERKIRI_INTERNAL_ARTEMIS) && \
@@ -179,6 +198,62 @@ engine_result_t CheckArtemisBetaAccess(DispatchHandle* handle) {
   }
   handle->last_error = "Artemis runtime requires active beta access";
   return ThreadError(ENGINE_RESULT_NOT_SUPPORTED, handle->last_error.c_str());
+}
+
+bool IsTextTranslationOption(const std::string& key) {
+  return key == ENGINE_OPTION_TEXT_TRANSLATION_ENABLED ||
+         key == ENGINE_OPTION_TEXT_TRANSLATION_MODEL_PATH ||
+         key == ENGINE_OPTION_TEXT_TRANSLATION_TARGET_LANGUAGE;
+}
+
+engine_result_t ConfigureTextTranslationLocked(DispatchHandle* handle,
+                                               const char* key,
+                                               const char* value) {
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  char error[1024] = {};
+  if (AetherInternalConfigureTextTranslation(key, value, error,
+                                             sizeof(error))) {
+    handle->last_error.clear();
+    SetThreadError(nullptr);
+    return ENGINE_RESULT_OK;
+  }
+  handle->last_error = error[0] != '\0'
+                           ? error
+                           : "private text translation rejected an option";
+  return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                     handle->last_error.c_str());
+#else
+  (void)key;
+  (void)value;
+  handle->last_error =
+      "local-model text translation is unavailable in this build";
+  return ThreadError(ENGINE_RESULT_NOT_SUPPORTED, handle->last_error.c_str());
+#endif
+}
+
+engine_result_t PrepareTextTranslationLocked(DispatchHandle* handle) {
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  char error[1024] = {};
+  if (AetherInternalPrepareTextTranslation(error, sizeof(error))) {
+    handle->startup_logs.push_back("text translation model prepare => OK");
+    return ENGINE_RESULT_OK;
+  }
+  handle->last_error = error[0] != '\0'
+                           ? error
+                           : "failed to prepare local translation model";
+  handle->startup_logs.push_back("text translation model prepare => FAILED");
+  return ThreadError(ENGINE_RESULT_INTERNAL_ERROR,
+                     handle->last_error.c_str());
+#else
+  (void)handle;
+  return ENGINE_RESULT_OK;
+#endif
+}
+
+void StartTextTranslationLoading() {
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  AetherInternalStartTextTranslationLoading();
+#endif
 }
 
 void HostLog(void* user_data, uint32_t level, const char* subsystem,
@@ -539,6 +614,7 @@ engine_result_t engine_destroy(engine_handle_t public_handle) {
   }
   DispatchHandle* handle = nullptr;
   std::vector<engine_media_handle_t> owned_media;
+  bool release_text_translation = false;
   {
     std::lock_guard<std::recursive_mutex> guard(g_dispatch_registry_mutex);
     const auto found = g_dispatch_handles.find(public_handle);
@@ -556,6 +632,7 @@ engine_result_t engine_destroy(engine_handle_t public_handle) {
       }
     }
     g_dispatch_handles.erase(found);
+    release_text_translation = g_dispatch_handles.empty();
     handle = Cast(public_handle);
   }
 
@@ -574,6 +651,14 @@ engine_result_t engine_destroy(engine_handle_t public_handle) {
   }
   const auto result = engine_legacy_destroy(handle->legacy);
   delete handle;
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  if (release_text_translation) {
+    std::lock_guard<std::recursive_mutex> guard(g_dispatch_registry_mutex);
+    if (g_dispatch_handles.empty()) AetherInternalReleaseTextTranslation();
+  }
+#else
+  (void)release_text_translation;
+#endif
   SetThreadError(nullptr);
   return result;
 }
@@ -719,9 +804,13 @@ engine_result_t engine_open_game(engine_handle_t public_handle,
   if (result != ENGINE_RESULT_OK) return result;
   result = CheckArtemisBetaAccess(handle);
   if (result != ENGINE_RESULT_OK) return result;
+  result = PrepareTextTranslationLocked(handle);
+  if (result != ENGINE_RESULT_OK) return result;
   if (handle->backend == BackendKind::kLegacy) {
-    return engine_legacy_open_game(handle->legacy, game_root_path_utf8,
-                                   startup_script_utf8);
+    result = engine_legacy_open_game(handle->legacy, game_root_path_utf8,
+                                     startup_script_utf8);
+    if (result == ENGINE_RESULT_OK) StartTextTranslationLoading();
+    return result;
   }
   handle->startup_state = ENGINE_STARTUP_STATE_RUNNING;
   AETHER_DISPATCH_DIAG_LOG("engine_open_game before provider open_game");
@@ -735,6 +824,7 @@ engine_result_t engine_open_game(engine_handle_t public_handle,
                                      ? "runtime provider open_game => OK"
                                      : "runtime provider open_game => FAILED");
   SetProviderError(handle, result, "runtime provider failed to open game");
+  if (result == ENGINE_RESULT_OK) StartTextTranslationLoading();
   return result;
 }
 
@@ -763,6 +853,8 @@ engine_result_t engine_open_game_async(engine_handle_t public_handle,
   }
   result = CheckArtemisBetaAccess(handle);
   if (result != ENGINE_RESULT_OK) return result;
+  result = PrepareTextTranslationLocked(handle);
+  if (result != ENGINE_RESULT_OK) return result;
   if (handle->backend == BackendKind::kLegacy) {
     return engine_legacy_open_game_async(handle->legacy, game_root_path_utf8,
                                          startup_script_utf8);
@@ -788,6 +880,7 @@ engine_result_t engine_open_game_async(engine_handle_t public_handle,
                                        : "runtime provider open_game => FAILED");
     SetProviderError(handle, open_result,
                      "runtime provider failed to open game asynchronously");
+    if (open_result == ENGINE_RESULT_OK) StartTextTranslationLoading();
   });
   SetThreadError(nullptr);
   return ENGINE_RESULT_OK;
@@ -798,14 +891,20 @@ engine_result_t engine_get_startup_state(engine_handle_t public_handle,
   if (out_state == nullptr) {
     return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT, "out_state is null");
   }
-  return Route(public_handle, "get_startup_state",
-               [&](engine_handle_t legacy) {
-                 return engine_legacy_get_startup_state(legacy, out_state);
-               },
-               [&](DispatchHandle* handle) {
-                 *out_state = handle->startup_state;
-                 return ENGINE_RESULT_OK;
-               });
+  const engine_result_t result = Route(
+      public_handle, "get_startup_state",
+      [&](engine_handle_t legacy) {
+        return engine_legacy_get_startup_state(legacy, out_state);
+      },
+      [&](DispatchHandle* handle) {
+        *out_state = handle->startup_state;
+        return ENGINE_RESULT_OK;
+      });
+  if (result == ENGINE_RESULT_OK &&
+      *out_state == ENGINE_STARTUP_STATE_SUCCEEDED) {
+    StartTextTranslationLoading();
+  }
+  return result;
 }
 
 engine_result_t engine_drain_startup_logs(engine_handle_t public_handle,
@@ -928,6 +1027,10 @@ engine_result_t engine_set_option(engine_handle_t public_handle,
     SetThreadError(nullptr);
     return ENGINE_RESULT_OK;
   }
+  if (IsTextTranslationOption(key)) {
+    return ConfigureTextTranslationLocked(handle, key.c_str(),
+                                          option->value_utf8);
+  }
   handle->pending_options[option->key_utf8] = option->value_utf8;
   if (handle->backend == BackendKind::kProvider) {
     if (!PROVIDER_HAS(handle->provider, set_option)) {
@@ -938,6 +1041,102 @@ engine_result_t engine_set_option(engine_handle_t public_handle,
     return result;
   }
   return engine_legacy_set_option(handle->legacy, option);
+}
+
+uint32_t engine_is_text_translation_available(void) {
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  return 1u;
+#else
+  return 0u;
+#endif
+}
+
+uint32_t engine_get_text_translation_state(void) {
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  return AetherInternalGetTextTranslationState();
+#else
+  return ENGINE_TEXT_TRANSLATION_DISABLED;
+#endif
+}
+
+engine_result_t engine_get_text_translation_stats(
+    engine_text_translation_stats_t* out_stats) {
+  if (out_stats == nullptr) {
+    return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                       "translation statistics output is required");
+  }
+  if (out_stats->struct_size < sizeof(engine_text_translation_stats_t)) {
+    return ThreadError(
+        ENGINE_RESULT_INVALID_ARGUMENT,
+        "engine_text_translation_stats_t.struct_size is too small");
+  }
+  const uint32_t requested_size = out_stats->struct_size;
+  std::memset(out_stats, 0, sizeof(*out_stats));
+  out_stats->struct_size = requested_size;
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  if (!AetherInternalGetTextTranslationStats(out_stats)) {
+    return ThreadError(ENGINE_RESULT_INTERNAL_ERROR,
+                       "private translation statistics query failed");
+  }
+#else
+  out_stats->state = ENGINE_TEXT_TRANSLATION_DISABLED;
+  out_stats->backend = ENGINE_TEXT_TRANSLATION_BACKEND_NONE;
+#endif
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_transform_text_utf8(const char* runtime_id_utf8,
+                                           const char* input_utf8,
+                                           char* out_buffer,
+                                           uint32_t buffer_size,
+                                           uint32_t* out_required_size) {
+  if (input_utf8 == nullptr || out_required_size == nullptr) {
+    return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                       "text transform input and size output are required");
+  }
+  const std::string transformed =
+      TVPTransformText(runtime_id_utf8 != nullptr ? runtime_id_utf8 : "",
+                       input_utf8);
+  if (transformed.size() >= UINT32_MAX) {
+    return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                       "transformed text is too large");
+  }
+  *out_required_size = static_cast<uint32_t>(transformed.size() + 1u);
+  if (out_buffer == nullptr || buffer_size < *out_required_size) {
+    SetThreadError(nullptr);
+    return ENGINE_RESULT_OK;
+  }
+  std::memcpy(out_buffer, transformed.c_str(), transformed.size() + 1u);
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_prefetch_text_utf8(const char* runtime_id_utf8,
+                                          const char* input_utf8) {
+  if (runtime_id_utf8 == nullptr || input_utf8 == nullptr) {
+    return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                       "translation prefetch runtime and input are required");
+  }
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  AetherInternalPrefetchTextTranslation(runtime_id_utf8, input_utf8);
+#endif
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
+}
+
+engine_result_t engine_set_text_translation_skipping(
+    const char* runtime_id_utf8, uint32_t skipping) {
+  if (runtime_id_utf8 == nullptr) {
+    return ThreadError(ENGINE_RESULT_INVALID_ARGUMENT,
+                       "translation skip runtime is required");
+  }
+#if defined(AETHERKIRI_INTERNAL_TEXT_TRANSLATION)
+  AetherInternalSetTextTranslationSkipping(runtime_id_utf8,
+                                            skipping != 0 ? 1u : 0u);
+#endif
+  SetThreadError(nullptr);
+  return ENGINE_RESULT_OK;
 }
 
 engine_result_t engine_set_surface_size(engine_handle_t public_handle,

--- a/bridge/godot_extension/src/aether_runtime_player.cpp
+++ b/bridge/godot_extension/src/aether_runtime_player.cpp
@@ -95,6 +95,10 @@ int32_t aether_native_launch_file_picker_present(
 int32_t aether_native_cover_file_picker_present(
     const char *title, const char *initial_directory,
     const char *destination_directory);
+int32_t aether_native_translation_model_file_picker_present(
+    const char *title, const char *initial_directory);
+char *aether_native_translation_model_restore_path(
+    const char *fallback_path);
 char *aether_native_launch_file_picker_copy_result_json();
 void aether_native_launch_file_picker_free_string(char *value);
 }
@@ -8595,6 +8599,56 @@ public:
         return frame_effect_provider_ != nullptr;
     }
 
+    bool is_text_translation_available() const {
+        return engine_is_text_translation_available() != 0;
+    }
+
+    int get_text_translation_state() const {
+        return static_cast<int>(engine_get_text_translation_state());
+    }
+
+    Dictionary get_text_translation_stats() const {
+        Dictionary output;
+        engine_text_translation_stats_t stats{};
+        stats.struct_size = sizeof(stats);
+        if (engine_get_text_translation_stats(&stats) != ENGINE_RESULT_OK) {
+            return output;
+        }
+        output["state"] = static_cast<int64_t>(stats.state);
+        output["backend"] = static_cast<int64_t>(stats.backend);
+        output["active_jobs"] = static_cast<int64_t>(stats.active_jobs);
+        output["model_file_bytes"] = static_cast<int64_t>(stats.model_file_bytes);
+        output["model_tensor_bytes"] = static_cast<int64_t>(stats.model_tensor_bytes);
+        output["context_state_bytes"] = static_cast<int64_t>(stats.context_state_bytes);
+        output["model_resident_bytes_estimate"] =
+            static_cast<int64_t>(stats.model_resident_bytes_estimate);
+        output["priority_queue_entries"] =
+            static_cast<int64_t>(stats.priority_queue_entries);
+        output["prefetch_queue_entries"] =
+            static_cast<int64_t>(stats.prefetch_queue_entries);
+        output["cache_entries"] = static_cast<int64_t>(stats.cache_entries);
+        output["failed_entries"] = static_cast<int64_t>(stats.failed_entries);
+        output["cache_hits"] = static_cast<int64_t>(stats.cache_hits);
+        output["cache_misses"] = static_cast<int64_t>(stats.cache_misses);
+        output["translations_started"] =
+            static_cast<int64_t>(stats.translations_started);
+        output["translations_completed"] =
+            static_cast<int64_t>(stats.translations_completed);
+        output["translations_failed"] =
+            static_cast<int64_t>(stats.translations_failed);
+        output["translations_cancelled"] =
+            static_cast<int64_t>(stats.translations_cancelled);
+        output["model_load_us"] = static_cast<int64_t>(stats.model_load_us);
+        output["last_inference_us"] =
+            static_cast<int64_t>(stats.last_inference_us);
+        output["max_inference_us"] = static_cast<int64_t>(stats.max_inference_us);
+        output["last_synchronous_wait_us"] =
+            static_cast<int64_t>(stats.last_synchronous_wait_us);
+        output["total_synchronous_wait_us"] =
+            static_cast<int64_t>(stats.total_synchronous_wait_us);
+        return output;
+    }
+
     bool is_frame_enhancement_available() const {
         if (frame_effect_provider_ == nullptr) {
             return false;
@@ -10462,6 +10516,37 @@ void main() {
 #endif
     }
 
+    bool native_translation_model_file_picker_open(
+            const String &title, const String &initial_directory) const {
+#if defined(__APPLE__)
+        const CharString title_utf8 = title.utf8();
+        const CharString directory_utf8 = initial_directory.utf8();
+        return aether_native_translation_model_file_picker_present(
+                   title_utf8.get_data(), directory_utf8.get_data()) != 0;
+#else
+        (void)title;
+        (void)initial_directory;
+        return false;
+#endif
+    }
+
+    String native_translation_model_restore_path(
+            const String &fallback_path) const {
+#if defined(__APPLE__)
+        const CharString fallback_utf8 = fallback_path.utf8();
+        char *path = aether_native_translation_model_restore_path(
+            fallback_utf8.get_data());
+        if (path == nullptr) {
+            return fallback_path;
+        }
+        const String result = String::utf8(path);
+        aether_native_launch_file_picker_free_string(path);
+        return result;
+#else
+        return fallback_path;
+#endif
+    }
+
     String native_launch_file_picker_take_result_json() const {
 #if defined(__APPLE__)
         char *json = aether_native_launch_file_picker_copy_result_json();
@@ -10571,6 +10656,12 @@ protected:
                              &AetherRuntimePlayer::get_frame_texture_backend);
         ClassDB::bind_method(D_METHOD("is_frame_enhancement_built"),
                              &AetherRuntimePlayer::is_frame_enhancement_built);
+        ClassDB::bind_method(D_METHOD("is_text_translation_available"),
+                             &AetherRuntimePlayer::is_text_translation_available);
+        ClassDB::bind_method(D_METHOD("get_text_translation_state"),
+                             &AetherRuntimePlayer::get_text_translation_state);
+        ClassDB::bind_method(D_METHOD("get_text_translation_stats"),
+                             &AetherRuntimePlayer::get_text_translation_stats);
         ClassDB::bind_method(D_METHOD("is_frame_enhancement_available"),
                              &AetherRuntimePlayer::is_frame_enhancement_available);
         ClassDB::bind_method(D_METHOD("set_frame_enhancement_enabled", "enabled"),
@@ -10626,6 +10717,13 @@ protected:
             D_METHOD("native_cover_file_picker_open", "title", "initial_directory",
                      "destination_directory"),
             &AetherRuntimePlayer::native_cover_file_picker_open);
+        ClassDB::bind_method(
+            D_METHOD("native_translation_model_file_picker_open", "title",
+                     "initial_directory"),
+            &AetherRuntimePlayer::native_translation_model_file_picker_open);
+        ClassDB::bind_method(
+            D_METHOD("native_translation_model_restore_path", "fallback_path"),
+            &AetherRuntimePlayer::native_translation_model_restore_path);
         ClassDB::bind_method(
             D_METHOD("native_launch_file_picker_take_result_json"),
             &AetherRuntimePlayer::native_launch_file_picker_take_result_json);

--- a/bridge/godot_extension/src/apple_native_file_picker.swift
+++ b/bridge/godot_extension/src/apple_native_file_picker.swift
@@ -13,6 +13,7 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
     private enum Purpose {
         case launchFile
         case coverImage(destinationDirectory: String)
+        case translationModel
     }
 
     private let lock = NSLock()
@@ -22,6 +23,10 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
 #if os(iOS)
     private var documentPicker: UIDocumentPickerViewController?
     private var documentPickerPurpose: Purpose = .launchFile
+    private var activeTranslationModelURL: URL?
+    private var activeTranslationModelUsesSecurityScope = false
+    private let translationModelBookmarksKey =
+        "AetherNativeFilePicker.TranslationModelBookmarks"
 #elseif os(macOS)
     private var openPanel: NSOpenPanel?
 #endif
@@ -72,6 +77,44 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
             initialDirectory: initialDirectory,
             purpose: .coverImage(destinationDirectory: destinationDirectory)
         )
+    }
+
+    func presentTranslationModel(title: String, initialDirectory: String) -> Bool {
+        return present(
+            title: title,
+            initialDirectory: initialDirectory,
+            purpose: .translationModel
+        )
+    }
+
+    func restoreTranslationModelPath(fallbackPath: String) -> String {
+#if os(iOS)
+        guard !fallbackPath.isEmpty else { return "" }
+        let normalizedFallback = URL(
+            fileURLWithPath: fallbackPath,
+            isDirectory: false
+        ).standardizedFileURL.path
+        let stored = UserDefaults.standard.dictionary(
+            forKey: translationModelBookmarksKey
+        ) ?? [:]
+        guard let bookmark = (stored[normalizedFallback] ?? stored[fallbackPath]) as? Data else {
+            return fallbackPath
+        }
+        do {
+            var stale = false
+            let url = try URL(
+                resolvingBookmarkData: bookmark,
+                options: [],
+                relativeTo: nil,
+                bookmarkDataIsStale: &stale
+            )
+            return try retainTranslationModelAccess(to: url)
+        } catch {
+            return fallbackPath
+        }
+#else
+        return fallbackPath
+#endif
     }
 
     func takeResultJSON() -> UnsafeMutablePointer<CChar>? {
@@ -152,6 +195,69 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
     }
 
 #if os(iOS)
+    private func retainTranslationModelAccess(to sourceURL: URL) throws -> String {
+        let url = sourceURL.standardizedFileURL
+        guard url.isFileURL, url.pathExtension.lowercased() == "gguf" else {
+            throw NSError(
+                domain: "AetherNativeFilePicker",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "The selected file is not a GGUF model"]
+            )
+        }
+
+        lock.lock()
+        let alreadyActive = activeTranslationModelURL?.standardizedFileURL == url
+        lock.unlock()
+
+        var startedSecurityScope = false
+        if !alreadyActive {
+            startedSecurityScope = url.startAccessingSecurityScopedResource()
+            guard startedSecurityScope || FileManager.default.isReadableFile(atPath: url.path) else {
+                throw NSError(
+                    domain: "AetherNativeFilePicker",
+                    code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "Unable to access the selected GGUF model"]
+                )
+            }
+        }
+
+        let bookmark: Data
+        do {
+            bookmark = try url.bookmarkData(
+                options: [],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+        } catch {
+            if startedSecurityScope {
+                url.stopAccessingSecurityScopedResource()
+            }
+            throw error
+        }
+
+        lock.lock()
+        let previousURL = activeTranslationModelURL
+        let previousUsesSecurityScope = activeTranslationModelUsesSecurityScope
+        activeTranslationModelURL = url
+        activeTranslationModelUsesSecurityScope = alreadyActive
+            ? previousUsesSecurityScope
+            : startedSecurityScope
+        lock.unlock()
+
+        if !alreadyActive && previousUsesSecurityScope {
+            previousURL?.stopAccessingSecurityScopedResource()
+        }
+
+        var stored = UserDefaults.standard.dictionary(
+            forKey: translationModelBookmarksKey
+        ) ?? [:]
+        stored[url.path] = bookmark
+        UserDefaults.standard.set(stored, forKey: translationModelBookmarksKey)
+        return url.path
+    }
+#endif
+
+#if os(iOS)
     private func presentOnMainThread(
         title: String,
         initialDirectory: String,
@@ -171,6 +277,8 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
                 .jpeg,
                 UTType(filenameExtension: "webp"),
             ].compactMap { $0 }
+        case .translationModel:
+            contentTypes = [UTType(filenameExtension: "gguf")].compactMap { $0 }
         }
         let picker = UIDocumentPickerViewController(
             forOpeningContentTypes: contentTypes,
@@ -226,6 +334,10 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
                 .jpeg,
                 UTType(filenameExtension: "webp"),
             ].compactMap { $0 }
+        case .translationModel:
+            panel.allowedContentTypes = [
+                UTType(filenameExtension: "gguf"),
+            ].compactMap { $0 }
         }
         panel.directoryURL = directoryURL(for: initialDirectory)
         openPanel = panel
@@ -246,6 +358,8 @@ private final class AetherNativeLaunchFilePicker: NSObject, @unchecked Sendable 
                     } catch {
                         self.complete(status: "error", error: error.localizedDescription)
                     }
+                case .translationModel:
+                    self.complete(status: "selected", path: url.standardizedFileURL.path)
                 }
             } else {
                 self.complete(status: "cancelled")
@@ -296,6 +410,13 @@ extension AetherNativeLaunchFilePicker: UIDocumentPickerDelegate {
             } catch {
                 complete(status: "error", error: error.localizedDescription)
             }
+        case .translationModel:
+            do {
+                let path = try retainTranslationModelAccess(to: url)
+                complete(status: "selected", path: path)
+            } catch {
+                complete(status: "error", error: error.localizedDescription)
+            }
         }
     }
 
@@ -333,6 +454,30 @@ public func aetherNativeCoverFilePickerPresent(
         initialDirectory: initialDirectory,
         destinationDirectory: destinationDirectory
     ) ? 1 : 0
+}
+
+@_cdecl("aether_native_translation_model_file_picker_present")
+public func aetherNativeTranslationModelFilePickerPresent(
+    _ titlePointer: UnsafePointer<CChar>?,
+    _ initialDirectoryPointer: UnsafePointer<CChar>?
+) -> Int32 {
+    let title = titlePointer.map { String(cString: $0) } ?? ""
+    let initialDirectory = initialDirectoryPointer.map { String(cString: $0) } ?? ""
+    return AetherNativeLaunchFilePicker.shared.presentTranslationModel(
+        title: title,
+        initialDirectory: initialDirectory
+    ) ? 1 : 0
+}
+
+@_cdecl("aether_native_translation_model_restore_path")
+public func aetherNativeTranslationModelRestorePath(
+    _ fallbackPathPointer: UnsafePointer<CChar>?
+) -> UnsafeMutablePointer<CChar>? {
+    let fallbackPath = fallbackPathPointer.map { String(cString: $0) } ?? ""
+    let path = AetherNativeLaunchFilePicker.shared.restoreTranslationModelPath(
+        fallbackPath: fallbackPath
+    )
+    return path.withCString { strdup($0) }
 }
 
 @_cdecl("aether_native_launch_file_picker_copy_result_json")

--- a/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
+++ b/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
@@ -546,6 +546,40 @@ size_t ScriptParser::loadFileIOBuf( const char *filename )
     string(REPLACE "${envdata_load_original}" "${envdata_load_embedded}"
            parser_source "${parser_source}")
 
+    set(text_token_original [=[
+        else{
+            script_h.addStringBuffer(ch);
+        }
+    }
+}
+
+int ScriptParser::readEffect( EffectLink *effect )
+]=])
+    set(text_token_embedded [=[
+        else{
+            script_h.addStringBuffer(ch);
+        }
+    }
+
+    // Translate after line-page click markers have been appended. The helper
+    // preserves those controls and never writes past ScriptHandler's buffer.
+    if (script_h.isText())
+        aetherkiri_onscripter_transform_text(
+            script_h.getStringBuffer(), 4096);
+    aetherkiri_onscripter_prefetch_text(script_h.getNext());
+}
+
+int ScriptParser::readEffect( EffectLink *effect )
+]=])
+    string(FIND "${parser_source}" "${text_token_original}"
+           text_token_position)
+    if(text_token_position EQUAL -1)
+        message(FATAL_ERROR
+            "OnscripterYuri text token path changed; update the embedded-host overlay.")
+    endif()
+    string(REPLACE "${text_token_original}" "${text_token_embedded}"
+           parser_source "${parser_source}")
+
     set(generated_parser "${generated_dir}/ScriptParser.cpp")
     file(WRITE "${generated_parser}" "${parser_source}")
 

--- a/bridge/onscripter_runtime/src/onscripter_host_shim.h
+++ b/bridge/onscripter_runtime/src/onscripter_host_shim.h
@@ -21,6 +21,9 @@ extern "C" int aetherkiri_onscripter_wait_event(SDL_Event *event);
 extern "C" void aetherkiri_onscripter_configure_video(
     int has_position, int x, int y, int width, int height,
     int asynchronous);
+extern "C" void aetherkiri_onscripter_transform_text(char *buffer,
+                                                       size_t capacity);
+extern "C" void aetherkiri_onscripter_prefetch_text(const char *script);
 
 #define exit(code) aetherkiri_onscripter_host_exit((code), __FILE__, __LINE__)
 #define SDL_FreeSurface aetherkiri_onscripter_free_surface

--- a/bridge/onscripter_runtime/src/onscripter_runtime.cpp
+++ b/bridge/onscripter_runtime/src/onscripter_runtime.cpp
@@ -100,6 +100,7 @@ uint64_t g_published_frame_serial = 0;
 std::atomic<bool> g_system_list_scroll_active{false};
 std::atomic<uint32_t> g_system_list_scroll_y{0};
 std::atomic<uint64_t> g_system_list_view_revision{0};
+std::atomic<ONScripter *> g_translation_ons{nullptr};
 
 void ResetPublishedFrame() {
     std::lock_guard<std::mutex> lock(g_published_frame_mutex);
@@ -200,6 +201,80 @@ extern "C" void aetherkiri_onscripter_end_system_list_scroll() {
     g_system_list_scroll_active.store(false);
     g_system_list_scroll_y.store(0);
     g_system_list_view_revision.fetch_add(1);
+}
+
+extern "C" void aetherkiri_onscripter_transform_text(char *buffer,
+                                                       size_t capacity) {
+    if (buffer == nullptr || capacity == 0 || buffer[0] == '\0') return;
+    ONScripter *active = g_translation_ons.load(std::memory_order_acquire);
+    const bool skipping =
+        active != nullptr &&
+        (active->skip_mode != ONScripter::SKIP_NONE ||
+         active->ctrl_pressed_status);
+    engine_set_text_translation_skipping("onscripter", skipping ? 1u : 0u);
+    if (skipping) {
+        return;
+    }
+    uint32_t required = 0;
+    if (engine_transform_text_utf8("onscripter", buffer, nullptr, 0,
+                                   &required) != ENGINE_RESULT_OK ||
+        required == 0 || required > capacity) {
+        return;
+    }
+    std::vector<char> transformed(required, '\0');
+    uint32_t written = 0;
+    if (engine_transform_text_utf8("onscripter", buffer,
+                                   transformed.data(), required,
+                                   &written) == ENGINE_RESULT_OK &&
+        written == required) {
+        std::memcpy(buffer, transformed.data(), required);
+    }
+}
+
+extern "C" void aetherkiri_onscripter_prefetch_text(const char *script) {
+    if (script == nullptr || *script == '\0') return;
+    ONScripter *active = g_translation_ons.load(std::memory_order_acquire);
+    const bool skipping =
+        active != nullptr &&
+        (active->skip_mode != ONScripter::SKIP_NONE ||
+         active->ctrl_pressed_status);
+    engine_set_text_translation_skipping("onscripter", skipping ? 1u : 0u);
+    if (skipping) return;
+
+    // ONS keeps the decoded script in one stable buffer. Scan a bounded
+    // number of subsequent physical lines and enqueue only lines containing
+    // non-ASCII text. Exact parser output is still promoted by transform_text
+    // when the line is reached; dynamic expressions simply miss this hint.
+    constexpr size_t kMaximumScanBytes = 16 * 1024;
+    constexpr size_t kMaximumLineBytes = 4095;
+    constexpr int kMaximumPrefetchLines = 12;
+    const char *cursor = script;
+    size_t scanned = 0;
+    int queued = 0;
+    while (*cursor != '\0' && scanned < kMaximumScanBytes &&
+           queued < kMaximumPrefetchLines) {
+        const char *line_end = cursor;
+        bool has_non_ascii = false;
+        while (*line_end != '\0' && *line_end != '\n' &&
+               scanned + static_cast<size_t>(line_end - cursor) <
+                   kMaximumScanBytes) {
+            has_non_ascii = has_non_ascii ||
+                static_cast<unsigned char>(*line_end) >= 0x80u;
+            ++line_end;
+        }
+        const size_t length = static_cast<size_t>(line_end - cursor);
+        if (has_non_ascii && length > 0 && length <= kMaximumLineBytes) {
+            std::string line(cursor, length);
+            engine_prefetch_text_utf8("onscripter", line.c_str());
+            ++queued;
+        }
+        scanned += length;
+        if (*line_end == '\n') {
+            ++line_end;
+            ++scanned;
+        }
+        cursor = line_end;
+    }
 }
 
 extern "C" int aetherkiri_onscripter_wait_event(SDL_Event *event) {
@@ -1144,6 +1219,7 @@ struct Runtime::Impl final : EmbeddedMovieHost {
             load_game_options(root);
             configure_encoding();
             ons = new (static_cast<void *>(&::ons)) ONScripter();
+            g_translation_ons.store(ons, std::memory_order_release);
             ons->setWindowMode();
             ons->setVsyncOff();
             ons->setArchivePath(root.u8string().c_str());
@@ -1317,6 +1393,7 @@ struct Runtime::Impl final : EmbeddedMovieHost {
         // explicitly before another object is placement-constructed in the
         // same ABI-visible storage.
         if (ons != nullptr) {
+            g_translation_ons.store(nullptr, std::memory_order_release);
             ons->~ONScripter();
             ons = nullptr;
         }

--- a/build/build_ios.sh
+++ b/build/build_ios.sh
@@ -439,7 +439,7 @@ patch_ios_export_project() {
     for archive in "${FORCE_LOAD_PLUGIN_ARCHIVES[@]}"; do
         flags+=" -Wl,-force_load,Aether/bin/ios/$export_build_type/$archive"
     done
-    flags+=' -framework AudioToolbox -framework AVFoundation -framework CoreBluetooth -framework CoreHaptics -framework CoreMedia -framework CoreMotion -framework CoreVideo -framework GameController -framework VideoToolbox -framework CoreGraphics -framework QuartzCore -framework Metal -framework MetalKit -framework OpenGLES -framework Security -framework StoreKit -framework SystemConfiguration -framework MobileCoreServices'
+    flags+=' -framework Accelerate -framework AudioToolbox -framework AVFoundation -framework CoreBluetooth -framework CoreHaptics -framework CoreMedia -framework CoreMotion -framework CoreVideo -framework GameController -framework VideoToolbox -framework CoreGraphics -framework QuartzCore -framework Metal -framework MetalKit -framework OpenGLES -framework Security -framework StoreKit -framework SystemConfiguration -framework MobileCoreServices'
 
     if [[ -f "$project_file" ]]; then
         FLAGS="$flags" perl -0pi -e 's/OTHER_LDFLAGS = "[^"]*";/"OTHER_LDFLAGS = \"" . $ENV{FLAGS} . "\";"/eg' "$project_file"

--- a/cpp/core/base/KAGParser.cpp
+++ b/cpp/core/base/KAGParser.cpp
@@ -15,6 +15,7 @@
 #include "tjsDictionary.h"
 #include "DebugIntf.h"
 #include "TextStream.h"
+#include "TextTransform.h"
 #include "StorageIntf.h"
 #include "ncbind.hpp"
 #include <algorithm>
@@ -698,6 +699,8 @@ void tTJSNI_KAGParser::Invalidate() {
 
 //---------------------------------------------------------------------------
 void tTJSNI_KAGParser::operator=(const tTJSNI_KAGParser &ref) {
+    ClearTextTagQueue();
+
     // copy Macros
     {
         tTJSVariant src(ref.Macros, ref.Macros);
@@ -1324,6 +1327,7 @@ void tTJSNI_KAGParser::Clear() {
 //---------------------------------------------------------------------------
 void tTJSNI_KAGParser::ClearBuffer() {
     // clear internal buffer
+    ClearTextTagQueue();
     if(Scenario)
         Scenario->Release(), Scenario = nullptr, Lines = nullptr,
                              CurLineStr = nullptr;
@@ -1913,6 +1917,58 @@ parse_start:
                CurLineStr[CurPos] == TJS_W('[') &&
                    CurLineStr[CurPos + 1] == TJS_W('[')) {
                 // normal character
+                // KAG exposes ordinary scenario text to MessageLayer one
+                // character at a time.  Translate the complete plain-text
+                // run before that split so language detection and the model
+                // both receive useful context while KAG keeps its original
+                // typewriter timing and per-character layout behavior.
+                if(!RecordingMacro && ExcludeLevel == -1 &&
+                   CurLineStr[CurPos] != TJS_W('[')) {
+                    tjs_int run_end = CurPos;
+                    while(CurLineStr[run_end] != 0 &&
+                          CurLineStr[run_end] != TJS_W('\n') &&
+                          CurLineStr[run_end] != TJS_W('['))
+                        ++run_end;
+
+                    if(run_end > CurPos) {
+                        const ttstr original(CurLineStr + CurPos,
+                                             run_end - CurPos);
+                        const std::string original_utf8 =
+                            original.AsStdString();
+                        // Queue the current run first, then raw future runs.
+                        // The synchronous lookup below promotes the current
+                        // key while the model can continue through lookahead
+                        // during the typewriter/read interval.
+                        TVPPrefetchText("kirikiri", original_utf8);
+                        PrefetchTextLookahead(run_end);
+                        const std::string translated_utf8 =
+                            TVPTransformText("kirikiri", original_utf8);
+                        if(translated_utf8 != original_utf8) {
+                            const ttstr translated(translated_utf8);
+                            const tjs_int prefix_length = CurPos;
+                            const tjs_int suffix_length =
+                                TJS_strlen(CurLineStr + run_end);
+                            ttstr new_buffer;
+                            tjs_char *dest = new_buffer.AllocBuffer(
+                                prefix_length + translated.GetLen() +
+                                suffix_length + 1);
+                            TJS_strncpy_s(dest,
+                                          prefix_length +
+                                              translated.GetLen() +
+                                              suffix_length + 1,
+                                          CurLineStr, prefix_length);
+                            dest += prefix_length;
+                            TJS_strcpy(dest, translated.c_str());
+                            dest += translated.GetLen();
+                            TJS_strcpy(dest, CurLineStr + run_end);
+                            new_buffer.FixLen();
+                            LineBuffer = new_buffer;
+                            CurLineStr = LineBuffer.c_str();
+                            LineBufferUsing = true;
+                        }
+                    }
+                }
+
                 tjs_char ch = CurLineStr[CurPos];
                 TagLine = CurLine;
 
@@ -2909,7 +2965,167 @@ parse_start:
 }
 
 //---------------------------------------------------------------------------
-iTJSDispatch2 *tTJSNI_KAGParser::GetNextTag() { return _GetNextTag(); }
+namespace {
+
+bool TVPReadKagCharacterTag(iTJSDispatch2 *tag, ttstr &text) {
+    if(!tag)
+        return false;
+
+    tTJSVariant tag_name;
+    if(TJS_FAILED(tag->PropGet(0, TJS_W("tagname"), nullptr, &tag_name,
+                               tag)) ||
+       tag_name.Type() == tvtVoid || ttstr(tag_name) != TJS_W("ch"))
+        return false;
+
+    tTJSVariant tag_text;
+    if(TJS_FAILED(tag->PropGet(0, TJS_W("text"), nullptr, &tag_text, tag)) ||
+       tag_text.Type() == tvtVoid)
+        return false;
+
+    text = tag_text;
+    return true;
+}
+
+void TVPSetKagCharacterTagText(iTJSDispatch2 *tag, const ttstr &text) {
+    tTJSVariant value(text);
+    tag->PropSet(TJS_MEMBERENSURE, TJS_W("text"), nullptr, &value, tag);
+}
+
+} // namespace
+
+void tTJSNI_KAGParser::ClearTextTagQueue() {
+    while(!TextTagQueue.empty()) {
+        TextTagQueue.front()->Release();
+        TextTagQueue.pop_front();
+    }
+}
+
+void tTJSNI_KAGParser::PrefetchTextLookahead(tjs_int current_run_end) {
+    if(Lines == nullptr || CurLine >= LineCount || RecordingMacro ||
+       ExcludeLevel != -1)
+        return;
+
+    constexpr size_t kMaximumPrefetchRuns = 12;
+    size_t queued = 0;
+    for(tjs_int line_index = CurLine;
+        line_index < LineCount && queued < kMaximumPrefetchRuns;
+        ++line_index) {
+        const tjs_char *line = line_index == CurLine
+            ? CurLineStr
+            : Lines[line_index].Start;
+        if(line == nullptr)
+            continue;
+        tjs_int position = line_index == CurLine ? current_run_end : 0;
+        // Never speculate through an inline-script or macro definition. Their
+        // bodies are code/template text, and execution may redirect parsing.
+        if(TJS_strstr(line, TJS_W("[iscript]")) != nullptr ||
+           TJS_strstr(line, TJS_W("@iscript")) != nullptr ||
+           TJS_strstr(line, TJS_W("[macro")) != nullptr)
+            break;
+        if(position == 0 && (line[0] == TJS_W(';') ||
+                             line[0] == TJS_W('*') ||
+                             line[0] == TJS_W('@')))
+            continue;
+
+        while(line[position] != 0 && queued < kMaximumPrefetchRuns) {
+            if(line[position] == TJS_W('[')) {
+                const tjs_char *close =
+                    TJS_strchr(const_cast<tjs_char *>(line + position + 1),
+                               TJS_W(']'));
+                if(close == nullptr)
+                    break;
+                position = static_cast<tjs_int>(close - line) + 1;
+                continue;
+            }
+            const tjs_int run_start = position;
+            while(line[position] != 0 && line[position] != TJS_W('[') &&
+                  line[position] != TJS_W('\n'))
+                ++position;
+            if(position > run_start) {
+                const ttstr candidate(line + run_start,
+                                      position - run_start);
+                TVPPrefetchText("kirikiri", candidate.AsStdString());
+                ++queued;
+            }
+        }
+    }
+}
+
+iTJSDispatch2 *tTJSNI_KAGParser::CloneTag(iTJSDispatch2 *source) {
+    if(!source)
+        return nullptr;
+    tTJSVariant source_value(source, source);
+    tTJSVariant *params[] = { &source_value };
+    return CopyTag(1, params);
+}
+
+iTJSDispatch2 *tTJSNI_KAGParser::GetNextTag() {
+    if(Interrupted)
+        ClearTextTagQueue();
+
+    if(!TextTagQueue.empty()) {
+        iTJSDispatch2 *tag = TextTagQueue.front();
+        TextTagQueue.pop_front();
+        return tag;
+    }
+
+    iTJSDispatch2 *parsed = _GetNextTag();
+    ttstr first_text;
+    if(!TVPReadKagCharacterTag(parsed, first_text))
+        return parsed;
+
+    std::vector<iTJSDispatch2 *> source_tags;
+    source_tags.reserve(64);
+    source_tags.push_back(CloneTag(parsed));
+    parsed->Release();
+
+    ttstr source_text(first_text);
+    iTJSDispatch2 *boundary = nullptr;
+    constexpr size_t kMaxTextRunTags = 2048;
+    while(source_tags.size() < kMaxTextRunTags) {
+        parsed = _GetNextTag();
+        ttstr next_text;
+        if(!TVPReadKagCharacterTag(parsed, next_text)) {
+            if(parsed) {
+                boundary = CloneTag(parsed);
+                parsed->Release();
+            }
+            break;
+        }
+
+        source_tags.push_back(CloneTag(parsed));
+        source_text += next_text;
+        parsed->Release();
+    }
+
+    const std::string source_utf8 = source_text.AsStdString();
+    const std::string translated_utf8 =
+        TVPTransformText("kirikiri", source_utf8);
+    const ttstr translated(translated_utf8);
+
+    if(translated.IsEmpty() || translated_utf8 == source_utf8) {
+        for(auto *tag : source_tags)
+            TextTagQueue.push_back(tag);
+    } else {
+        for(tjs_int i = 0; i < translated.GetLen(); ++i) {
+            const size_t template_index = std::min<size_t>(
+                static_cast<size_t>(i), source_tags.size() - 1);
+            iTJSDispatch2 *tag = CloneTag(source_tags[template_index]);
+            const ttstr character(translated.c_str() + i, 1);
+            TVPSetKagCharacterTagText(tag, character);
+            TextTagQueue.push_back(tag);
+        }
+        for(auto *tag : source_tags)
+            tag->Release();
+    }
+
+    if(boundary)
+        TextTagQueue.push_back(boundary);
+
+    iTJSDispatch2 *tag = TextTagQueue.front();
+    TextTagQueue.pop_front();
+    return tag;
+}
 
 //---------------------------------------------------------------------------
 iTJSDispatch2 *tTJSNI_KAGParser::CopyTag(tjs_int numparams,

--- a/cpp/core/base/KAGParser.h
+++ b/cpp/core/base/KAGParser.h
@@ -23,6 +23,7 @@
 #include "CharacterSet.h"
 #include "TransIntf.h"
 #include "tjsHashSearch.h"
+#include <deque>
 #include <vector>
 
 using namespace TJS;
@@ -268,6 +269,11 @@ private:
     bool Interrupted;
     bool MultiLineTagEnabled;
 
+    // Tags produced from one translated text run.  KAG scripts can encode
+    // dialogue either as plain text or as consecutive explicit [ch] tags;
+    // this queue gives both representations the same parser-level boundary.
+    std::deque<iTJSDispatch2 *> TextTagQueue;
+
 public:
     void operator=(const tTJSNI_KAGParser &ref);
 
@@ -338,6 +344,11 @@ private:
 
 private:
     iTJSDispatch2 *_GetNextTag();
+
+    iTJSDispatch2 *CloneTag(iTJSDispatch2 *source);
+
+    void ClearTextTagQueue();
+    void PrefetchTextLookahead(tjs_int current_run_end);
 
 public:
     iTJSDispatch2 *GetNextTag();

--- a/cpp/core/base/ScriptMgnIntf.cpp
+++ b/cpp/core/base/ScriptMgnIntf.cpp
@@ -64,12 +64,36 @@
 #include <android/log.h>
 #endif
 
+#include <algorithm>
 #include <atomic>
 #include <cstdlib>
 #include <utility>
 #include <vector>
 
 namespace {
+
+std::vector<tTVPPostStartupScriptHook> &TVPGetPostStartupScriptHooks() {
+    static std::vector<tTVPPostStartupScriptHook> hooks;
+    return hooks;
+}
+
+void TVPRunPostStartupScriptHooks() {
+    // A hook may register itself again while refreshing. Iterate over a copy
+    // so registration cannot invalidate this pass.
+    const auto hooks = TVPGetPostStartupScriptHooks();
+    for(const auto hook : hooks) {
+        if(!hook)
+            continue;
+        try {
+            hook();
+        } catch(const TJS::eTJS &e) {
+            spdlog::warn("Post-startup script hook failed: {}",
+                         e.GetMessage().AsStdString());
+        } catch(...) {
+            spdlog::warn("Post-startup script hook failed");
+        }
+    }
+}
 
 // Monotonically records actual entries into the engine's storage executor.
 // Script-side loader wrappers can use this to detect that they returned
@@ -81,6 +105,14 @@ tjs_uint64 TVPGetStorageExecutionSerial() {
 }
 
 } // namespace
+
+void TVPRegisterPostStartupScriptHook(tTVPPostStartupScriptHook hook) {
+    auto &hooks = TVPGetPostStartupScriptHooks();
+    if(!hook ||
+       std::find(hooks.begin(), hooks.end(), hook) != hooks.end())
+        return;
+    hooks.push_back(hook);
+}
 
 //---------------------------------------------------------------------------
 // Script system initialization script
@@ -4180,6 +4212,7 @@ void TVPExecuteStartupScript() {
         } catch(...) {
         }
         TVPInstallKagLoadContractGuard();
+        TVPRunPostStartupScriptHooks();
 
     }
     TJS_CONVERT_TO_TJS_EXCEPTION

--- a/cpp/core/base/ScriptMgnIntf.h
+++ b/cpp/core/base/ScriptMgnIntf.h
@@ -79,6 +79,12 @@ TJS_EXP_FUNC_DEF(void, TVPExecuteBytecode,
                   const tjs_char *name = nullptr));
 
 extern void TVPExecuteStartupScript();
+
+// Native plug-ins can use this hook to refresh script members after the
+// framework's root patch and AfterStartup.tjs have replaced global classes.
+// Re-registering the same callback is harmless.
+using tTVPPostStartupScriptHook = void (*)();
+extern void TVPRegisterPostStartupScriptHook(tTVPPostStartupScriptHook hook);
 extern const tjs_char *TVPGetStartupPatchPrerequisitesScript();
 extern const tjs_char *TVPGetPatchWindowPrerequisitesScript();
 extern const tjs_char *TVPGetKagLoadContractGuardScript();

--- a/cpp/core/utils/CMakeLists.txt
+++ b/cpp/core/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UTILS_SOURCE_FILES
     ${UTILS_PATH}/Random.cpp
     ${UTILS_PATH}/RealFFT_Default.cpp
     ${UTILS_PATH}/ThreadIntf.cpp
+    ${UTILS_PATH}/TextTransform.cpp
     ${UTILS_PATH}/TickCount.cpp
     ${UTILS_PATH}/TimerIntf.cpp
     ${UTILS_PATH}/VelocityTracker.cpp

--- a/cpp/core/utils/TextTransform.cpp
+++ b/cpp/core/utils/TextTransform.cpp
@@ -1,0 +1,49 @@
+#include "TextTransform.h"
+
+#include <atomic>
+
+namespace {
+
+std::atomic<tTVPTextTransformCallback> g_text_transform_callback{nullptr};
+std::atomic<tTVPTextPrefetchCallback> g_text_prefetch_callback{nullptr};
+
+}  // namespace
+
+void TVPSetTextTransformCallback(tTVPTextTransformCallback callback) {
+    g_text_transform_callback.store(callback, std::memory_order_release);
+}
+
+void TVPSetTextPrefetchCallback(tTVPTextPrefetchCallback callback) {
+    g_text_prefetch_callback.store(callback, std::memory_order_release);
+}
+
+std::string TVPTransformText(const char *runtime_id,
+                             const std::string &input) {
+    const auto callback =
+        g_text_transform_callback.load(std::memory_order_acquire);
+    if(callback == nullptr || input.empty())
+        return input;
+
+    std::string output;
+    try {
+        if(callback(runtime_id != nullptr ? runtime_id : "", input, &output) &&
+           !output.empty())
+            return output;
+    } catch(...) {
+        // Text rendering must remain fail-open: a translation problem must not
+        // break the game or suppress its original text.
+    }
+    return input;
+}
+
+void TVPPrefetchText(const char *runtime_id, const std::string &input) {
+    const auto callback =
+        g_text_prefetch_callback.load(std::memory_order_acquire);
+    if(callback == nullptr || input.empty())
+        return;
+    try {
+        callback(runtime_id != nullptr ? runtime_id : "", input);
+    } catch(...) {
+        // Speculative work must never affect parser execution.
+    }
+}

--- a/cpp/core/utils/TextTransform.h
+++ b/cpp/core/utils/TextTransform.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+// Runtime-neutral text transformation hook.  Public runtimes only know that
+// text may be transformed; the implementation (and any model state) lives in
+// the optional private package.
+using tTVPTextTransformCallback = bool (*)(const char *runtime_id,
+                                           const std::string &input,
+                                           std::string *output);
+using tTVPTextPrefetchCallback = void (*)(const char *runtime_id,
+                                          const std::string &input);
+
+void TVPSetTextTransformCallback(tTVPTextTransformCallback callback);
+void TVPSetTextPrefetchCallback(tTVPTextPrefetchCallback callback);
+std::string TVPTransformText(const char *runtime_id,
+                             const std::string &input);
+void TVPPrefetchText(const char *runtime_id, const std::string &input);

--- a/cpp/plugins/extkagparser/ExtKAGParser.cpp
+++ b/cpp/plugins/extkagparser/ExtKAGParser.cpp
@@ -22,6 +22,9 @@
 #include "EventIntf.h"
 
 #include "ExtKAGParser.hpp"
+#include "TextTransform.h"
+
+#include <algorithm>
 
 namespace {
 
@@ -37,6 +40,32 @@ int utf16_char_len(const tjs_char *text)
             return 2;
     }
     return 1;
+}
+
+bool read_character_tag(iTJSDispatch2 *tag, ttstr &text)
+{
+    if (!tag)
+        return false;
+
+    tTJSVariant tag_name;
+    if (TJS_FAILED(tag->PropGet(0, TJS_W("tagname"), nullptr, &tag_name,
+                                tag)) ||
+        tag_name.Type() == tvtVoid || ttstr(tag_name) != TJS_W("ch"))
+        return false;
+
+    tTJSVariant tag_text;
+    if (TJS_FAILED(tag->PropGet(0, TJS_W("text"), nullptr, &tag_text, tag)) ||
+        tag_text.Type() == tvtVoid)
+        return false;
+
+    text = tag_text;
+    return true;
+}
+
+void set_character_tag_text(iTJSDispatch2 *tag, const ttstr &text)
+{
+    tTJSVariant value(text);
+    tag->PropSet(TJS_MEMBERENSURE, TJS_W("text"), nullptr, &value, tag);
 }
 
 } // namespace
@@ -467,6 +496,8 @@ void tTJSNI_ExtKAGParser::Invalidate()
 //---------------------------------------------------------------------------
 void tTJSNI_ExtKAGParser::operator=(const tTJSNI_ExtKAGParser& ref)
 {
+    ClearTextTagQueue();
+
     // copy Macros
     Macros.Assign(ref.Macros.GetDicNoAddRef()); // GetDicNoAddRef() is const
 
@@ -1230,6 +1261,7 @@ void tTJSNI_ExtKAGParser::ClearBuffer()
     if (DebugLevel > tkdlVerbose)
         TVPAddLog(TJS_W("Invoking: KAGParser::ClearBuffer()"));
     // clear internal buffer
+    ClearTextTagQueue();
     BreakConditionAndMacro();
     // BreakConditionAndMacro() should be before Scenario = NULL,
     // as Scenario is referenced in PopWhileStack();
@@ -2415,6 +2447,39 @@ iTJSDispatch2* tTJSNI_ExtKAGParser::_GetNextTag()
         else
         {
             // normal character
+            // Preserve ExtKAGParser's per-character output, but give the
+            // optional text transformer the whole visible run first.  This
+            // is required by local translation models and avoids changing
+            // the script's reveal timing or layout contract.
+            if (!RecordingMacro && NeedToDoThisTag() &&
+                GetCurChar() != TJS_W('['))
+            {
+                tjs_int run_end = CurPos;
+                while (CurLineStr[run_end] != 0 &&
+                       CurLineStr[run_end] != TJS_W('\n') &&
+                       CurLineStr[run_end] != TJS_W('['))
+                    ++run_end;
+
+                if (run_end > CurPos)
+                {
+                    const ttstr original(CurLineStr + CurPos,
+                                         run_end - CurPos);
+                    const std::string original_utf8 = original.AsStdString();
+                    TVPPrefetchText("kirikiri", original_utf8);
+                    PrefetchTextLookahead(run_end);
+                    const std::string translated_utf8 =
+                        TVPTransformText("kirikiri", original_utf8);
+                    if (translated_utf8 != original_utf8)
+                    {
+                        const ttstr translated(translated_utf8);
+                        InsertStringOntoLineBuffer(
+                            CurPos, translated, run_end - CurPos);
+                        CurLineStr = LineBuffer.c_str();
+                        LineBufferUsing = true;
+                    }
+                }
+            }
+
             const tjs_char* chstart = CurLineStr + CurPos;
             int chLen = utf16_char_len(CurLineStr + CurPos);
             CurPos += chLen;
@@ -3443,9 +3508,155 @@ iTJSDispatch2* tTJSNI_ExtKAGParser::_GetNextTag()
     return NULL;
 }
 //---------------------------------------------------------------------------
+void tTJSNI_ExtKAGParser::ClearTextTagQueue()
+{
+    while (!TextTagQueue.empty())
+    {
+        TextTagQueue.front()->Release();
+        TextTagQueue.pop_front();
+    }
+}
+
+void tTJSNI_ExtKAGParser::PrefetchTextLookahead(tjs_int current_run_end)
+{
+    if (!Lines || CurLine >= LineCount || RecordingMacro ||
+        !NeedToDoThisTag())
+        return;
+
+    constexpr size_t kMaximumPrefetchRuns = 12;
+    size_t queued = 0;
+    for (tjs_int line_index = CurLine;
+         line_index < LineCount && queued < kMaximumPrefetchRuns;
+         ++line_index)
+    {
+        const tjs_char *line = line_index == CurLine
+            ? CurLineStr
+            : Lines[line_index].Start;
+        if (!line)
+            continue;
+        tjs_int position = line_index == CurLine ? current_run_end : 0;
+        if (TJS_strstr(line, TJS_W("[iscript]")) != nullptr ||
+            TJS_strstr(line, TJS_W("@iscript")) != nullptr ||
+            TJS_strstr(line, TJS_W("[macro")) != nullptr)
+            break;
+        if (position == 0 && (line[0] == TJS_W(';') ||
+                              line[0] == TJS_W('*') ||
+                              line[0] == TJS_W('@')))
+            continue;
+
+        while (line[position] != 0 && queued < kMaximumPrefetchRuns)
+        {
+            if (line[position] == TJS_W('['))
+            {
+                const tjs_char *close = TJS_strchr(
+                    const_cast<tjs_char *>(line + position + 1), TJS_W(']'));
+                if (!close)
+                    break;
+                position = static_cast<tjs_int>(close - line) + 1;
+                continue;
+            }
+            const tjs_int run_start = position;
+            while (line[position] != 0 && line[position] != TJS_W('[') &&
+                   line[position] != TJS_W('\n'))
+                ++position;
+            if (position > run_start)
+            {
+                const ttstr candidate(line + run_start,
+                                      position - run_start);
+                TVPPrefetchText("kirikiri", candidate.AsStdString());
+                ++queued;
+            }
+        }
+    }
+}
+
+iTJSDispatch2* tTJSNI_ExtKAGParser::CloneTag(iTJSDispatch2 *source)
+{
+    if (!source)
+        return nullptr;
+
+    tTJSDic clone;
+    clone.Assign(source);
+    return clone.GetDic();
+}
+
 iTJSDispatch2* tTJSNI_ExtKAGParser::GetNextTag()
 {
-    return _GetNextTag();
+    if (Interrupted)
+        ClearTextTagQueue();
+
+    if (!TextTagQueue.empty())
+    {
+        iTJSDispatch2 *tag = TextTagQueue.front();
+        TextTagQueue.pop_front();
+        return tag;
+    }
+
+    iTJSDispatch2 *parsed = _GetNextTag();
+    ttstr first_text;
+    if (!read_character_tag(parsed, first_text))
+        return parsed;
+
+    std::vector<iTJSDispatch2 *> source_tags;
+    source_tags.reserve(64);
+    source_tags.push_back(CloneTag(parsed));
+    parsed->Release();
+
+    ttstr source_text(first_text);
+    iTJSDispatch2 *boundary = nullptr;
+    constexpr size_t kMaxTextRunTags = 2048;
+    while (source_tags.size() < kMaxTextRunTags)
+    {
+        parsed = _GetNextTag();
+        ttstr next_text;
+        if (!read_character_tag(parsed, next_text))
+        {
+            if (parsed)
+            {
+                boundary = CloneTag(parsed);
+                parsed->Release();
+            }
+            break;
+        }
+
+        source_tags.push_back(CloneTag(parsed));
+        source_text += next_text;
+        parsed->Release();
+    }
+
+    const std::string source_utf8 = source_text.AsStdString();
+    const std::string translated_utf8 =
+        TVPTransformText("kirikiri", source_utf8);
+    const ttstr translated(translated_utf8);
+
+    if (translated.IsEmpty() || translated_utf8 == source_utf8)
+    {
+        for (auto *tag : source_tags)
+            TextTagQueue.push_back(tag);
+    }
+    else
+    {
+        for (tjs_int i = 0; i < translated.GetLen();)
+        {
+            const size_t template_index = std::min<size_t>(
+                static_cast<size_t>(i), source_tags.size() - 1);
+            iTJSDispatch2 *tag = CloneTag(source_tags[template_index]);
+            const tjs_int character_length = utf16_char_len(translated.c_str() + i);
+            const ttstr character(translated.c_str() + i, character_length);
+            set_character_tag_text(tag, character);
+            TextTagQueue.push_back(tag);
+            i += character_length;
+        }
+        for (auto *tag : source_tags)
+            tag->Release();
+    }
+
+    if (boundary)
+        TextTagQueue.push_back(boundary);
+
+    iTJSDispatch2 *tag = TextTagQueue.front();
+    TextTagQueue.pop_front();
+    return tag;
 }
 //---------------------------------------------------------------------------
 tTJSDic& tTJSNI_ExtKAGParser::GetMacroTopNoAddRef() const

--- a/cpp/plugins/extkagparser/ExtKAGParser.hpp
+++ b/cpp/plugins/extkagparser/ExtKAGParser.hpp
@@ -14,6 +14,7 @@
 //---------------------------------------------------------------------------
 
 #include "ExttjsHashSearch.h"
+#include <deque>
 #include <vector>
 #include "TJSAry.h"
 #include "TJSDic.h"
@@ -284,6 +285,10 @@ private:
 
 	bool Interrupted;
 
+	// Tags produced from one translated explicit-character run.  Keep the
+	// parser's per-character contract while translating with sentence context.
+	std::deque<iTJSDispatch2 *> TextTagQueue;
+
 	// ExtKAGParser extends
 	bool MultiLineTagEnabled;
 	bool NumericMacroArgumentsEnabled;
@@ -367,6 +372,9 @@ public:
 
 private:
 	iTJSDispatch2 * _GetNextTag();
+	iTJSDispatch2 * CloneTag(iTJSDispatch2 *source);
+	void ClearTextTagQueue();
+	void PrefetchTextLookahead(tjs_int current_run_end);
 
 public:
 	iTJSDispatch2 * GetNextTag();

--- a/cpp/plugins/sqlitePlugin.cpp
+++ b/cpp/plugins/sqlitePlugin.cpp
@@ -1,5 +1,6 @@
 #include "PluginStub.h"
 #include "StorageIntf.h"
+#include "TextTransform.h"
 #include "ncbind.hpp"
 #include "sqlite/sqlite3.h"
 
@@ -161,7 +162,72 @@ int bindParams(sqlite3_stmt *stmt, const tTJSVariant &params) {
     return errorCode;
 }
 
-void getColumnData(sqlite3_stmt *stmt, tTJSVariant &variant, int column) {
+int findColumn(sqlite3_stmt *stmt, const tjs_char *name) {
+    if(!stmt || !name)
+        return -1;
+    const int count = sqlite3_column_count(stmt);
+    for(int i = 0; i < count; ++i) {
+        const auto *columnName = reinterpret_cast<const tjs_char *>(
+            sqlite3_column_name16(stmt, i));
+        if(columnName && TJS_stricmp(name, columnName) == 0)
+            return i;
+    }
+    return -1;
+}
+
+bool isScenarioTextColumn(sqlite3_stmt *stmt, int column) {
+    return column >= 0 && column == findColumn(stmt, TJS_W("text")) &&
+        findColumn(stmt, TJS_W("scene")) >= 0 &&
+        findColumn(stmt, TJS_W("idx")) >= 0;
+}
+
+void prefetchColumnText(sqlite3_stmt *stmt, int column) {
+    if(!stmt || column < 0 ||
+       sqlite3_column_type(stmt, column) != SQLITE_TEXT)
+        return;
+    const auto *text = reinterpret_cast<const tjs_char *>(
+        sqlite3_column_text16(stmt, column));
+    if(text && *text)
+        TVPPrefetchText("kirikiri", ttstr(text).AsStdString());
+}
+
+void prefetchScenarioTextLookahead(sqlite3 *db, sqlite3_stmt *current) {
+    if(!db || !current)
+        return;
+    const int sceneColumn = findColumn(current, TJS_W("scene"));
+    const int indexColumn = findColumn(current, TJS_W("idx"));
+    const int textColumn = findColumn(current, TJS_W("text"));
+    if(sceneColumn < 0 || indexColumn < 0 || textColumn < 0 ||
+       sqlite3_column_type(current, sceneColumn) != SQLITE_INTEGER ||
+       sqlite3_column_type(current, indexColumn) != SQLITE_INTEGER)
+        return;
+
+    prefetchColumnText(current, textColumn);
+
+    // Several KiriKiri scene systems keep compiled dialogue in a SQLite table
+    // keyed by (scene, idx), then split the returned string into character
+    // draw calls.  Read a small, indexed window while the current line is on
+    // screen so later rows are already translated when the script asks for
+    // them.  The query is intentionally schema-driven and does not depend on
+    // a game path, archive, or script implementation.
+    static const tjs_char lookaheadSql[] =
+        TJS_W("SELECT text FROM text WHERE scene=?1 AND idx>?2 "
+              "ORDER BY idx LIMIT 12");
+    sqlite3_stmt *lookahead = nullptr;
+    if(sqlite3_prepare16_v2(db, lookaheadSql, -1, &lookahead, nullptr) !=
+       SQLITE_OK)
+        return;
+    sqlite3_bind_int64(lookahead, 1,
+                       sqlite3_column_int64(current, sceneColumn));
+    sqlite3_bind_int64(lookahead, 2,
+                       sqlite3_column_int64(current, indexColumn));
+    while(sqlite3_step(lookahead) == SQLITE_ROW)
+        prefetchColumnText(lookahead, 0);
+    sqlite3_finalize(lookahead);
+}
+
+void getColumnData(sqlite3_stmt *stmt, tTJSVariant &variant, int column,
+                   bool transformScenarioText = false) {
     switch(sqlite3_column_type(stmt, column)) {
         case SQLITE_INTEGER:
             variant = static_cast<tTVInteger>(sqlite3_column_int64(stmt, column));
@@ -169,11 +235,19 @@ void getColumnData(sqlite3_stmt *stmt, tTJSVariant &variant, int column) {
         case SQLITE_FLOAT:
             variant = sqlite3_column_double(stmt, column);
             break;
-        case SQLITE_TEXT:
-            variant =
-                reinterpret_cast<const tjs_char *>(sqlite3_column_text16(stmt,
-                                                                          column));
+        case SQLITE_TEXT: {
+            const auto *text = reinterpret_cast<const tjs_char *>(
+                sqlite3_column_text16(stmt, column));
+            variant = text;
+            if(transformScenarioText && text && *text) {
+                const std::string original = ttstr(text).AsStdString();
+                const std::string translated =
+                    TVPTransformText("kirikiri", original);
+                if(translated != original)
+                    variant = ttstr(translated);
+            }
             break;
+        }
         case SQLITE_BLOB:
             variant = tTJSVariant(
                 static_cast<const tjs_uint8 *>(sqlite3_column_blob(stmt, column)),
@@ -479,14 +553,18 @@ public:
 
     int exec() {
         const int ret = stmt_ ? sqlite3_step(stmt_) : SQLITE_MISUSE;
-        if(ret != SQLITE_ROW)
+        if(ret == SQLITE_ROW)
+            prefetchScenarioTextLookahead(db_, stmt_);
+        else
             reset();
         return ret;
     }
 
     bool step() {
-        if(stmt_ && sqlite3_step(stmt_) == SQLITE_ROW)
+        if(stmt_ && sqlite3_step(stmt_) == SQLITE_ROW) {
+            prefetchScenarioTextLookahead(db_, stmt_);
             return true;
+        }
         reset();
         return false;
     }
@@ -521,7 +599,8 @@ public:
             iTJSDispatch2 *line = TJSCreateArrayObject();
             for(int i = 0; i < count; ++i) {
                 tTJSVariant value;
-                getColumnData(self->stmt_, value, i);
+                getColumnData(self->stmt_, value, i,
+                              isScenarioTextColumn(self->stmt_, i));
                 tTJSVariant *argv[] = { &value };
                 line->FuncCall(0, TJS_W("add"), nullptr, nullptr, 1, argv, line);
             }
@@ -537,7 +616,8 @@ public:
             else
                 result->Clear();
         } else {
-            getColumnData(self->stmt_, *result, col);
+            getColumnData(self->stmt_, *result, col,
+                          isScenarioTextColumn(self->stmt_, col));
         }
         return TJS_S_OK;
     }
@@ -553,7 +633,8 @@ public:
             const int col = self->getColumnNo(*params[1]);
             if(col >= 0) {
                 tTJSVariant value;
-                getColumnData(self->stmt_, value, col);
+                getColumnData(self->stmt_, value, col,
+                              isScenarioTextColumn(self->stmt_, col));
                 params[2]->AsObjectClosureNoAddRef().PropSet(
                     0, nullptr, nullptr, &value, nullptr);
                 ret = true;

--- a/cpp/plugins/textrender.cpp
+++ b/cpp/plugins/textrender.cpp
@@ -12,6 +12,7 @@
 #include "FontBaseline.h"
 #include "LayerIntf.h"
 #include "RectItf.h"
+#include "TextTransform.h"
 #include "textrender_timing.h"
 #include "tvpfontstruc.h"
 #include "WindowIntf.h"
@@ -1064,6 +1065,10 @@ std::optional<double> TextRenderBase::resolveDelayLabel(
 bool TextRenderBase::render(tTJSString text, int autoIndent, int diff, int all,
                             bool same, bool plain,
                             iTJSDispatch2 *callbackThis) {
+  const std::string originalText = text.AsStdString();
+  const std::string translatedText =
+      TVPTransformText("kirikiri", originalText);
+  if (translatedText != originalText) text = tTJSString(translatedText);
   // A new message keeps the already laid-out glyphs, but their reveal time is
   // reset to zero.  This is how MsgwinRender appends a new line while only
   // animating the newly supplied text.  `same` is used by synchronized

--- a/tests/unit-tests/engine_api/CMakeLists.txt
+++ b/tests/unit-tests/engine_api/CMakeLists.txt
@@ -6,12 +6,14 @@ add_executable(engine-api-diagnostics
     ${CMAKE_SOURCE_DIR}/bridge/engine_api/src/engine_api.cpp
     ${CMAKE_SOURCE_DIR}/bridge/engine_api/src/engine_api_dispatch.cpp
     ${CMAKE_SOURCE_DIR}/bridge/engine_api/src/engine_runtime_provider.cpp
+    ${CMAKE_SOURCE_DIR}/cpp/core/utils/TextTransform.cpp
 )
 
 target_compile_features(engine-api-diagnostics PRIVATE cxx_std_17)
 target_include_directories(engine-api-diagnostics PRIVATE
     ${CMAKE_SOURCE_DIR}/bridge/engine_api/include
     ${CMAKE_SOURCE_DIR}/bridge/engine_api/src
+    ${CMAKE_SOURCE_DIR}/cpp/core/utils
 )
 target_link_libraries(engine-api-diagnostics PRIVATE Catch2::Catch2WithMain)
 

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -500,3 +500,31 @@ TEST_CASE("plugin debug snapshot is bounded JSON and validates buffers") {
                                        &written) == ENGINE_RESULT_INVALID_ARGUMENT);
   REQUIRE(written == 0);
 }
+
+TEST_CASE("text translation state is disabled without the private provider") {
+  REQUIRE(engine_is_text_translation_available() == 0);
+  REQUIRE(engine_get_text_translation_state() ==
+          ENGINE_TEXT_TRANSLATION_DISABLED);
+  engine_text_translation_stats_t translation_stats{};
+  translation_stats.struct_size = sizeof(translation_stats);
+  REQUIRE(engine_get_text_translation_stats(&translation_stats) ==
+          ENGINE_RESULT_OK);
+  REQUIRE(translation_stats.state == ENGINE_TEXT_TRANSLATION_DISABLED);
+  REQUIRE(translation_stats.backend == ENGINE_TEXT_TRANSLATION_BACKEND_NONE);
+  REQUIRE(translation_stats.model_tensor_bytes == 0);
+  REQUIRE(engine_get_text_translation_stats(nullptr) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  engine_text_translation_stats_t short_translation_stats{};
+  short_translation_stats.struct_size = sizeof(uint32_t);
+  REQUIRE(engine_get_text_translation_stats(&short_translation_stats) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_prefetch_text_utf8("kirikiri", "テスト") == ENGINE_RESULT_OK);
+  REQUIRE(engine_set_text_translation_skipping("kirikiri", 1) ==
+          ENGINE_RESULT_OK);
+  REQUIRE(engine_prefetch_text_utf8(nullptr, "テスト") ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_prefetch_text_utf8("kirikiri", nullptr) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+  REQUIRE(engine_set_text_translation_skipping(nullptr, 1) ==
+          ENGINE_RESULT_INVALID_ARGUMENT);
+}

--- a/tests/unit-tests/plugins/registry.cpp
+++ b/tests/unit-tests/plugins/registry.cpp
@@ -2,12 +2,15 @@
 
 #include "PluginImpl.h"
 #include "ScriptMgnIntf.h"
+#include "TextTransform.h"
 #include "TransIntf.h"
 #include "ncbind.hpp"
 #include "tjsDictionary.h"
 
+#include <algorithm>
 #include <cstring>
 #include <utility>
+#include <vector>
 
 extern tTJS *TVPScriptEngine;
 extern "C" void TVPRegisterLayerExDrawPluginAnchor();
@@ -64,6 +67,37 @@ public:
 private:
     ttstr Scenario;
 };
+
+class TextTransformReset {
+public:
+    ~TextTransformReset() {
+        TVPSetTextTransformCallback(nullptr);
+        TVPSetTextPrefetchCallback(nullptr);
+    }
+};
+
+std::vector<std::string> prefetchedKagTestRuns;
+
+void recordKagTestPrefetch(const char *runtime, const std::string &input) {
+    if(std::strcmp(runtime, "kirikiri") == 0)
+        prefetchedKagTestRuns.push_back(input);
+}
+
+bool translateKagTestRun(const char *runtime, const std::string &input,
+                         std::string *output) {
+    if(std::strcmp(runtime, "kirikiri") != 0 || input != "日本語です")
+        return false;
+    *output = "中文文本";
+    return true;
+}
+
+bool translateSqliteTestRun(const char *runtime, const std::string &input,
+                            std::string *output) {
+    if(std::strcmp(runtime, "kirikiri") != 0 || input != "最初の文章です")
+        return false;
+    *output = "第一句";
+    return true;
+}
 
 tTJSVariant getIndex(const tTJSVariant &object, tjs_int index) {
     REQUIRE(object.Type() == tvtObject);
@@ -358,6 +392,85 @@ TEST_CASE("plugin load mode defaults to krkrsdl3 and can select all modules") {
     CHECK(TVPGetPluginLoadMode() == TJS_W("krkrsdl3"));
 }
 
+TEST_CASE("SQLite scene rows transform text and prefetch following dialogue") {
+    ensurePluginRegistryRuntime();
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("sqlite3.dll")));
+
+    tTJSVariant sqliteClass = getGlobalProp(TJS_W("Sqlite"));
+    iTJSDispatch2 *database = nullptr;
+    tTJSVariant databaseName(TJS_W(":memory:"));
+    tTJSVariant *databaseArgs[] = { &databaseName };
+    REQUIRE(TJS_SUCCEEDED(sqliteClass.AsObjectClosureNoAddRef().CreateNew(
+        0, nullptr, nullptr, &database, 1, databaseArgs, nullptr)));
+    REQUIRE(database != nullptr);
+
+    const auto execSql = [&](const tjs_char *sql) {
+        tTJSVariant statement(sql);
+        tTJSVariant *args[] = { &statement };
+        tTJSVariant result;
+        REQUIRE(TJS_SUCCEEDED(database->FuncCall(
+            0, TJS_W("exec"), nullptr, &result, 1, args, database)));
+        REQUIRE(static_cast<bool>(result));
+    };
+    execSql(TJS_W("CREATE TABLE text (scene INTEGER, idx INTEGER, "
+                  "name INTEGER, disp STRING, text STRING)"));
+    execSql(TJS_W("INSERT INTO text VALUES "
+                  "(7,1,0,'','最初の文章です'),"
+                  "(7,2,0,'','次の文章です'),"
+                  "(7,3,0,'','最後の文章です')"));
+
+    tTJSVariant statementClass = getGlobalProp(TJS_W("SqliteStatement"));
+    tTJSVariant databaseValue(database, database);
+    tTJSVariant selectSql(
+        TJS_W("SELECT scene,idx,name,disp,text FROM text "
+              "WHERE scene=? AND idx=?"));
+    tTJSVariant *statementArgs[] = { &databaseValue, &selectSql };
+    iTJSDispatch2 *statement = nullptr;
+    REQUIRE(TJS_SUCCEEDED(statementClass.AsObjectClosureNoAddRef().CreateNew(
+        0, nullptr, nullptr, &statement, 2, statementArgs, nullptr)));
+    REQUIRE(statement != nullptr);
+
+    iTJSDispatch2 *bindings = TJSCreateArrayObject();
+    REQUIRE(bindings != nullptr);
+    tTJSVariant scene(static_cast<tTVInteger>(7));
+    tTJSVariant index(static_cast<tTVInteger>(1));
+    tTJSVariant *sceneArg[] = { &scene };
+    tTJSVariant *indexArg[] = { &index };
+    REQUIRE(TJS_SUCCEEDED(bindings->FuncCall(
+        0, TJS_W("add"), nullptr, nullptr, 1, sceneArg, bindings)));
+    REQUIRE(TJS_SUCCEEDED(bindings->FuncCall(
+        0, TJS_W("add"), nullptr, nullptr, 1, indexArg, bindings)));
+    tTJSVariant bindingsValue(bindings, bindings);
+    tTJSVariant *bindArgs[] = { &bindingsValue };
+    REQUIRE(TJS_SUCCEEDED(statement->FuncCall(
+        0, TJS_W("bind"), nullptr, nullptr, 1, bindArgs, statement)));
+
+    TextTransformReset transformReset;
+    prefetchedKagTestRuns.clear();
+    TVPSetTextTransformCallback(&translateSqliteTestRun);
+    TVPSetTextPrefetchCallback(&recordKagTestPrefetch);
+
+    tTJSVariant hasRow;
+    REQUIRE(TJS_SUCCEEDED(statement->FuncCall(
+        0, TJS_W("step"), nullptr, &hasRow, 0, nullptr, statement)));
+    REQUIRE(static_cast<bool>(hasRow));
+
+    tTJSVariant row;
+    REQUIRE(TJS_SUCCEEDED(statement->FuncCall(
+        0, TJS_W("get"), nullptr, &row, 0, nullptr, statement)));
+    CHECK(ttstr(getIndex(row, 4)) == TJS_W("第一句"));
+    CHECK(std::find(prefetchedKagTestRuns.begin(),
+                    prefetchedKagTestRuns.end(),
+                    "次の文章です") != prefetchedKagTestRuns.end());
+    CHECK(std::find(prefetchedKagTestRuns.begin(),
+                    prefetchedKagTestRuns.end(),
+                    "最後の文章です") != prefetchedKagTestRuns.end());
+
+    bindings->Release();
+    statement->Release();
+    database->Release();
+}
+
 TEST_CASE("KAGParserEx getNextTag returns ordered taglist") {
     ensurePluginRegistryRuntime();
     ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll"));
@@ -415,6 +528,122 @@ TEST_CASE("KAGParserEx getNextTag returns ordered taglist") {
     for(tjs_int i = 0; i < enumeratedCount; i += 2)
         CHECK(ttstr(getIndex(enumeratedValue, i)) != TJS_W("taglist"));
     enumerated->Release();
+
+    parser->Release();
+    REQUIRE(ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll")));
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+    global->DeleteMember(0, TJS_W("AetherKiriKAGParserEx"), nullptr, global);
+    global->Release();
+}
+
+TEST_CASE("KAGParserEx transforms a complete text run before character tags") {
+    ensurePluginRegistryRuntime();
+    ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll"));
+
+    iTJSDispatch2 *global = TVPGetScriptDispatch();
+    REQUIRE(global != nullptr);
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("KAGParserEx.dll")));
+    tTJSVariant parserClass = getGlobalProp(TJS_W("KAGParser"));
+    REQUIRE(parserClass.Type() == tvtObject);
+
+    iTJSDispatch2 *parser = nullptr;
+    tTJSVariantClosure parserClosure = parserClass.AsObjectClosureNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(parserClosure.CreateNew(0, nullptr, nullptr, &parser,
+                                                  0, nullptr, nullptr)));
+    REQUIRE(parser != nullptr);
+
+    ScenarioLoadCallback *callback = new ScenarioLoadCallback(
+        TJS_W("日本語です[p]\n次の文章です[p]\n"));
+    tTJSVariant callbackValue(callback, callback);
+    setProp(parser, TJS_W("onScenarioLoad"), callbackValue);
+    callback->Release();
+
+    TextTransformReset transformReset;
+    prefetchedKagTestRuns.clear();
+    TVPSetTextTransformCallback(&translateKagTestRun);
+    TVPSetTextPrefetchCallback(&recordKagTestPrefetch);
+
+    tTJSVariant storage(TJS_W("translation.ks"));
+    tTJSVariant *loadArgs[] = { &storage };
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(0, TJS_W("loadScenario"), nullptr,
+                                           nullptr, 1, loadArgs, parser)));
+
+    ttstr transformed;
+    for(tjs_int i = 0; i < 4; ++i) {
+        tTJSVariant tag;
+        REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+            0, TJS_W("getNextTag"), nullptr, &tag, 0, nullptr, parser)));
+        REQUIRE(tag.Type() == tvtObject);
+        CHECK(ttstr(getProp(tag, TJS_W("tagname"))) == TJS_W("ch"));
+        transformed += ttstr(getProp(tag, TJS_W("text")));
+    }
+    CHECK(transformed == TJS_W("中文文本"));
+    CHECK(std::find(prefetchedKagTestRuns.begin(),
+                    prefetchedKagTestRuns.end(),
+                    "次の文章です") != prefetchedKagTestRuns.end());
+
+    tTJSVariant pageBreak;
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+        0, TJS_W("getNextTag"), nullptr, &pageBreak, 0, nullptr, parser)));
+    CHECK(ttstr(getProp(pageBreak, TJS_W("tagname"))) == TJS_W("p"));
+
+    parser->Release();
+    REQUIRE(ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll")));
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+    global->DeleteMember(0, TJS_W("AetherKiriKAGParserEx"), nullptr, global);
+    global->Release();
+}
+
+TEST_CASE("KAGParserEx transforms consecutive explicit character tags") {
+    ensurePluginRegistryRuntime();
+    ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll"));
+
+    iTJSDispatch2 *global = TVPGetScriptDispatch();
+    REQUIRE(global != nullptr);
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("KAGParserEx.dll")));
+    tTJSVariant parserClass = getGlobalProp(TJS_W("KAGParser"));
+    REQUIRE(parserClass.Type() == tvtObject);
+
+    iTJSDispatch2 *parser = nullptr;
+    tTJSVariantClosure parserClosure = parserClass.AsObjectClosureNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(parserClosure.CreateNew(0, nullptr, nullptr, &parser,
+                                                  0, nullptr, nullptr)));
+    REQUIRE(parser != nullptr);
+
+    ScenarioLoadCallback *callback = new ScenarioLoadCallback(
+        TJS_W("[ch text='日'][ch text='本'][ch text='語']"
+              "[ch text='で'][ch text='す'][p]\n"));
+    tTJSVariant callbackValue(callback, callback);
+    setProp(parser, TJS_W("onScenarioLoad"), callbackValue);
+    callback->Release();
+
+    TextTransformReset transformReset;
+    TVPSetTextTransformCallback(&translateKagTestRun);
+
+    tTJSVariant storage(TJS_W("compiled-translation.ks"));
+    tTJSVariant *loadArgs[] = { &storage };
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(0, TJS_W("loadScenario"), nullptr,
+                                           nullptr, 1, loadArgs, parser)));
+
+    ttstr transformed;
+    for(tjs_int i = 0; i < 4; ++i) {
+        tTJSVariant tag;
+        REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+            0, TJS_W("getNextTag"), nullptr, &tag, 0, nullptr, parser)));
+        REQUIRE(tag.Type() == tvtObject);
+        CHECK(ttstr(getProp(tag, TJS_W("tagname"))) == TJS_W("ch"));
+        transformed += ttstr(getProp(tag, TJS_W("text")));
+    }
+    CHECK(transformed == TJS_W("中文文本"));
+
+    tTJSVariant pageBreak;
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+        0, TJS_W("getNextTag"), nullptr, &pageBreak, 0, nullptr, parser)));
+    CHECK(ttstr(getProp(pageBreak, TJS_W("tagname"))) == TJS_W("p"));
 
     parser->Release();
     REQUIRE(ncbAutoRegister::UnloadModule(TJS_W("KAGParserEx.dll")));
@@ -646,6 +875,62 @@ TEST_CASE("ExtKAGParser preserves native local and parameter macro semantics") {
     REQUIRE(restored.Type() == tvtObject);
     CHECK(restored.AsObjectNoAddRef() == original);
 
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+    global->Release();
+}
+
+TEST_CASE("ExtKAGParser transforms consecutive explicit character tags") {
+    ensurePluginRegistryRuntime();
+    ncbAutoRegister::UnloadModule(TJS_W("ExtKAGParser.dll"));
+
+    iTJSDispatch2 *global = TVPGetScriptDispatch();
+    REQUIRE(global != nullptr);
+    global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
+
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("ExtKAGParser.dll")));
+    tTJSVariant parserClass = getGlobalProp(TJS_W("KAGParser"));
+    REQUIRE(parserClass.Type() == tvtObject);
+
+    iTJSDispatch2 *parser = nullptr;
+    tTJSVariantClosure parserClosure = parserClass.AsObjectClosureNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(parserClosure.CreateNew(0, nullptr, nullptr, &parser,
+                                                  0, nullptr, nullptr)));
+    REQUIRE(parser != nullptr);
+
+    ScenarioLoadCallback *callback = new ScenarioLoadCallback(
+        TJS_W("[ch text='日'][ch text='本'][ch text='語']"
+              "[ch text='で'][ch text='す'][p]\n"));
+    tTJSVariant callbackValue(callback, callback);
+    setProp(parser, TJS_W("onScenarioLoad"), callbackValue);
+    callback->Release();
+
+    TextTransformReset transformReset;
+    TVPSetTextTransformCallback(&translateKagTestRun);
+
+    tTJSVariant storage(TJS_W("ext-compiled-translation.ks"));
+    tTJSVariant *loadArgs[] = { &storage };
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(0, TJS_W("loadScenario"), nullptr,
+                                           nullptr, 1, loadArgs, parser)));
+
+    ttstr transformed;
+    for(tjs_int i = 0; i < 4; ++i) {
+        tTJSVariant tag;
+        REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+            0, TJS_W("getNextTag"), nullptr, &tag, 0, nullptr, parser)));
+        REQUIRE(tag.Type() == tvtObject);
+        CHECK(ttstr(getProp(tag, TJS_W("tagname"))) == TJS_W("ch"));
+        transformed += ttstr(getProp(tag, TJS_W("text")));
+    }
+    CHECK(transformed == TJS_W("中文文本"));
+
+    tTJSVariant pageBreak;
+    REQUIRE(TJS_SUCCEEDED(parser->FuncCall(
+        0, TJS_W("getNextTag"), nullptr, &pageBreak, 0, nullptr, parser)));
+    CHECK(ttstr(getProp(pageBreak, TJS_W("tagname"))) == TJS_W("p"));
+
+    parser->Release();
+    parserClass.Clear();
+    REQUIRE(ncbAutoRegister::UnloadModule(TJS_W("ExtKAGParser.dll")));
     global->DeleteMember(0, TJS_W("KAGParser"), nullptr, global);
     global->Release();
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -52,6 +52,17 @@
     "libjpeg-turbo",
     "lua",
     {
+      "name": "llama-cpp",
+      "platform": "!emscripten"
+    },
+    {
+      "name": "ggml",
+      "features": [
+        "metal"
+      ],
+      "platform": "osx"
+    },
+    {
       "name": "libogg",
       "platform": "android"
     },

--- a/vcpkg/ports/ggml/portfile.cmake
+++ b/vcpkg/ports/ggml/portfile.cmake
@@ -1,0 +1,21 @@
+# ggml enables -march=native unless it detects a reproducible/cross build.
+# When producing x86_64 on an Apple Silicon host, clang expands that flag to
+# apple-m1 and rejects it for the x86 target. Scope the reproducible-build hint
+# to ggml so the rest of the dependency graph keeps its existing ABI.
+set(_aether_had_source_date_epoch FALSE)
+if(DEFINED ENV{SOURCE_DATE_EPOCH})
+    set(_aether_had_source_date_epoch TRUE)
+    set(_aether_source_date_epoch "$ENV{SOURCE_DATE_EPOCH}")
+endif()
+set(ENV{SOURCE_DATE_EPOCH} "1")
+
+set(_aether_overlay_port_dir "${CURRENT_PORT_DIR}")
+set(CURRENT_PORT_DIR "${VCPKG_ROOT_DIR}/ports/ggml")
+include("${VCPKG_ROOT_DIR}/ports/ggml/portfile.cmake")
+set(CURRENT_PORT_DIR "${_aether_overlay_port_dir}")
+
+if(_aether_had_source_date_epoch)
+    set(ENV{SOURCE_DATE_EPOCH} "${_aether_source_date_epoch}")
+else()
+    unset(ENV{SOURCE_DATE_EPOCH})
+endif()

--- a/vcpkg/ports/ggml/vcpkg.json
+++ b/vcpkg/ports/ggml/vcpkg.json
@@ -1,0 +1,68 @@
+{
+  "name": "ggml",
+  "version": "0.11.1",
+  "description": "Tensor library for machine learning",
+  "homepage": "https://github.com/ggml-org/ggml",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "blas": {
+      "description": "Enable BLAS support",
+      "dependencies": [
+        "blas",
+        "cblas"
+      ]
+    },
+    "cuda": {
+      "description": "Enable CUDA support",
+      "supports": "!(windows & staticcrt)",
+      "dependencies": [
+        "cuda"
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal support",
+      "supports": "osx"
+    },
+    "opencl": {
+      "description": "Enable OpenCL support",
+      "supports": "!arm32",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "openmp": {
+      "description": "Enable OpenMP support",
+      "supports": "!osx"
+    },
+    "vulkan": {
+      "description": "Enable Vulkan support",
+      "dependencies": [
+        {
+          "name": "ggml",
+          "host": true,
+          "default-features": false,
+          "features": [
+            "vulkan"
+          ]
+        },
+        {
+          "name": "shaderc",
+          "host": true
+        },
+        "spirv-headers",
+        "vulkan"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add configurable local GGUF translation for KiriKiri, Artemis, and ONScripter runtimes, with language detection and fail-open behavior
- defer model loading until game startup, prefetch upcoming text asynchronously, bypass/cancel translation while skipping, and expose model memory/performance statistics in the overlay
- use platform-native model selection on Apple platforms and native Godot system dialogs on desktop/Android, including persistent iOS document access
- show a loading notice while the model initializes
- clamp the virtual cursor using the arrow hotspot so reaching the bottom edge no longer recenters it
- refresh startup compatibility hooks used by valid save-thumbnail generation

## Validation

- `./build.sh ios debug`
- signed iOS Debug build installed and launched on a physical iPad
- iOS and macOS Swift type-checks
- Godot script parse validation
- public CI Web, iOS, and Android jobs passed with the Web portability fix
- `git diff --check` in both repositories

## Private dependencies

- merged feature PR: AetherKiri/AetherInternal#28
- merged Web portability fix: AetherKiri/AetherInternal#29
- pinned private main commit: `b523bda3b6f8838de36842455c0f2fc501c44e00`

The public gitlink now points to the private `main` merge commit.