### PR TITLE
fix(ons): stop Ctrl fast-forward after release

### DIFF
--- a/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
+++ b/bridge/onscripter_runtime/cmake/PrepareOnscripterYuriSources.cmake
@@ -274,6 +274,16 @@ void ONScripter::waitEventSub(int count)
     // ONS_BREAK_EVENT. Avoid the shared queue for that synchronous case and
     // reproduce the exact timeout state handled by runEventLoop.
     if (count == 0) {
+        // Ctrl makes ONS skip timed waits entirely. A Ctrl key-up queued by
+        // the host would otherwise never reach runEventLoop, leaving
+        // ctrl_pressed_status latched forever. Drain key releases without
+        // consuming unrelated pointer/input events before taking the fast
+        // zero-timeout path.
+        SDL_Event host_key_release;
+        while (aetherkiri_onscripter_poll_host_key_release(
+                   &host_key_release)) {
+            keyUpEvent(&host_key_release.key);
+        }
         if (automode_flag || autoclick_time > 0)
             current_button_state.button = 0;
         else if (usewheel_flag) {

--- a/bridge/onscripter_runtime/src/onscripter_host_shim.h
+++ b/bridge/onscripter_runtime/src/onscripter_host_shim.h
@@ -18,6 +18,7 @@ extern "C" int aetherkiri_onscripter_play_video(
 extern "C" void aetherkiri_onscripter_stop_video();
 extern "C" void aetherkiri_onscripter_shutdown_parallel();
 extern "C" int aetherkiri_onscripter_wait_event(SDL_Event *event);
+extern "C" int aetherkiri_onscripter_poll_host_key_release(SDL_Event *event);
 extern "C" void aetherkiri_onscripter_configure_video(
     int has_position, int x, int y, int width, int height,
     int asynchronous);

--- a/bridge/onscripter_runtime/src/onscripter_runtime.cpp
+++ b/bridge/onscripter_runtime/src/onscripter_runtime.cpp
@@ -128,6 +128,22 @@ bool PopHostEvent(SDL_Event *event) {
     return true;
 }
 
+bool PopHostKeyRelease(SDL_Event *event) {
+    if (event == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_host_event_mutex);
+    const auto release = std::find_if(
+        g_host_events.begin(), g_host_events.end(),
+        [](const SDL_Event &queued) { return queued.type == SDL_KEYUP; });
+    if (release == g_host_events.end()) {
+        return false;
+    }
+    *event = *release;
+    g_host_events.erase(release);
+    return true;
+}
+
 void ClearHostEvents() {
     std::lock_guard<std::mutex> lock(g_host_event_mutex);
     g_host_events.clear();
@@ -297,6 +313,11 @@ extern "C" int aetherkiri_onscripter_wait_event(SDL_Event *event) {
         }
     }
     return 0;
+}
+
+extern "C" int
+aetherkiri_onscripter_poll_host_key_release(SDL_Event *event) {
+    return PopHostKeyRelease(event) ? 1 : 0;
 }
 
 extern "C" void SDLCALL

--- a/doc/verified_games.md
+++ b/doc/verified_games.md
@@ -2,7 +2,7 @@
 
 [简体中文](verified_games.zh-CN.md)
 
-Last updated: 2026-09-01
+Last updated: 2026-09-02
 
 This document tracks games that have been manually smoke-tested with
 AetherKiri. It is a compatibility notebook, not a guarantee that every route,
@@ -73,6 +73,7 @@ movie, plugin path, or save state in a title has been exhaustively validated.
 | 死に逝く君、館に芽吹く憎悪 | Linux x64 release app; iOS/iPadOS release app build on iPad | Import, startup, title/menu rendering, new-game flow, scene/text rendering, audio playback, and basic input | Flow verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
 | 枯れない世界と終わる花 | Linux x64 release app; iOS/iPadOS release app build on iPad | Import, startup, title/menu rendering, new-game flow, scene/text rendering, audio playback, and basic input | Flow verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
 | エッチで一途なド田舎兄さまと、古式ゆかしい病弱妹 | Linux x64 release app; iOS/iPadOS release app build on iPad | Import, startup, title/menu rendering, new-game flow, scene/text rendering, audio playback, and basic input | Flow verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
+| 大図書館の羊飼い | iOS/iPadOS release app build on iPad | ONS game startup and virtual Ctrl press/release flow, including stopping fast-forward after release | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Uses the ONScripterYuri runtime. Local game files are not committed. |
 | 穢翼のユースティア | macOS debug app; iOS/iPadOS debug app build on iPad | ONS game import, startup, title/menu rendering, new-game and second-save load flows, opening subtitles and transitions, scene/text rendering, audio playback, skip mode, save-list scrolling, and mouse/touch input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Uses the ONScripterYuri runtime. Local game files are not committed. |
 | 美少女万華鏡 -呪われし伝説の少女- | macOS debug app; iOS/iPadOS debug app build on iPad | ONS game import, startup, initial title/menu rendering, scene/text rendering, audio playback, and basic input | Smoke verified | [@akitaSummer](https://github.com/akitaSummer) | Uses the ONScripterYuri runtime. Local game files are not committed. |
 

--- a/doc/verified_games.zh-CN.md
+++ b/doc/verified_games.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](verified_games.md)
 
-最后更新：2026-09-01
+最后更新：2026-09-02
 
 本文档记录已经用 AetherKiri 手动 smoke test 或 flow test 过的游戏。它是兼容性记录，
 不代表每条路线、每个视频、每个插件路径或每个存档状态都已经完整验证。
@@ -72,6 +72,7 @@
 | 死に逝く君、館に芽吹く憎悪 | Linux x64 release app；iOS/iPadOS iPad release app build | 导入、启动、标题/菜单渲染、开始游戏流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
 | 枯れない世界と終わる花 | Linux x64 release app；iOS/iPadOS iPad release app build | 导入、启动、标题/菜单渲染、开始游戏流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
 | エッチで一途なド田舎兄さまと、古式ゆかしい病弱妹 | Linux x64 release app；iOS/iPadOS iPad release app build | 导入、启动、标题/菜单渲染、开始游戏流程、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
+| 大図書館の羊飼い | iOS/iPadOS iPad release app build | ONS 游戏启动与虚拟 Ctrl 按下/松开流程，包括松开后停止快进 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 使用 ONScripterYuri Runtime；本地游戏文件不提交到仓库。 |
 | 穢翼のユースティア | macOS debug app；iOS/iPadOS iPad debug app build | ONS 游戏导入、启动、标题/菜单渲染、开始游戏与第二个存档读取流程、开场字幕和转场、场景/文字渲染、音频播放、快进、存档列表滚动，以及鼠标/触控输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 使用 ONScripterYuri Runtime；本地游戏文件不提交到仓库。 |
 | 美少女万華鏡 -呪われし伝説の少女- | macOS debug app；iOS/iPadOS iPad debug app build | ONS 游戏导入、启动、初始标题/菜单渲染、场景/文字渲染、音频播放和基础输入 | 冒烟验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 使用 ONScripterYuri Runtime；本地游戏文件不提交到仓库。 |
 

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -43,6 +43,11 @@ if(AETHERKIRI_INTERNAL_ENABLED)
         AETHERKIRI_EXPECT_INTERNAL_EMOTE=1)
 endif()
 
+if(AETHERKIRI_INTERNAL_ENABLED AND NOT BUILD_GPU_BRIDGE)
+    target_compile_definitions(motionplayer-dll PRIVATE
+        AETHERKIRI_EXPECT_INTERNAL_GRAPHICS=1)
+endif()
+
 if(AETHERKIRI_INTERNAL_ENABLED AND COMMAND aetherinternal_extend_krkr2plugin_tests)
     aetherinternal_extend_krkr2plugin_tests(motionplayer-dll)
 endif()

--- a/tests/unit-tests/plugins/registry.cpp
+++ b/tests/unit-tests/plugins/registry.cpp
@@ -267,6 +267,16 @@ TEST_CASE("GLAlphaMovie exposes texture-atlas frame upload") {
     CHECK(copyFrame.Type() == tvtObject);
 }
 
+TEST_CASE("krkrgles module loads in every build profile") {
+    ensurePluginRegistryRuntime();
+
+    REQUIRE(ncbAutoRegister::HasModule(TJS_W("krkrgles.dll")));
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("krkrgles.dll")));
+}
+
+// Matrix32 is supplied by the optional Internal graphics backend, not the
+// public fallback. Keep its regression coverage in builds that provide it.
+#if defined(AETHERKIRI_EXPECT_INTERNAL_GRAPHICS)
 TEST_CASE("krkrgles Matrix32 preserves pivot-scaled canvas placement") {
     ensurePluginRegistryRuntime();
 
@@ -285,6 +295,7 @@ TEST_CASE("krkrgles Matrix32 preserves pivot-scaled canvas placement") {
         &result));
     CHECK(result.AsInteger() == 1);
 }
+#endif
 
 TEST_CASE("extNagano transition providers survive a module reload") {
     ensurePluginRegistryRuntime();


### PR DESCRIPTION
## Summary

- drain queued ONS key-release events from the iOS zero-timeout fast-forward path
- preserve unrelated pointer and input events in the private host queue
- document the verified iPad flow for 大図書館の羊飼い

## Root cause

Holding Ctrl sets `ctrl_pressed_status`, which makes ONS use its zero-timeout path. On embedded iOS that path returned without entering `runEventLoop`, so the virtual Ctrl KeyUp remained in the private host queue and fast-forward stayed latched.

## Validation

- RED: generated iOS zero-wait path did not drain queued host key releases
- `game_virtual_controls_test.gd`: PASS
- `mobile_safe_area_test.gd`: `MOBILE_SAFE_AREA_OK`
- macOS `aether_onscripter_runtime` native target: built successfully
- iOS Release public-fallback app: built, signed, and installed successfully
- iPad manual verification with 大図書館の羊飼い: Ctrl release stops fast-forward
- `git diff --check`: PASS

The iOS test build used the established public fallback because the local proprietary E-mote archive is unavailable. No game files, saves, logs, or local paths are included.