### PR TITLE
fix: complete Artemis compatibility and improve virtual controls

### DIFF
--- a/apps/godot_app/scripts/game_virtual_controls.gd
+++ b/apps/godot_app/scripts/game_virtual_controls.gd
@@ -30,8 +30,11 @@ const POINTER_MOD_RIGHT := 0x10
 const OVERLAY_LAYER := 120
 const BUTTON_MIN_SIZE := 44.0
 const BUTTON_MAX_SIZE := 68.0
+const MENU_BUTTON_SIZE := Vector2(44.0, 40.0)
 const CURSOR_SIZE := 44.0
 const CURSOR_HOTSPOT := Vector2(15.0, 10.0)
+const CURSOR_TAP_DRAG_THRESHOLD := 10.0
+const CURSOR_TWO_FINGER_TAP_WINDOW_MSEC := 220
 const MENU_DRAG_THRESHOLD := 6.0
 const SCROLL_HOLD_DELAY_MSEC := 360
 const SCROLL_HOLD_REPEAT_MSEC := 90
@@ -42,6 +45,8 @@ const INPUT_DEVICE_ID_EMULATION := -1
 const INPUT_MODE_MOUSE := "mouse"
 const INPUT_MODE_TOUCH := "touch"
 const INPUT_MODES := [INPUT_MODE_MOUSE, INPUT_MODE_TOUCH]
+const KEYBOARD_CONTROLS_OPACITY_MIN := 0.2
+const KEYBOARD_CONTROLS_OPACITY_MAX := 1.0
 
 const REFERENCE_FILL := Color(0.30, 0.31, 0.33, 0.58)
 const REFERENCE_FILL_HOVER := Color(0.36, 0.37, 0.39, 0.72)
@@ -74,6 +79,8 @@ var dpad_center: Panel
 var _root: Control
 var _tokens
 var _enabled := false
+var _menu_button_enabled := true
+var _keyboard_controls_opacity := 1.0
 var _panel_open := false
 var _menu_open := false
 var _safe_rect := Rect2()
@@ -86,6 +93,14 @@ var _cursor_mouse_dragging := false
 var _cursor_initialized := false
 var _cursor_drag_has_position := false
 var _cursor_drag_last_screen_position := Vector2.ZERO
+var _cursor_touch_start_screen_position := Vector2.ZERO
+var _cursor_touch_down_msec := 0
+var _cursor_touch_tap_candidate := false
+var _cursor_touch_released := false
+var _cursor_secondary_touch_index := -1
+var _cursor_secondary_touch_start_screen_position := Vector2.ZERO
+var _cursor_secondary_touch_released := false
+var _cursor_two_finger_tap_candidate := false
 var _menu_touch_index := -1
 var _menu_mouse_dragging := false
 var _menu_drag_start_pointer_y := 0.0
@@ -204,11 +219,12 @@ func setup(tokens) -> void:
     _interactive_controls.append(menu_button)
     _interactive_controls.append(keyboard_button)
     _interactive_controls.append(virtual_controls_button)
+    _apply_keyboard_controls_opacity()
     set_enabled(false)
 
 func set_enabled(enabled: bool) -> void:
     if _enabled == enabled:
-        visible = enabled
+        visible = enabled and _menu_button_enabled
         _sync_visibility()
         return
     _enabled = enabled
@@ -216,7 +232,7 @@ func set_enabled(enabled: bool) -> void:
         release_all()
         _panel_open = false
         _menu_open = false
-        _cursor_touch_index = -1
+        _reset_cursor_touch_gesture()
         _cursor_mouse_dragging = false
         _reset_cursor_drag_position()
         _menu_touch_index = -1
@@ -225,8 +241,42 @@ func set_enabled(enabled: bool) -> void:
         _dpad_touch_index = -1
         _dpad_mouse_dragging = false
         _mouse_mode_blocked_touch_indices.clear()
-    visible = enabled
+    visible = enabled and _menu_button_enabled
     _sync_visibility()
+
+func set_menu_button_enabled(enabled: bool) -> void:
+    if _menu_button_enabled == enabled:
+        visible = _enabled and enabled
+        _sync_visibility()
+        return
+    _menu_button_enabled = enabled
+    if not enabled:
+        release_all()
+        _panel_open = false
+        _menu_open = false
+        _reset_cursor_touch_gesture()
+        _cursor_mouse_dragging = false
+        _reset_cursor_drag_position()
+        _mouse_mode_blocked_touch_indices.clear()
+        _menu_touch_index = -1
+        _menu_mouse_dragging = false
+        _menu_drag_moved = false
+    visible = _enabled and enabled
+    _sync_visibility()
+
+func is_menu_button_enabled() -> bool:
+    return _menu_button_enabled
+
+func set_keyboard_controls_opacity(opacity: float) -> void:
+    _keyboard_controls_opacity = clampf(
+        opacity,
+        KEYBOARD_CONTROLS_OPACITY_MIN,
+        KEYBOARD_CONTROLS_OPACITY_MAX
+    )
+    _apply_keyboard_controls_opacity()
+
+func keyboard_controls_opacity() -> float:
+    return _keyboard_controls_opacity
 
 func is_panel_open() -> bool:
     return _panel_open
@@ -247,7 +297,7 @@ func set_input_mode(mode: String, notify: bool = false) -> void:
         _sync_visibility()
         return
     release_all()
-    _cursor_touch_index = -1
+    _reset_cursor_touch_gesture()
     _cursor_mouse_dragging = false
     _reset_cursor_drag_position()
     _mouse_mode_blocked_touch_indices.clear()
@@ -258,7 +308,7 @@ func set_input_mode(mode: String, notify: bool = false) -> void:
         input_mode_changed.emit(_input_mode)
 
 func show_virtual_controls() -> void:
-    if not _enabled:
+    if not _enabled or not _menu_button_enabled:
         return
     _menu_open = false
     _panel_open = true
@@ -288,7 +338,9 @@ func layout(_window_size: Vector2, safe_rect: Rect2) -> void:
     var safe_end := safe_rect.end
     var key_size := Vector2(diameter, diameter)
 
-    var menu_size := Vector2(maxf(46.0, diameter), maxf(42.0, diameter * 0.92))
+    # Keep the edge affordance close to the 40 px standard-button token from
+    # DESIGN.md instead of scaling it up with the larger virtual key caps.
+    var menu_size := MENU_BUTTON_SIZE
     var menu_y_range := maxf(0.0, safe_rect.size.y - menu_size.y)
     menu_button.position = Vector2(
         safe_end.x - menu_size.x,
@@ -431,6 +483,7 @@ func routes_pointer(event: InputEvent) -> bool:
             and _panel_open
             and _dpad_contains_point(touch.position)
         ):
+            _cancel_cursor_tap_for_additional_touch(touch.index)
             if _dpad_touch_index == -1:
                 _dpad_touch_index = touch.index
                 # iOS may synthesize a mouse press before exposing the same
@@ -442,7 +495,17 @@ func routes_pointer(event: InputEvent) -> bool:
             if not touch.pressed:
                 _mouse_mode_blocked_touch_indices.erase(touch.index)
             return true
-        if touch.pressed and menu_button.get_global_rect().has_point(touch.position):
+        if touch.index == _cursor_secondary_touch_index:
+            if not touch.pressed:
+                _finish_cursor_secondary_touch()
+            return true
+        if touch.pressed and _visible_interactive_control_at(touch.position):
+            _cancel_cursor_tap_for_additional_touch(touch.index)
+        if (
+            touch.pressed
+            and menu_button.visible
+            and menu_button.get_global_rect().has_point(touch.position)
+        ):
             _begin_menu_drag(touch.position.y)
             _menu_touch_index = touch.index
             return true
@@ -458,21 +521,23 @@ func routes_pointer(event: InputEvent) -> bool:
             and not _visible_interactive_control_at(touch.position)
         ):
             if _cursor_touch_index == -1:
-                _cursor_touch_index = touch.index
+                if _cursor_two_finger_tap_candidate:
+                    _cancel_cursor_two_finger_tap()
+                    _mouse_mode_blocked_touch_indices[touch.index] = true
+                    return true
                 # iOS can deliver the same finger as both a mouse track and a
                 # ScreenTouch track. Their positions are not guaranteed to be
                 # in the same coordinate space, so the real touch must always
                 # take ownership before its first ScreenDrag.
                 if _cursor_mouse_dragging:
                     _cursor_mouse_dragging = false
-                _begin_cursor_drag(touch.position)
+                _begin_cursor_touch(touch.index, touch.position)
             elif _cursor_touch_index != touch.index:
-                _mouse_mode_blocked_touch_indices[touch.index] = true
+                _begin_cursor_secondary_touch(touch.index, touch.position)
             return true
         if touch.index == _cursor_touch_index:
             if not touch.pressed:
-                _cursor_touch_index = -1
-                _finish_cursor_drag_if_inactive()
+                _finish_cursor_primary_touch()
             return true
     elif event is InputEventScreenDrag:
         var drag := event as InputEventScreenDrag
@@ -481,11 +546,14 @@ func routes_pointer(event: InputEvent) -> bool:
             return true
         if _mouse_mode_blocked_touch_indices.has(drag.index):
             return true
+        if drag.index == _cursor_secondary_touch_index:
+            _update_cursor_secondary_touch(drag.position)
+            return true
         if drag.index == _menu_touch_index:
             _drag_menu_to(drag.position.y)
             return true
         if drag.index == _cursor_touch_index:
-            _drag_cursor_to(drag.position)
+            _update_cursor_primary_touch(drag.position)
             return true
     elif event is InputEventMouseButton:
         var mouse_button := event as InputEventMouseButton
@@ -508,6 +576,7 @@ func routes_pointer(event: InputEvent) -> bool:
                 mouse_button.device != INPUT_DEVICE_ID_EMULATION
                 and
                 mouse_button.pressed
+                and menu_button.visible
                 and menu_button.get_global_rect().has_point(mouse_button.position)
             ):
                 _begin_menu_drag(mouse_button.position.y)
@@ -1066,13 +1135,15 @@ func _clear_menu_drag_flag() -> void:
         _menu_drag_moved = false
 
 func _toggle_menu() -> void:
-    if not _enabled:
+    if not _enabled or not _menu_button_enabled:
         return
     if _menu_drag_moved:
         _menu_drag_moved = false
         return
     if _panel_open:
         release_all()
+        _reset_cursor_touch_gesture()
+        _mouse_mode_blocked_touch_indices.clear()
         _panel_open = false
         _menu_open = true
     else:
@@ -1080,9 +1151,11 @@ func _toggle_menu() -> void:
     _sync_visibility()
 
 func _request_keyboard() -> void:
-    if not _enabled:
+    if not _enabled or not _menu_button_enabled:
         return
     release_all()
+    _reset_cursor_touch_gesture()
+    _mouse_mode_blocked_touch_indices.clear()
     _menu_open = false
     _panel_open = false
     _sync_visibility()
@@ -1109,15 +1182,23 @@ func _sync_input_mode_presentation() -> void:
 func _sync_visibility() -> void:
     if menu_button == null:
         return
-    menu_button.visible = _enabled
-    keyboard_button.visible = _enabled and _menu_open
-    virtual_controls_button.visible = _enabled and _menu_open
+    var controls_visible := _enabled and _menu_button_enabled
+    menu_button.visible = controls_visible
+    keyboard_button.visible = controls_visible and _menu_open
+    virtual_controls_button.visible = controls_visible and _menu_open
     for control in _panel_controls:
-        control.visible = _enabled and _panel_open
-    var show_virtual_mouse := _enabled and _panel_open and not is_touch_mode()
+        control.visible = controls_visible and _panel_open
+    var show_virtual_mouse := controls_visible and _panel_open and not is_touch_mode()
     mouse_left_button.visible = show_virtual_mouse
     mouse_right_button.visible = show_virtual_mouse
     cursor_handle.visible = show_virtual_mouse
+
+func _apply_keyboard_controls_opacity() -> void:
+    for control in _panel_controls:
+        # The pointer must remain precise even when the surrounding virtual
+        # key caps are intentionally subdued.
+        var opacity := 1.0 if control == cursor_handle else _keyboard_controls_opacity
+        control.self_modulate = Color(1.0, 1.0, 1.0, opacity)
 
 func _press_key(key_code: int) -> void:
     if not _enabled or not _panel_open or _held_keys.has(key_code):
@@ -1204,6 +1285,129 @@ func _move_cursor_by(screen_delta: Vector2) -> void:
     var delta := current - previous
     if not delta.is_zero_approx():
         pointer_move_requested.emit(current, delta)
+
+func _begin_cursor_touch(index: int, screen_position: Vector2) -> void:
+    _cursor_touch_index = index
+    _cursor_touch_start_screen_position = screen_position
+    _cursor_touch_down_msec = Time.get_ticks_msec()
+    _cursor_touch_tap_candidate = true
+    _cursor_touch_released = false
+    _cursor_secondary_touch_index = -1
+    _cursor_secondary_touch_start_screen_position = Vector2.ZERO
+    _cursor_secondary_touch_released = false
+    _cursor_two_finger_tap_candidate = false
+    _begin_cursor_drag(screen_position)
+
+func _begin_cursor_secondary_touch(index: int, screen_position: Vector2) -> void:
+    if _cursor_secondary_touch_index != -1:
+        _cancel_cursor_two_finger_tap()
+        _mouse_mode_blocked_touch_indices[index] = true
+        return
+    var age_msec := Time.get_ticks_msec() - _cursor_touch_down_msec
+    if (
+        not _cursor_touch_tap_candidate
+        or age_msec > CURSOR_TWO_FINGER_TAP_WINDOW_MSEC
+    ):
+        _cursor_touch_tap_candidate = false
+        _mouse_mode_blocked_touch_indices[index] = true
+        return
+    _cursor_touch_tap_candidate = false
+    _cursor_secondary_touch_index = index
+    _cursor_secondary_touch_start_screen_position = screen_position
+    _cursor_secondary_touch_released = false
+    _cursor_two_finger_tap_candidate = true
+
+func _update_cursor_primary_touch(screen_position: Vector2) -> void:
+    var moved_distance := screen_position.distance_to(
+        _cursor_touch_start_screen_position
+    )
+    if _cursor_two_finger_tap_candidate:
+        if moved_distance >= CURSOR_TAP_DRAG_THRESHOLD:
+            _cancel_cursor_two_finger_tap()
+            _drag_cursor_to(screen_position)
+        return
+    if moved_distance >= CURSOR_TAP_DRAG_THRESHOLD:
+        _cursor_touch_tap_candidate = false
+    _drag_cursor_to(screen_position)
+
+func _update_cursor_secondary_touch(screen_position: Vector2) -> void:
+    if (
+        _cursor_two_finger_tap_candidate
+        and screen_position.distance_to(
+            _cursor_secondary_touch_start_screen_position
+        ) >= CURSOR_TAP_DRAG_THRESHOLD
+    ):
+        _cancel_cursor_two_finger_tap()
+
+func _finish_cursor_primary_touch() -> void:
+    _cursor_touch_index = -1
+    _cursor_touch_released = true
+    _finish_cursor_drag_if_inactive()
+    if _cursor_two_finger_tap_candidate:
+        _finish_cursor_two_finger_tap_if_ready()
+        return
+    var should_click := _cursor_touch_tap_candidate
+    _reset_cursor_touch_gesture()
+    if should_click:
+        _click_cursor_button(0, 0)
+
+func _finish_cursor_secondary_touch() -> void:
+    _cursor_secondary_touch_index = -1
+    _cursor_secondary_touch_released = true
+    _finish_cursor_two_finger_tap_if_ready()
+
+func _finish_cursor_two_finger_tap_if_ready() -> void:
+    if (
+        not _cursor_two_finger_tap_candidate
+        or not _cursor_touch_released
+        or not _cursor_secondary_touch_released
+    ):
+        return
+    _reset_cursor_touch_gesture()
+    _click_cursor_button(1, POINTER_MOD_RIGHT)
+
+func _cancel_cursor_two_finger_tap() -> void:
+    _cursor_two_finger_tap_candidate = false
+    _cursor_touch_tap_candidate = false
+    if _cursor_secondary_touch_index != -1:
+        _mouse_mode_blocked_touch_indices[_cursor_secondary_touch_index] = true
+    _cursor_secondary_touch_index = -1
+    _cursor_secondary_touch_released = false
+    _cursor_secondary_touch_start_screen_position = Vector2.ZERO
+    if _cursor_touch_released:
+        _reset_cursor_touch_gesture()
+
+func _cancel_cursor_tap_for_additional_touch(index: int) -> void:
+    if index == _cursor_touch_index or index == _cursor_secondary_touch_index:
+        return
+    if _cursor_two_finger_tap_candidate:
+        _cancel_cursor_two_finger_tap()
+    elif _cursor_touch_index != -1:
+        _cursor_touch_tap_candidate = false
+
+func _reset_cursor_touch_gesture() -> void:
+    _cursor_touch_index = -1
+    _cursor_touch_start_screen_position = Vector2.ZERO
+    _cursor_touch_down_msec = 0
+    _cursor_touch_tap_candidate = false
+    _cursor_touch_released = false
+    _cursor_secondary_touch_index = -1
+    _cursor_secondary_touch_start_screen_position = Vector2.ZERO
+    _cursor_secondary_touch_released = false
+    _cursor_two_finger_tap_candidate = false
+    if not _cursor_mouse_dragging:
+        _reset_cursor_drag_position()
+
+func _click_cursor_button(button: int, modifiers: int) -> void:
+    if (
+        not _enabled
+        or not _panel_open
+        or is_touch_mode()
+        or _held_mouse_buttons.has(modifiers)
+    ):
+        return
+    _press_mouse_button(button, modifiers)
+    _release_mouse_button(button, modifiers)
 
 func _begin_cursor_drag(screen_position: Vector2) -> void:
     _cursor_drag_last_screen_position = screen_position

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -69,6 +69,7 @@ const AetherMotion = preload("res://scripts/ui/aether_motion.gd")
 const AetherWidgets = preload("res://scripts/ui/aether_widgets.gd")
 const AetherSegmentedControl = preload("res://scripts/ui/aether_segmented_control.gd")
 const AetherSwitch = preload("res://scripts/ui/aether_switch.gd")
+const AetherSlider = preload("res://scripts/ui/aether_slider.gd")
 const AetherDisclosure = preload("res://scripts/ui/aether_disclosure.gd")
 const AetherSelect = preload("res://scripts/ui/aether_select.gd")
 const AetherDisplayScale = preload("res://scripts/ui/aether_display_scale.gd")
@@ -172,6 +173,10 @@ const UI_TEXT := {
         "settings.style_desc": "可在当前深色风格和旧版原始浅色风格之间切换",
         "settings.ui_scale": "界面比例",
         "settings.ui_scale_desc": "调整 iPhone 和 iPad 上的界面大小，保存后立即生效",
+        "settings.virtual_control_menu": "游戏内控制菜单",
+        "settings.virtual_control_menu_desc": "在游戏画面右上角显示虚拟控制菜单按钮",
+        "settings.keyboard_control_opacity": "Keyboard 模式按键透明度",
+        "settings.keyboard_control_opacity_desc": "调整屏幕虚拟按键的透明度；鼠标指针保持清晰",
         "ui_scale.compact": "较小",
         "ui_scale.comfortable": "合适",
         "ui_scale.standard": "标准",
@@ -449,6 +454,10 @@ const UI_TEXT := {
         "settings.style_desc": "可在目前深色風格和舊版原始淺色風格之間切換",
         "settings.ui_scale": "介面比例",
         "settings.ui_scale_desc": "調整 iPhone 和 iPad 上的介面大小，儲存後立即生效",
+        "settings.virtual_control_menu": "遊戲內控制選單",
+        "settings.virtual_control_menu_desc": "在遊戲畫面右上角顯示虛擬控制選單按鈕",
+        "settings.keyboard_control_opacity": "Keyboard 模式按鍵透明度",
+        "settings.keyboard_control_opacity_desc": "調整螢幕虛擬按鍵的透明度；滑鼠指標保持清晰",
         "ui_scale.compact": "較小",
         "ui_scale.comfortable": "合適",
         "ui_scale.standard": "標準",
@@ -724,6 +733,10 @@ const UI_TEXT := {
         "settings.style_desc": "Switch between the current dark style and the original classic light style",
         "settings.ui_scale": "Interface Scale",
         "settings.ui_scale_desc": "Adjust the interface size on iPhone and iPad; applies immediately after saving",
+        "settings.virtual_control_menu": "In-Game Controls Menu",
+        "settings.virtual_control_menu_desc": "Show the virtual-controls menu button at the top-right of the game view",
+        "settings.keyboard_control_opacity": "Keyboard Button Opacity",
+        "settings.keyboard_control_opacity_desc": "Adjust on-screen virtual-key opacity while keeping the mouse pointer clear",
         "ui_scale.compact": "Smaller",
         "ui_scale.comfortable": "Comfortable",
         "ui_scale.standard": "Standard",
@@ -1001,6 +1014,10 @@ const UI_TEXT := {
         "settings.style_desc": "現在のダークスタイルと旧来のクラシックライトスタイルを切り替えます",
         "settings.ui_scale": "UI スケール",
         "settings.ui_scale_desc": "iPhone と iPad の UI サイズを調整します。保存後すぐに反映されます",
+        "settings.virtual_control_menu": "ゲーム内コントロールメニュー",
+        "settings.virtual_control_menu_desc": "ゲーム画面の右上に仮想コントロールメニューボタンを表示します",
+        "settings.keyboard_control_opacity": "Keyboard モードのキー透明度",
+        "settings.keyboard_control_opacity_desc": "画面上の仮想キーの透明度を調整します。マウスポインターは鮮明なままです",
         "ui_scale.compact": "小さめ",
         "ui_scale.comfortable": "快適",
         "ui_scale.standard": "標準",
@@ -1276,6 +1293,10 @@ const UI_TEXT := {
         "settings.style_desc": "현재 다크 스타일과 기존 클래식 라이트 스타일을 전환합니다",
         "settings.ui_scale": "인터페이스 크기",
         "settings.ui_scale_desc": "iPhone 및 iPad의 인터페이스 크기를 조절하며 저장 후 즉시 적용됩니다",
+        "settings.virtual_control_menu": "게임 내 컨트롤 메뉴",
+        "settings.virtual_control_menu_desc": "게임 화면 오른쪽 위에 가상 컨트롤 메뉴 버튼을 표시합니다",
+        "settings.keyboard_control_opacity": "Keyboard 모드 버튼 투명도",
+        "settings.keyboard_control_opacity_desc": "화면 가상 키의 투명도를 조절하며 마우스 포인터는 선명하게 유지합니다",
         "ui_scale.compact": "작게",
         "ui_scale.comfortable": "적당히",
         "ui_scale.standard": "표준",
@@ -1531,6 +1552,12 @@ const ONSCRIPTER_SCRIPT_MARKERS := [
 ]
 const SHELL_SCROLL_DRAG_THRESHOLD := 4.0
 const SHELL_SCROLL_BUTTON_DRAG_THRESHOLD := 28.0
+const SHELL_SCROLL_SLIDER_AXIS_THRESHOLD := 10.0
+const SHELL_SCROLL_SLIDER_VERTICAL_DOMINANCE := 1.25
+const SHELL_SCROLL_AXIS_NONE := ""
+const SHELL_SCROLL_AXIS_PENDING := "pending"
+const SHELL_SCROLL_AXIS_HORIZONTAL := "horizontal"
+const SHELL_SCROLL_AXIS_VERTICAL := "vertical"
 const SHELL_SCROLL_DRAG_SPEED := 1.0
 const SHELL_SCROLL_TOUCHPAD_SPEED := 12.0
 const SHELL_SCROLL_WHEEL_SPEED := 4.0
@@ -1546,6 +1573,8 @@ const SETTINGS_DRAFT_KEYS := [
     "language",
     "style",
     "ios_ui_scale_mode",
+    "game_virtual_menu_enabled",
+    "game_virtual_keyboard_opacity",
     "backend",
     "upscale_algorithm",
     "output_resolution",
@@ -1608,6 +1637,8 @@ var detail_scroll: ScrollContainer
 var game_view: Control
 var game_virtual_controls
 var game_virtual_input_mode := GameVirtualControls.INPUT_MODE_MOUSE
+var game_virtual_menu_enabled := true
+var game_virtual_keyboard_opacity := 1.0
 var modal_layer: Control
 var active_modal_scrim: ColorRect
 var active_modal_dialog: Control
@@ -1989,6 +2020,9 @@ const VIRTUAL_KEYBOARD_REOPEN_DELAY_MS := 750
 const TOUCH_POINTER_ID_OFFSET := 100000
 const TOUCH_SECONDARY_POINTER_ID := 0
 const VIRTUAL_CONTROLS_POINTER_ID := TOUCH_POINTER_ID_OFFSET + 65535
+const GAME_VIRTUAL_KEYBOARD_OPACITY_MIN := 0.2
+const GAME_VIRTUAL_KEYBOARD_OPACITY_MAX := 1.0
+const GAME_VIRTUAL_KEYBOARD_OPACITY_STEP := 0.05
 const TOUCH_SECONDARY_TAP_WINDOW_MS := 180
 const TOUCH_SECONDARY_QUARANTINE_MS := 320
 const TOUCH_SINGLE_TAP_DELAY_MS := 90
@@ -2309,6 +2343,7 @@ func _build_ui() -> void:
     add_child(game_virtual_controls)
     game_virtual_controls.setup(ui_tokens)
     game_virtual_controls.set_input_mode(game_virtual_input_mode)
+    _apply_game_virtual_control_preferences()
     game_virtual_controls.key_event_requested.connect(
         _on_game_virtual_key_event
     )
@@ -3221,6 +3256,16 @@ func _load_shell_settings() -> void:
     game_virtual_input_mode = _normalize_game_virtual_input_mode(String(
         cfg.get_value("input", "virtual_control_mode", game_virtual_input_mode)
     ))
+    game_virtual_menu_enabled = bool(cfg.get_value(
+        "input", "virtual_control_menu_enabled", game_virtual_menu_enabled
+    ))
+    game_virtual_keyboard_opacity = _normalize_game_virtual_keyboard_opacity(
+        float(cfg.get_value(
+            "input",
+            "virtual_control_keyboard_opacity",
+            game_virtual_keyboard_opacity
+        ))
+    )
     plugin_load_mode = String(cfg.get_value("developer", "plugin_load_mode", plugin_load_mode))
     if not plugin_load_mode in ["krkrsdl3", "aether_all"]:
         plugin_load_mode = "krkrsdl3"
@@ -3264,6 +3309,16 @@ func _normalize_game_virtual_input_mode(value: String) -> String:
         else GameVirtualControls.INPUT_MODE_MOUSE
     )
 
+func _normalize_game_virtual_keyboard_opacity(value: float) -> float:
+    return snappedf(
+        clampf(
+            value,
+            GAME_VIRTUAL_KEYBOARD_OPACITY_MIN,
+            GAME_VIRTUAL_KEYBOARD_OPACITY_MAX
+        ),
+        GAME_VIRTUAL_KEYBOARD_OPACITY_STEP
+    )
+
 func _save_shell_settings() -> void:
     var cfg := ConfigFile.new()
     cfg.set_value("interface", "language", language_mode)
@@ -3288,6 +3343,14 @@ func _save_shell_settings() -> void:
     cfg.set_value("rendering", "force_landscape", lock_landscape)
     cfg.set_value("rendering", "orientation_schema", MOBILE_ORIENTATION_SCHEMA_VERSION)
     cfg.set_value("input", "virtual_control_mode", game_virtual_input_mode)
+    cfg.set_value(
+        "input", "virtual_control_menu_enabled", game_virtual_menu_enabled
+    )
+    cfg.set_value(
+        "input",
+        "virtual_control_keyboard_opacity",
+        game_virtual_keyboard_opacity
+    )
     cfg.set_value("developer", "plugin_load_mode", plugin_load_mode)
     cfg.set_value("developer", "mock_enabled", mock_enabled)
     cfg.set_value("developer", "error_dialog_logs", error_dialog_logs)
@@ -3322,6 +3385,8 @@ func _current_settings_snapshot() -> Dictionary:
         "language": language_mode,
         "style": style_mode,
         "ios_ui_scale_mode": ios_ui_scale_mode,
+        "game_virtual_menu_enabled": game_virtual_menu_enabled,
+        "game_virtual_keyboard_opacity": game_virtual_keyboard_opacity,
         "backend": selected_backend,
         "upscale_algorithm": upscale_algorithm,
         "output_resolution": output_resolution,
@@ -3451,6 +3516,9 @@ func _settings_draft_bool(key: String, fallback: bool) -> bool:
 func _settings_draft_int(key: String, fallback: int) -> int:
     return int(settings_draft.get(key, fallback))
 
+func _settings_draft_float(key: String, fallback: float) -> float:
+    return float(settings_draft.get(key, fallback))
+
 func _settings_draft_custom_chain() -> PackedStringArray:
     return _normalize_frame_enhancement_custom_chain(settings_draft.get(
         "frame_enhancement_custom_chain",
@@ -3465,6 +3533,16 @@ func _apply_settings_snapshot(snapshot: Dictionary) -> void:
     ios_ui_scale_mode = String(snapshot.get("ios_ui_scale_mode", ios_ui_scale_mode))
     if not ios_ui_scale_mode in IOS_UI_SCALE_MODES:
         ios_ui_scale_mode = "comfortable"
+    game_virtual_menu_enabled = bool(snapshot.get(
+        "game_virtual_menu_enabled", game_virtual_menu_enabled
+    ))
+    game_virtual_keyboard_opacity = _normalize_game_virtual_keyboard_opacity(
+        float(snapshot.get(
+            "game_virtual_keyboard_opacity",
+            game_virtual_keyboard_opacity
+        ))
+    )
+    _apply_game_virtual_control_preferences()
 
     selected_backend = _normalize_backend_name(String(snapshot.get("backend", selected_backend)))
     if not selected_backend in BACKENDS:
@@ -4643,6 +4721,20 @@ func _rebuild_settings_view() -> void:
     _add_settings_row(interface_group, _settings_block(_t("settings.style"), _t("settings.style_desc"), _style_select(), stack_settings_controls))
     if OS.get_name() == "iOS":
         _add_settings_row(interface_group, _settings_block(_t("settings.ui_scale"), _t("settings.ui_scale_desc"), _ios_ui_scale_segment(), stack_settings_controls))
+    _add_settings_row(interface_group, _settings_toggle_row(
+        _t("settings.virtual_control_menu"),
+        _t("settings.virtual_control_menu_desc"),
+        _settings_draft_bool(
+            "game_virtual_menu_enabled", game_virtual_menu_enabled
+        ),
+        "game_virtual_menu"
+    ))
+    _add_settings_row(interface_group, _settings_block(
+        _t("settings.keyboard_control_opacity"),
+        _t("settings.keyboard_control_opacity_desc"),
+        _keyboard_controls_opacity_control(),
+        stack_settings_controls
+    ))
 
     var render_group := _settings_group(primary_column, _t("settings.section.render"), ICON_PERFORMANCE, animate_page, 0.055)
     _add_settings_row(render_group, _settings_block(_t("settings.render_backend"), _t("settings.render_backend_desc"), _backend_segment(), stack_settings_controls))
@@ -5446,6 +5538,9 @@ func _start_shell_scroll_drag(key: int, position: Vector2) -> void:
     _stop_shell_scroll_tween(scroll)
     var control := _control_at_pointer(position)
     var button := _nearest_base_button(control) if control != null else null
+    var horizontal_slider := (
+        _nearest_horizontal_slider(control) if control != null else null
+    )
     shell_scroll_drag_states[key] = {
         # Controls can be rebuilt between the touch press and the following
         # drag/release event (for example after changing a settings selector).
@@ -5460,6 +5555,8 @@ func _start_shell_scroll_drag(key: int, position: Vector2) -> void:
         "pending_y": 0.0,
         "dragging": false,
         "threshold": SHELL_SCROLL_BUTTON_DRAG_THRESHOLD if button != null else SHELL_SCROLL_DRAG_THRESHOLD,
+        "axis_lock": SHELL_SCROLL_AXIS_PENDING if horizontal_slider != null else SHELL_SCROLL_AXIS_NONE,
+        "gesture_delta": Vector2.ZERO,
     }
 
 func _update_shell_scroll_drag(
@@ -5493,6 +5590,12 @@ func _update_shell_scroll_drag(
     state["last"] = position
     var distance := float(state.get("distance", 0.0)) + absf(delta.y)
     var pending_y := float(state.get("pending_y", 0.0)) + delta.y
+    var axis_lock := _update_shell_scroll_axis_lock(state, delta)
+    if axis_lock == SHELL_SCROLL_AXIS_PENDING or axis_lock == SHELL_SCROLL_AXIS_HORIZONTAL:
+        state["distance"] = distance
+        state["pending_y"] = pending_y
+        shell_scroll_drag_states[key] = state
+        return false
     var was_dragging := bool(state.get("dragging", false))
     var threshold := float(state.get("threshold", SHELL_SCROLL_DRAG_THRESHOLD))
     var dragging := was_dragging or distance >= threshold
@@ -5567,6 +5670,35 @@ func _nearest_base_button(control: Control) -> BaseButton:
             return current as BaseButton
         current = current.get_parent()
     return null
+
+func _nearest_horizontal_slider(control: Control) -> HSlider:
+    var current: Node = control
+    while current != null:
+        if current is HSlider:
+            return current as HSlider
+        current = current.get_parent()
+    return null
+
+func _update_shell_scroll_axis_lock(state: Dictionary, delta: Vector2) -> String:
+    var axis_lock := String(state.get("axis_lock", SHELL_SCROLL_AXIS_NONE))
+    if axis_lock != SHELL_SCROLL_AXIS_PENDING:
+        return axis_lock
+    var gesture_delta: Vector2 = state.get("gesture_delta", Vector2.ZERO)
+    gesture_delta += delta
+    state["gesture_delta"] = gesture_delta
+    var horizontal_distance := absf(gesture_delta.x)
+    var vertical_distance := absf(gesture_delta.y)
+    if maxf(horizontal_distance, vertical_distance) < SHELL_SCROLL_SLIDER_AXIS_THRESHOLD:
+        return SHELL_SCROLL_AXIS_PENDING
+    # A gesture that begins on a horizontal slider is biased toward the
+    # slider. Only a clearly vertical initial motion may become page scrolling;
+    # once horizontal wins, later vertical wobble cannot change ownership.
+    if vertical_distance > horizontal_distance * SHELL_SCROLL_SLIDER_VERTICAL_DOMINANCE:
+        axis_lock = SHELL_SCROLL_AXIS_VERTICAL
+    else:
+        axis_lock = SHELL_SCROLL_AXIS_HORIZONTAL
+    state["axis_lock"] = axis_lock
+    return axis_lock
 
 func _is_scroll_bar_control(control: Control) -> bool:
     var current: Node = control
@@ -6340,6 +6472,46 @@ func _apple_select(width: float = 220.0):
     select.custom_minimum_size.x = width
     return select
 
+func _keyboard_controls_opacity_control() -> Control:
+    var row := HBoxContainer.new()
+    row.name = "KeyboardControlsOpacityControl"
+    row.custom_minimum_size = Vector2(272.0, 40.0)
+    row.add_theme_constant_override("separation", 8)
+
+    var slider = AetherSlider.new()
+    slider.name = "KeyboardControlsOpacitySlider"
+    slider.min_value = GAME_VIRTUAL_KEYBOARD_OPACITY_MIN
+    slider.max_value = GAME_VIRTUAL_KEYBOARD_OPACITY_MAX
+    slider.step = GAME_VIRTUAL_KEYBOARD_OPACITY_STEP
+    slider.setup(
+        ui_tokens,
+        _normalize_game_virtual_keyboard_opacity(_settings_draft_float(
+            "game_virtual_keyboard_opacity",
+            game_virtual_keyboard_opacity
+        ))
+    )
+    row.add_child(slider)
+
+    var value_label := Label.new()
+    value_label.name = "KeyboardControlsOpacityValue"
+    value_label.custom_minimum_size = Vector2(44.0, 40.0)
+    value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+    value_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    value_label.add_theme_font_size_override("font_size", 13)
+    value_label.add_theme_color_override("font_color", ui_tokens.text_secondary)
+    value_label.text = _opacity_percentage_text(slider.value)
+    row.add_child(value_label)
+
+    slider.value_changed.connect(func(value: float):
+        var normalized := _normalize_game_virtual_keyboard_opacity(value)
+        value_label.text = _opacity_percentage_text(normalized)
+        _set_settings_draft_value("game_virtual_keyboard_opacity", normalized)
+    )
+    return row
+
+func _opacity_percentage_text(value: float) -> String:
+    return "%d%%" % int(round(clampf(value, 0.0, 1.0) * 100.0))
+
 func _settings_fps_row() -> Control:
     var margin := MarginContainer.new()
     margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -6684,6 +6856,8 @@ func _backend_segment() -> Control:
 func _on_setting_toggle(key: String, value: bool) -> void:
     if key == "fps_limit":
         _set_settings_draft_value("fps_limit_enabled", value)
+    elif key == "game_virtual_menu":
+        _set_settings_draft_value("game_virtual_menu_enabled", value)
     elif key == "landscape":
         _set_settings_draft_value("force_landscape", value)
     elif key == "mock":
@@ -14667,12 +14841,21 @@ func _can_forward_game_input() -> bool:
 func _sync_game_virtual_controls() -> void:
     if game_virtual_controls == null:
         return
+    _apply_game_virtual_control_preferences()
     game_virtual_controls.set_enabled(
         _should_enable_game_virtual_controls(
             _is_touch_platform(),
             _can_forward_game_input(),
             app_lifecycle_paused
         )
+    )
+
+func _apply_game_virtual_control_preferences() -> void:
+    if game_virtual_controls == null:
+        return
+    game_virtual_controls.set_menu_button_enabled(game_virtual_menu_enabled)
+    game_virtual_controls.set_keyboard_controls_opacity(
+        game_virtual_keyboard_opacity
     )
 
 func _should_enable_game_virtual_controls(

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -10991,14 +10991,10 @@ func _show_runtime_dialog(values: Dictionary) -> void:
     modal_layer.add_child(dim)
 
     var dialog := PanelContainer.new()
-    dialog.anchor_left = 0.5
-    dialog.anchor_top = 0.5
-    dialog.anchor_right = 0.5
-    dialog.anchor_bottom = 0.5
-    dialog.offset_left = -390.0
-    dialog.offset_top = -220.0
-    dialog.offset_right = 390.0
-    dialog.offset_bottom = 220.0
+    dialog.name = "ArtemisRuntimeDialog"
+    dialog.clip_contents = true
+    _mark_centered_safe_dialog(dialog, Vector2(780, 520))
+    _layout_safe_dialog(dialog, _ui_safe_rect(get_viewport_rect().size))
     dialog.mouse_filter = Control.MOUSE_FILTER_STOP
     dialog.add_theme_stylebox_override(
         "panel",
@@ -11006,7 +11002,15 @@ func _show_runtime_dialog(values: Dictionary) -> void:
     )
     modal_layer.add_child(dialog)
 
+    _build_runtime_dialog_content(dialog, values)
+
+func _build_runtime_dialog_content(
+    dialog: PanelContainer,
+    values: Dictionary
+) -> void:
+
     var margin := MarginContainer.new()
+    margin.name = "ArtemisDialogMargin"
     margin.add_theme_constant_override("margin_left", 30)
     margin.add_theme_constant_override("margin_top", 26)
     margin.add_theme_constant_override("margin_right", 30)
@@ -11014,22 +11018,37 @@ func _show_runtime_dialog(values: Dictionary) -> void:
     dialog.add_child(margin)
 
     var box := VBoxContainer.new()
+    box.name = "ArtemisDialogContent"
     box.add_theme_constant_override("separation", 20)
     margin.add_child(box)
 
     var title := Label.new()
     title.text = String(values.get("title", ""))
+    title.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
     title.add_theme_font_size_override("font_size", 30)
     title.add_theme_color_override("font_color", color_text)
     box.add_child(title)
 
+    var message_scroll := ScrollContainer.new()
+    message_scroll.name = "ArtemisDialogMessageScroll"
+    message_scroll.custom_minimum_size = Vector2(0, 64)
+    message_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    message_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    message_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+    message_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+    message_scroll.scroll_deadzone = 0
+    message_scroll.mouse_force_pass_scroll_events = false
+    box.add_child(message_scroll)
+
     var message := Label.new()
+    message.name = "ArtemisDialogMessage"
     message.text = String(values.get("message", ""))
+    message.custom_minimum_size = Vector2.ZERO
+    message.size_flags_horizontal = Control.SIZE_EXPAND_FILL
     message.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-    message.size_flags_vertical = Control.SIZE_EXPAND_FILL
     message.add_theme_font_size_override("font_size", 23)
     message.add_theme_color_override("font_color", color_text)
-    box.add_child(message)
+    message_scroll.add_child(message)
 
     var text_field := String(values.get("text_field", "0")) == "1"
     var yes_no := String(values.get("yes_no", "0")) == "1"
@@ -11048,6 +11067,7 @@ func _show_runtime_dialog(values: Dictionary) -> void:
         box.add_child(runtime_dialog_input)
 
     var buttons := HBoxContainer.new()
+    buttons.name = "ArtemisDialogButtons"
     buttons.alignment = BoxContainer.ALIGNMENT_END
     buttons.add_theme_constant_override("separation", 14)
     box.add_child(buttons)

--- a/apps/godot_app/scripts/ui/aether_slider.gd
+++ b/apps/godot_app/scripts/ui/aether_slider.gd
@@ -1,0 +1,70 @@
+extends HSlider
+
+const CONTROL_SIZE := Vector2(220.0, 40.0)
+const KNOB_SIZE := 18
+
+var tokens
+
+func setup(design_tokens, initial_value: float) -> void:
+    tokens = design_tokens
+    custom_minimum_size = CONTROL_SIZE
+    size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    size_flags_vertical = Control.SIZE_SHRINK_CENTER
+    focus_mode = Control.FOCUS_ALL
+    mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+    mouse_force_pass_scroll_events = false
+    value = clampf(initial_value, min_value, max_value)
+
+    add_theme_stylebox_override(
+        "slider",
+        _track_style(tokens.background_raised)
+    )
+    add_theme_stylebox_override(
+        "grabber_area",
+        _track_style(tokens.accent)
+    )
+    add_theme_stylebox_override(
+        "grabber_area_highlight",
+        _track_style(tokens.accent.lightened(0.055))
+    )
+    add_theme_stylebox_override("focus", tokens.focus_style(8))
+    var knob_fill: Color = (
+        tokens.text_primary if tokens.mode == "dark" else tokens.background
+    )
+    add_theme_icon_override(
+        "grabber",
+        _knob_texture(knob_fill, tokens.accent)
+    )
+    add_theme_icon_override(
+        "grabber_highlight",
+        _knob_texture(Color.WHITE, tokens.accent.lightened(0.08))
+    )
+    add_theme_icon_override(
+        "grabber_disabled",
+        _knob_texture(tokens.text_tertiary, tokens.separator)
+    )
+
+func _track_style(fill: Color) -> StyleBoxFlat:
+    var style := StyleBoxFlat.new()
+    style.bg_color = fill
+    style.set_corner_radius_all(3)
+    style.content_margin_top = 3
+    style.content_margin_bottom = 3
+    return style
+
+func _knob_texture(fill: Color, outline: Color) -> Texture2D:
+    var image := Image.create(KNOB_SIZE, KNOB_SIZE, false, Image.FORMAT_RGBA8)
+    image.fill(Color.TRANSPARENT)
+    var center := Vector2.ONE * (float(KNOB_SIZE) - 1.0) * 0.5
+    var outer_radius := float(KNOB_SIZE) * 0.5 - 0.5
+    var inner_radius := outer_radius - 1.5
+    for y in range(KNOB_SIZE):
+        for x in range(KNOB_SIZE):
+            var distance := Vector2(float(x), float(y)).distance_to(center)
+            var edge_alpha := clampf(outer_radius + 0.5 - distance, 0.0, 1.0)
+            if edge_alpha <= 0.0:
+                continue
+            var color := fill if distance <= inner_radius else outline
+            color.a *= edge_alpha
+            image.set_pixel(x, y, color)
+    return ImageTexture.create_from_image(image)

--- a/apps/godot_app/scripts/ui/aether_slider.gd.uid
+++ b/apps/godot_app/scripts/ui/aether_slider.gd.uid
@@ -1,0 +1,1 @@
+uid://cahcouslyxet5

--- a/apps/godot_app/tests/game_virtual_controls_test.gd
+++ b/apps/godot_app/tests/game_virtual_controls_test.gd
@@ -82,6 +82,11 @@ func _run() -> void:
     ):
         _fail("Menu does not start at the top edge")
         return
+    if not controls.menu_button.size.is_equal_approx(
+        GameVirtualControls.MENU_BUTTON_SIZE
+    ):
+        _fail("edge Menu does not use the compact DESIGN.md button size")
+        return
     if (
         not controls.menu_button.text.is_empty()
         or controls.menu_button.get_node_or_null("MenuIcon") == null
@@ -100,6 +105,32 @@ func _run() -> void:
         or menu_style.corner_radius_bottom_right != 0
     ):
         _fail("edge Menu is missing its visible right-edge semicircle")
+        return
+
+    var hidden_menu_position: Vector2 = (
+        controls.menu_button.get_global_rect().get_center()
+    )
+    controls.set_menu_button_enabled(false)
+    await process_frame
+    if (
+        controls.visible
+        or controls.menu_button.visible
+        or controls.is_menu_open()
+        or controls.is_panel_open()
+    ):
+        _fail("disabled edge Menu still renders virtual controls")
+        return
+    var hidden_menu_touch := InputEventScreenTouch.new()
+    hidden_menu_touch.index = 30
+    hidden_menu_touch.pressed = true
+    hidden_menu_touch.position = hidden_menu_position
+    if controls.routes_pointer(hidden_menu_touch):
+        _fail("disabled edge Menu retained an invisible input target")
+        return
+    controls.set_menu_button_enabled(true)
+    await process_frame
+    if not controls.visible or not controls.menu_button.visible:
+        _fail("default-enabled edge Menu did not return after re-enabling")
         return
 
     var menu_x: float = controls.menu_button.position.x
@@ -162,6 +193,23 @@ func _run() -> void:
     if not controls.is_panel_open() or _virtual_requests != 1:
         _fail("virtual-control panel did not open")
         return
+    controls.set_keyboard_controls_opacity(0.55)
+    if (
+        not is_equal_approx(controls.keyboard_controls_opacity(), 0.55)
+        or not is_equal_approx(controls.escape_button.self_modulate.a, 0.55)
+        or not is_equal_approx(controls.dpad_backdrop.self_modulate.a, 0.55)
+        or not is_equal_approx(controls.cursor_handle.self_modulate.a, 1.0)
+    ):
+        _fail("keyboard-control opacity did not apply without dimming the cursor")
+        return
+    controls.set_keyboard_controls_opacity(0.0)
+    if not is_equal_approx(
+        controls.keyboard_controls_opacity(),
+        GameVirtualControls.KEYBOARD_CONTROLS_OPACITY_MIN
+    ):
+        _fail("keyboard-control opacity did not clamp to its safe minimum")
+        return
+    controls.set_keyboard_controls_opacity(1.0)
     var required_controls: Array[Control] = [
         controls.escape_button, controls.control_button,
         controls.w_button, controls.a_button, controls.s_button, controls.d_button,
@@ -564,6 +612,119 @@ func _run() -> void:
         _fail("switching back did not restore mouse-mode controls")
         return
 
+    _pointer_buttons.clear()
+    var button_area_down := InputEventScreenTouch.new()
+    button_area_down.index = 20
+    button_area_down.pressed = true
+    button_area_down.position = controls.escape_button.get_global_rect().get_center()
+    var button_area_up := InputEventScreenTouch.new()
+    button_area_up.index = button_area_down.index
+    button_area_up.pressed = false
+    button_area_up.position = button_area_down.position
+    controls.routes_pointer(button_area_down)
+    controls.routes_pointer(button_area_up)
+    if not _pointer_buttons.is_empty():
+        _fail("a virtual-key touch was misclassified as a trackpad click")
+        return
+
+    var tap_position := (
+        safe_rect.position + safe_rect.size * Vector2(0.55, 0.28)
+    )
+    var click_cursor_position := controls.cursor_screen_position()
+    var single_tap_down := InputEventScreenTouch.new()
+    single_tap_down.index = 21
+    single_tap_down.pressed = true
+    single_tap_down.position = tap_position
+    var single_tap_up := InputEventScreenTouch.new()
+    single_tap_up.index = single_tap_down.index
+    single_tap_up.pressed = false
+    single_tap_up.position = tap_position
+    if (
+        not controls.routes_pointer(single_tap_down)
+        or not controls.routes_pointer(single_tap_up)
+        or _pointer_buttons.size() != 2
+        or not _pointer_buttons[0].pressed
+        or _pointer_buttons[0].button != 0
+        or _pointer_buttons[0].modifiers != 0
+        or _pointer_buttons[1].pressed
+        or _pointer_buttons[1].button != 0
+        or not _pointer_buttons[0].position.is_equal_approx(
+            click_cursor_position
+        )
+        or not _pointer_buttons[1].position.is_equal_approx(
+            click_cursor_position
+        )
+    ):
+        _fail("single-finger trackpad tap did not emit a left click")
+        return
+
+    _pointer_buttons.clear()
+    var two_finger_first_down := InputEventScreenTouch.new()
+    two_finger_first_down.index = 22
+    two_finger_first_down.pressed = true
+    two_finger_first_down.position = tap_position
+    var two_finger_second_down := InputEventScreenTouch.new()
+    two_finger_second_down.index = 23
+    two_finger_second_down.pressed = true
+    two_finger_second_down.position = tap_position + Vector2(-32.0, 0.0)
+    controls.routes_pointer(two_finger_first_down)
+    controls.routes_pointer(two_finger_second_down)
+    var two_finger_first_up := InputEventScreenTouch.new()
+    two_finger_first_up.index = two_finger_first_down.index
+    two_finger_first_up.pressed = false
+    two_finger_first_up.position = two_finger_first_down.position
+    controls.routes_pointer(two_finger_first_up)
+    if not _pointer_buttons.is_empty():
+        _fail("two-finger tap clicked before both fingers were released")
+        return
+    var two_finger_second_up := InputEventScreenTouch.new()
+    two_finger_second_up.index = two_finger_second_down.index
+    two_finger_second_up.pressed = false
+    two_finger_second_up.position = two_finger_second_down.position
+    controls.routes_pointer(two_finger_second_up)
+    if (
+        _pointer_buttons.size() != 2
+        or not _pointer_buttons[0].pressed
+        or _pointer_buttons[0].button != 1
+        or _pointer_buttons[0].modifiers != 0x10
+        or _pointer_buttons[1].pressed
+        or _pointer_buttons[1].button != 1
+        or _pointer_buttons[1].modifiers != 0x10
+        or not _pointer_buttons[0].position.is_equal_approx(
+            click_cursor_position
+        )
+        or not _pointer_buttons[1].position.is_equal_approx(
+            click_cursor_position
+        )
+    ):
+        _fail("two-finger trackpad tap did not emit a right click")
+        return
+
+    _pointer_buttons.clear()
+    two_finger_first_down.index = 24
+    two_finger_second_down.index = 25
+    controls.routes_pointer(two_finger_first_down)
+    controls.routes_pointer(two_finger_second_down)
+    var two_finger_drag := InputEventScreenDrag.new()
+    two_finger_drag.index = two_finger_second_down.index
+    two_finger_drag.position = (
+        two_finger_second_down.position
+        + Vector2(GameVirtualControls.CURSOR_TAP_DRAG_THRESHOLD + 2.0, 0.0)
+    )
+    two_finger_drag.relative = Vector2(
+        GameVirtualControls.CURSOR_TAP_DRAG_THRESHOLD + 2.0,
+        0.0
+    )
+    controls.routes_pointer(two_finger_drag)
+    two_finger_second_up.index = two_finger_second_down.index
+    two_finger_second_up.position = two_finger_drag.position
+    two_finger_first_up.index = two_finger_first_down.index
+    controls.routes_pointer(two_finger_second_up)
+    controls.routes_pointer(two_finger_first_up)
+    if not _pointer_buttons.is_empty():
+        _fail("a two-finger drag was misclassified as a right click")
+        return
+
     controls.escape_button.emit_signal("button_down")
     controls.escape_button.emit_signal("button_down")
     controls.escape_button.emit_signal("button_up")
@@ -625,6 +786,9 @@ func _run() -> void:
     cursor_up.position = cursor_drag.position
     if not controls.routes_pointer(cursor_up):
         _fail("cursor release was not captured")
+        return
+    if not _pointer_buttons.is_empty():
+        _fail("cursor drag was misclassified as a left click")
         return
 
     controls.mouse_left_button.emit_signal("button_down")

--- a/apps/godot_app/tests/mobile_safe_area_test.gd
+++ b/apps/godot_app/tests/mobile_safe_area_test.gd
@@ -144,6 +144,45 @@ func _initialize() -> void:
     assert(dialog_rect.end.x <= portrait.end.x)
     assert(dialog_rect.end.y <= portrait.end.y)
 
+    var runtime_dialog := PanelContainer.new()
+    runtime_dialog.clip_contents = true
+    root.add_child(runtime_dialog)
+    var runtime_safe_rect := Rect2(40, 24, 852, 382)
+    app._mark_centered_safe_dialog(runtime_dialog, Vector2(780, 520))
+    app._layout_safe_dialog(runtime_dialog, runtime_safe_rect)
+    app._build_runtime_dialog_content(runtime_dialog, {
+        "title": "Help",
+        "message": "\n".join(PackedStringArray(Array(range(120)).map(
+            func(index: int): return "Long Artemis help line %d" % index
+        ))),
+        "yes_no": "0",
+        "text_field": "0",
+    })
+    await process_frame
+    await process_frame
+    var runtime_dialog_rect := runtime_dialog.get_rect()
+    assert(runtime_dialog_rect.position.x >= runtime_safe_rect.position.x)
+    assert(runtime_dialog_rect.position.y >= runtime_safe_rect.position.y)
+    assert(runtime_dialog_rect.end.x <= runtime_safe_rect.end.x)
+    assert(runtime_dialog_rect.end.y <= runtime_safe_rect.end.y)
+    var message_scroll := runtime_dialog.get_node(
+        "ArtemisDialogMargin/ArtemisDialogContent/ArtemisDialogMessageScroll"
+    ) as ScrollContainer
+    var runtime_buttons := runtime_dialog.get_node(
+        "ArtemisDialogMargin/ArtemisDialogContent/ArtemisDialogButtons"
+    ) as HBoxContainer
+    assert(message_scroll != null)
+    assert(runtime_buttons != null)
+    assert(message_scroll.vertical_scroll_mode == ScrollContainer.SCROLL_MODE_AUTO)
+    assert(message_scroll.horizontal_scroll_mode == ScrollContainer.SCROLL_MODE_DISABLED)
+    assert(not message_scroll.mouse_force_pass_scroll_events)
+    assert(message_scroll.get_rect().end.y <= runtime_buttons.get_rect().position.y)
+    var message_scroll_bar := message_scroll.get_v_scroll_bar()
+    assert(message_scroll_bar.max_value > message_scroll_bar.page)
+    message_scroll.scroll_vertical = 120
+    await process_frame
+    assert(message_scroll.scroll_vertical > 0)
+
     assert(app._edge_back_gesture_qualified(
         Vector2(8, 400),
         Vector2(120, 410),
@@ -240,6 +279,7 @@ func _initialize() -> void:
     launch_shell.free()
     native_scroll_bar.free()
     dialog.free()
+    runtime_dialog.free()
     app.free()
     print("MOBILE_SAFE_AREA_OK")
     quit(0)

--- a/apps/godot_app/tests/virtual_control_settings_test.gd
+++ b/apps/godot_app/tests/virtual_control_settings_test.gd
@@ -1,0 +1,158 @@
+extends SceneTree
+
+const MAIN_SCRIPT := preload("res://scripts/main.gd")
+
+func _initialize() -> void:
+    call_deferred("_run")
+
+func _run() -> void:
+    var app = MAIN_SCRIPT.new()
+    var snapshot: Dictionary = app._current_settings_snapshot()
+
+    assert(app.game_virtual_menu_enabled)
+    assert(is_equal_approx(app.game_virtual_keyboard_opacity, 1.0))
+    assert(bool(snapshot.get("game_virtual_menu_enabled", false)))
+    assert(is_equal_approx(
+        float(snapshot.get("game_virtual_keyboard_opacity", 0.0)),
+        1.0
+    ))
+    assert("game_virtual_menu_enabled" in app.SETTINGS_DRAFT_KEYS)
+    assert("game_virtual_keyboard_opacity" in app.SETTINGS_DRAFT_KEYS)
+
+    assert(is_equal_approx(
+        app._normalize_game_virtual_keyboard_opacity(-1.0),
+        app.GAME_VIRTUAL_KEYBOARD_OPACITY_MIN
+    ))
+    assert(is_equal_approx(
+        app._normalize_game_virtual_keyboard_opacity(2.0),
+        app.GAME_VIRTUAL_KEYBOARD_OPACITY_MAX
+    ))
+    assert(is_equal_approx(
+        app._normalize_game_virtual_keyboard_opacity(0.63),
+        0.65
+    ))
+
+    app._begin_settings_edit()
+    app._on_setting_toggle("game_virtual_menu", false)
+    assert(not bool(app.settings_draft.get("game_virtual_menu_enabled", true)))
+    assert(app.dirty_settings)
+
+    var opacity_control := app._keyboard_controls_opacity_control()
+    root.add_child(opacity_control)
+    await process_frame
+    var slider := opacity_control.get_node(
+        "KeyboardControlsOpacitySlider"
+    ) as HSlider
+    var value_label := opacity_control.get_node(
+        "KeyboardControlsOpacityValue"
+    ) as Label
+    assert(slider != null)
+    assert(value_label != null)
+    assert(slider.custom_minimum_size.x >= 220.0)
+    assert(is_equal_approx(slider.min_value, 0.2))
+    assert(is_equal_approx(slider.max_value, 1.0))
+    assert(slider.get_theme_stylebox("slider") is StyleBoxFlat)
+    assert(slider.get_theme_stylebox("grabber_area") is StyleBoxFlat)
+    assert(not slider.mouse_force_pass_scroll_events)
+    assert(app._nearest_horizontal_slider(slider) == slider)
+
+    var drag_state := {
+        "axis_lock": app.SHELL_SCROLL_AXIS_PENDING,
+        "gesture_delta": Vector2.ZERO,
+    }
+    assert(app._update_shell_scroll_axis_lock(
+        drag_state,
+        Vector2(2.0, 5.0)
+    ) == app.SHELL_SCROLL_AXIS_PENDING)
+    assert(app._update_shell_scroll_axis_lock(
+        drag_state,
+        Vector2(24.0, 1.0)
+    ) == app.SHELL_SCROLL_AXIS_HORIZONTAL)
+    assert(app._update_shell_scroll_axis_lock(
+        drag_state,
+        Vector2(0.0, 120.0)
+    ) == app.SHELL_SCROLL_AXIS_HORIZONTAL)
+
+    var vertical_drag_state := {
+        "axis_lock": app.SHELL_SCROLL_AXIS_PENDING,
+        "gesture_delta": Vector2.ZERO,
+    }
+    assert(app._update_shell_scroll_axis_lock(
+        vertical_drag_state,
+        Vector2(1.0, 20.0)
+    ) == app.SHELL_SCROLL_AXIS_VERTICAL)
+
+    var regression_scroll := ScrollContainer.new()
+    regression_scroll.size = Vector2(320.0, 120.0)
+    root.add_child(regression_scroll)
+    var scroll_content := Control.new()
+    scroll_content.custom_minimum_size = Vector2(320.0, 800.0)
+    regression_scroll.add_child(scroll_content)
+    opacity_control.reparent(scroll_content)
+    opacity_control.position = Vector2(20.0, 140.0)
+    app.shell_root = regression_scroll
+    app.settings_view = regression_scroll
+    await process_frame
+    regression_scroll.scroll_vertical = 100
+    await process_frame
+    var initial_scroll := regression_scroll.scroll_vertical
+    var pointer := slider.get_global_rect().get_center()
+    var pointer_key := 73
+    app.shell_scroll_drag_states[pointer_key] = {
+        "scroll_id": regression_scroll.get_instance_id(),
+        "control_id": slider.get_instance_id(),
+        "last": pointer,
+        "last_motion_msec": Time.get_ticks_msec(),
+        "velocity_y": 0.0,
+        "distance": 0.0,
+        "pending_y": 0.0,
+        "dragging": false,
+        "threshold": app.SHELL_SCROLL_DRAG_THRESHOLD,
+        "axis_lock": app.SHELL_SCROLL_AXIS_PENDING,
+        "gesture_delta": Vector2.ZERO,
+    }
+    assert(not app._update_shell_scroll_drag(
+        pointer_key,
+        pointer + Vector2(30.0, 2.0),
+        Vector2(30.0, 2.0)
+    ))
+    assert(not app._update_shell_scroll_drag(
+        pointer_key,
+        pointer + Vector2(30.0, 82.0),
+        Vector2(0.0, 80.0)
+    ))
+    assert(regression_scroll.scroll_vertical == initial_scroll)
+    app._finish_shell_scroll_drag(pointer_key)
+    app.shell_root = null
+    app.settings_view = null
+    opacity_control.reparent(root)
+    regression_scroll.free()
+
+    slider.value = 0.65
+    await process_frame
+    assert(is_equal_approx(
+        float(app.settings_draft.get("game_virtual_keyboard_opacity", 0.0)),
+        0.65
+    ))
+    assert(value_label.text == "65%")
+
+    snapshot = app._current_settings_snapshot()
+    snapshot["game_virtual_menu_enabled"] = false
+    snapshot["game_virtual_keyboard_opacity"] = 0.65
+    app._apply_settings_snapshot(snapshot)
+    assert(not app.game_virtual_menu_enabled)
+    assert(is_equal_approx(app.game_virtual_keyboard_opacity, 0.65))
+
+    for language in ["zh_hans", "zh_hant", "en", "ja", "ko"]:
+        app.active_language = language
+        assert(not String(app._t("settings.virtual_control_menu")).is_empty())
+        assert(not String(app._t("settings.virtual_control_menu_desc")).is_empty())
+        assert(not String(app._t("settings.keyboard_control_opacity")).is_empty())
+        assert(not String(app._t(
+            "settings.keyboard_control_opacity_desc"
+        )).is_empty())
+
+    opacity_control.free()
+    app.free()
+    print("virtual_control_settings_test: PASS")
+    quit(0)

--- a/apps/godot_app/tests/virtual_control_settings_test.gd.uid
+++ b/apps/godot_app/tests/virtual_control_settings_test.gd.uid
@@ -1,0 +1,1 @@
+uid://jmdhychh3pqt

--- a/bridge/engine_api/src/engine_input_queue_gate.h
+++ b/bridge/engine_api/src/engine_input_queue_gate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <unordered_set>
 
@@ -7,16 +8,18 @@
 
 namespace aetherkiri::engine_api {
 
-// A click can synchronously run an expensive KAG transition. Once a complete
-// primary click is queued for the next engine tick, coalesce further primary
-// gestures instead of replaying stale clicks after the transition finishes.
+// A click can synchronously run an expensive KAG transition. Keep a bounded
+// number of complete primary gestures so taps delivered while the engine is
+// busy are replayed in order, while still preventing an unbounded stale-click
+// backlog after a transition or modal closes.
 class PrimaryClickQueueGate {
  public:
   bool should_enqueue(const engine_input_event_t& event) {
     const bool primary_pointer = event.button == 0;
     if (primary_pointer &&
         event.type == ENGINE_INPUT_EVENT_POINTER_DOWN &&
-        primary_release_pending_) {
+        (primary_down_pending_ ||
+         queued_primary_gestures_ >= kMaxQueuedPrimaryGestures)) {
       suppressed_pointer_ids_.insert(event.pointer_id);
       return false;
     }
@@ -31,24 +34,36 @@ class PrimaryClickQueueGate {
       if (suppressed_pointer_ids_.erase(event.pointer_id) != 0) {
         return false;
       }
-      primary_release_pending_ = true;
+      if (!primary_down_pending_) return false;
+      primary_down_pending_ = false;
+      ++queued_primary_gestures_;
+    }
+    if (primary_pointer && event.type == ENGINE_INPUT_EVENT_POINTER_DOWN) {
+      primary_down_pending_ = true;
     }
     return true;
   }
 
   void on_dequeued(const engine_input_event_t& event) {
+    if (event.type == ENGINE_INPUT_EVENT_POINTER_DOWN &&
+        event.button == 0) {
+      primary_down_pending_ = false;
+    }
     if (event.type == ENGINE_INPUT_EVENT_POINTER_UP && event.button == 0) {
-      primary_release_pending_ = false;
+      if (queued_primary_gestures_ != 0) --queued_primary_gestures_;
     }
   }
 
   void reset() {
-    primary_release_pending_ = false;
+    primary_down_pending_ = false;
+    queued_primary_gestures_ = 0;
     suppressed_pointer_ids_.clear();
   }
 
  private:
-  bool primary_release_pending_ = false;
+  static constexpr size_t kMaxQueuedPrimaryGestures = 8;
+  bool primary_down_pending_ = false;
+  size_t queued_primary_gestures_ = 0;
   std::unordered_set<int32_t> suppressed_pointer_ids_;
 };
 

--- a/doc/verified_games.md
+++ b/doc/verified_games.md
@@ -2,7 +2,7 @@
 
 [简体中文](verified_games.zh-CN.md)
 
-Last updated: 2026-09-02
+Last updated: 2026-09-03
 
 This document tracks games that have been manually smoke-tested with
 AetherKiri. It is a compatibility notebook, not a guarantee that every route,
@@ -20,6 +20,7 @@ movie, plugin path, or save state in a title has been exhaustively validated.
 
 | Game | Verified platforms / builds | Verified scope | Result | Verifier | Notes |
 | --- | --- | --- | --- | --- | --- |
+| Magical Charming! | macOS x64 debug app | Startup through the package's absent optional opening cut-ins, title/menu rendering, new-game button dispatch, first scenario/background/text rendering, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | The iOS package omits the stock `ab_*` opening cut-ins; AetherKiri skips only those missing opening waits. Local game files are not committed. |
 | 恋がさくころ桜どき | Linux x64 release app; macOS app; iOS/iPadOS app build on iPad | Import, startup, initial title/UI and text rendering, and basic input | Smoke verified | [@KYoiRyi](https://github.com/KYoiRyi), [@MadCcc](https://github.com/MadCcc) | Local game files are not committed. |
 | ましろ色シンフォニー | Linux x64 release app | Import, startup, initial title/UI and text rendering, and basic input | Smoke verified | [@KYoiRyi](https://github.com/KYoiRyi) | Local game files are not committed. |
 | ましろ色シンフォニー -Love is pure white- Remake for FHD | macOS app; iOS/iPadOS app build on iPad | Import, startup, title/menu rendering, scene/text rendering, audio playback, and basic input | Flow verified | [@akitaSummer](https://github.com/akitaSummer) | Local game files are not committed. |

--- a/doc/verified_games.zh-CN.md
+++ b/doc/verified_games.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](verified_games.md)
 
-最后更新：2026-09-02
+最后更新：2026-09-03
 
 本文档记录已经用 AetherKiri 手动 smoke test 或 flow test 过的游戏。它是兼容性记录，
 不代表每条路线、每个视频、每个插件路径或每个存档状态都已经完整验证。
@@ -19,6 +19,7 @@
 
 | 游戏 | 已验证平台/构建 | 验证范围 | 结果 | 验证人 | 备注 |
 | --- | --- | --- | --- | --- | --- |
+| Magical Charming! | macOS x64 debug app | 启动时跳过包内缺失的可选开场切入图、标题/菜单渲染、开始游戏按钮分发、首个场景/背景/文字渲染，以及基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 该 iOS 资源包未包含标准 `ab_*` 开场切入图；AetherKiri 只跳过这些缺失开场图对应的等待。本地游戏文件不提交到仓库。 |
 | 恋がさくころ桜どき | Linux x64 release app；macOS app；iOS/iPadOS iPad app build | 导入、启动、初始标题/UI 与文本渲染，以及基础输入 | 冒烟验证通过 | [@KYoiRyi](https://github.com/KYoiRyi)、[@MadCcc](https://github.com/MadCcc) | 本地游戏文件不提交到仓库。 |
 | ましろ色シンフォニー | Linux x64 release app | 导入、启动、初始标题/UI 与文本渲染，以及基础输入 | 冒烟验证通过 | [@KYoiRyi](https://github.com/KYoiRyi) | 本地游戏文件不提交到仓库。 |
 | ましろ色シンフォニー -Love is pure white- Remake for FHD | macOS app；iOS/iPadOS iPad app build | 导入、启动、标题/菜单渲染、场景/文字渲染、音频播放和基础输入 | 流程验证通过 | [@akitaSummer](https://github.com/akitaSummer) | 本地游戏文件不提交到仓库。 |

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -198,7 +198,7 @@ const engine_runtime_provider_v1_t kArtemisGateProvider = [] {
 
 }  // namespace
 
-TEST_CASE("primary click queue gate coalesces clicks before the next tick") {
+TEST_CASE("primary click queue gate bounds rapid primary gestures") {
   aetherkiri::engine_api::PrimaryClickQueueGate gate;
   engine_input_event_t event{};
   event.struct_size = sizeof(event);
@@ -212,6 +212,12 @@ TEST_CASE("primary click queue gate coalesces clicks before the next tick") {
   REQUIRE(gate.should_enqueue(event));
   const engine_input_event_t queued_release = event;
 
+  for (size_t click = 0; click < 7; ++click) {
+    event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+    REQUIRE(gate.should_enqueue(event));
+    event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+    REQUIRE(gate.should_enqueue(event));
+  }
   event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
   REQUIRE_FALSE(gate.should_enqueue(event));
   event.type = ENGINE_INPUT_EVENT_POINTER_MOVE;

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -237,8 +237,10 @@ TEST_CASE("primary click queue gate preserves every secondary pointer edge") {
 
   // Leave a primary release waiting so a wrongly encoded virtual right click
   // would be coalesced as stale primary input.
-  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
   event.button = 0;
+  REQUIRE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
   REQUIRE(gate.should_enqueue(event));
   const engine_input_event_t queued_primary_release = event;
 

--- a/vcpkg/ports/libarchive/vcpkg.json
+++ b/vcpkg/ports/libarchive/vcpkg.json
@@ -8,6 +8,10 @@
   "supports": "!uwp",
   "dependencies": [
     {
+      "name": "libb2",
+      "platform": "osx"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     }


### PR DESCRIPTION
## Summary

- finish the public Artemis input/runtime integration and pin the merged private implementation
- add verified compatibility coverage and the libarchive dependency correction
- make the virtual-control menu smaller and configurable, with a default-on visibility switch
- add adjustable Keyboard-mode control opacity using the shared slider design
- lock slider gestures to the horizontal axis and add trackpad semantics: one-finger tap for left click and two-finger tap for right click

## Validation

- macOS x86_64 Debug application built successfully with AetherInternal and the official E-mote SDK enabled
- application executable and both bundled dylibs verified as x86_64
- deep code-signature verification passed
- virtual-control behavior, settings, slider, mobile safe-area, and primary/secondary input-queue tests passed
- 210 private Artemis, IET, PF archive, save/load, input, and E-mote tests passed

## Paired private change

- merged AetherInternal PR: https://github.com/AetherKiri/AetherInternal/pull/32
- pinned private main commit: 1ba48083018d2c3499177a71b353617061efbd5c

## Known upstream issue

- the private repository full suite contains one unrelated SHA-256 streaming-vector fixture failure; this public branch does not modify that code