### PR TITLE
fix: restore runtime and input compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,7 @@ endif ()
 add_compile_definitions(
         $<$<CONFIG:Debug>:DEBUG>
         $<$<CONFIG:Debug>:_DEBUG>   # 对于 MSVC 兼容性
-        # Artemis is compiled into Apple Store products as a gated preview.
-        # Debug builds bypass the product gate; Release requires a verified
-        # beta-access grant before the runtime can open a game.
+        # Artemis is a supported runtime in every product configuration.
         AETHERKIRI_ENABLE_ARTEMIS_RUNTIME
         $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
 )

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -286,7 +286,7 @@ const UI_TEXT := {
         "secret.unlock.confirm": "确认",
         "secret.unlock.failed": "密码不正确，请重试。",
         "secret.unlock.success": "内购已解锁，内测功能有效期至：%s",
-        "iap.artemis_unavailable": "此视觉小说兼容正在测试中，请等待后续支持",
+        "iap.beta_runtime_unavailable": "此视觉小说兼容正在测试中，请等待后续支持",
         "iap.status.purchased": "已购买",
         "iap.status.not_purchased": "未购买",
         "iap.status.loading": "正在读取商品信息…",
@@ -567,7 +567,7 @@ const UI_TEXT := {
         "secret.unlock.confirm": "確認",
         "secret.unlock.failed": "密碼不正確，請再試一次。",
         "secret.unlock.success": "內購已解鎖，測試功能有效期限至：%s",
-        "iap.artemis_unavailable": "此視覺小說的相容支援仍在測試中，請等待後續支援",
+        "iap.beta_runtime_unavailable": "此視覺小說的相容支援仍在測試中，請等待後續支援",
         "iap.status.purchased": "已購買",
         "iap.status.not_purchased": "尚未購買",
         "iap.status.loading": "正在載入商品資訊…",
@@ -846,7 +846,7 @@ const UI_TEXT := {
         "secret.unlock.confirm": "Confirm",
         "secret.unlock.failed": "Incorrect passphrase. Please try again.",
         "secret.unlock.success": "Purchases unlocked; beta feature access expires: %s",
-        "iap.artemis_unavailable": "Compatibility for this visual novel is still being tested. Please wait for a future update.",
+        "iap.beta_runtime_unavailable": "Compatibility for this visual novel is still being tested. Please wait for a future update.",
         "iap.status.purchased": "Purchased",
         "iap.status.not_purchased": "Not purchased",
         "iap.status.loading": "Loading product information…",
@@ -1127,7 +1127,7 @@ const UI_TEXT := {
         "secret.unlock.confirm": "確認",
         "secret.unlock.failed": "パスフレーズが正しくありません。もう一度お試しください。",
         "secret.unlock.success": "課金が解錠されました。ベータ機能の有効期限：%s",
-        "iap.artemis_unavailable": "このビジュアルノベルの互換対応はテスト中です。今後の対応をお待ちください。",
+        "iap.beta_runtime_unavailable": "このビジュアルノベルの互換対応はテスト中です。今後の対応をお待ちください。",
         "iap.status.purchased": "購入済み",
         "iap.status.not_purchased": "未購入",
         "iap.status.loading": "商品情報を読み込み中…",
@@ -1406,7 +1406,7 @@ const UI_TEXT := {
         "secret.unlock.confirm": "확인",
         "secret.unlock.failed": "암호가 올바르지 않습니다. 다시 시도해 주세요.",
         "secret.unlock.success": "인앱 구매가 잠금 해제되었습니다. 베타 기능 만료일: %s",
-        "iap.artemis_unavailable": "이 비주얼 노벨의 호환성은 아직 테스트 중입니다. 추후 지원을 기다려 주세요.",
+        "iap.beta_runtime_unavailable": "이 비주얼 노벨의 호환성은 아직 테스트 중입니다. 추후 지원을 기다려 주세요.",
         "iap.status.purchased": "구입 완료",
         "iap.status.not_purchased": "구입하지 않음",
         "iap.status.loading": "상품 정보 불러오는 중…",
@@ -8036,7 +8036,7 @@ func _process_iap(delta: float) -> void:
     if iap_pending_beta_check_id > 0 and int(coffee_state.get(
         "entitlement_check_completed", 0
     )) >= iap_pending_beta_check_id:
-        _complete_artemis_beta_check()
+        _complete_runtime_beta_check()
 
     var operation_state_source := (
         coffee_state
@@ -10512,7 +10512,7 @@ func _start_selected_game_after_iap() -> void:
         return
     var selected_runtime_kind := _game_runtime_kind(library_path)
     # Development artifacts and Android releases do not use the Apple-only
-    # beta entitlement flow. Keep the Artemis grant enabled for both paths.
+    # beta entitlement flow.
     if not _beta_access_enforcement_enabled():
         if (
             selected_runtime_kind == RUNTIME_KIRIKIRI
@@ -10520,25 +10520,18 @@ func _start_selected_game_after_iap() -> void:
             and not _switch_runtime_player(RUNTIME_KIRIKIRI)
         ):
             return
-        if player.has_method("set_engine_option"):
-            player.set_engine_option("artemis_beta_allowed", "1")
         _start_selected_game_after_entitlements()
         return
 
     # StoreKit lives on the KiriKiri host. Return to that host before probing
-    # Artemis or authorizing ONScripter after an earlier ONS game exits.
+    # a provider-backed beta runtime after another runtime exits.
     if (
         current_player_runtime_kind != RUNTIME_KIRIKIRI
         and not _switch_runtime_player(RUNTIME_KIRIKIRI)
     ):
         return
-    if player.has_method("set_engine_option"):
-        # Reset a grant left on the reusable engine handle before every Release
-        # launch. A fresh verified coffee entitlement enables it again below.
-        player.set_engine_option("artemis_beta_allowed", "0")
     var requires_beta_access := (
         _runtime_requires_beta_access(selected_runtime_kind)
-        or _selected_game_uses_artemis()
         or _selected_game_uses_wa2()
     )
     if not requires_beta_access:
@@ -10547,36 +10540,27 @@ func _start_selected_game_after_iap() -> void:
 
     iap_pending_beta_game = selected_game.duplicate(true)
     if not _iap_supported_platform() or not player.has_method("iap_refresh_entitlement"):
-        _deny_artemis_beta_launch()
+        _deny_runtime_beta_launch()
         return
     iap_pending_beta_check_id = int(player.iap_refresh_entitlement(
         IAP_COFFEE_PRODUCT_ID
     ))
     if iap_pending_beta_check_id <= 0:
-        _deny_artemis_beta_launch()
+        _deny_runtime_beta_launch()
 
 func _runtime_requires_beta_access(runtime_kind: String) -> bool:
-    # ONS and Minori support follow the same Apple release policy as Artemis:
-    # unrestricted in Debug and Android builds, and gated by an active coffee
-    # entitlement in iOS and macOS distribution builds. Provider-backed
-    # runtimes such as WA2 are checked separately by their runtime probe.
-    return runtime_kind == RUNTIME_ONSCRIPTER or runtime_kind == RUNTIME_MINORI
+    # ONS and Artemis are generally available. Minori remains gated by an
+    # active coffee entitlement in iOS and macOS distribution builds.
+    # Provider-backed runtimes such as WA2 are checked separately.
+    return runtime_kind == RUNTIME_MINORI
 
 func _beta_access_enforcement_enabled(platform_name: String = "") -> bool:
     var effective_platform := platform_name if not platform_name.is_empty() else OS.get_name()
     return effective_platform in ["iOS", "macOS"] and not OS.is_debug_build()
 
-func _selected_game_uses_artemis() -> bool:
-    if player == null or not player.has_method("probe_runtime"):
-        return false
-    var library_path := String(selected_game.get("path", "")).strip_edges()
-    if library_path.is_empty():
-        return false
-    return int(player.probe_runtime("artemis", library_path)) > 0
-
 func _selected_game_uses_wa2() -> bool:
     # WHITE ALBUM2 runs on the KiriKiri host through the compiled Wa2
-    # provider, so it follows the same coffee beta-access policy as Artemis.
+    # provider and retains the provider beta-access policy.
     if player == null or not player.has_method("probe_runtime"):
         return false
     var library_path := String(selected_game.get("path", "")).strip_edges()
@@ -10584,31 +10568,23 @@ func _selected_game_uses_wa2() -> bool:
         return false
     return int(player.probe_runtime("wa2", library_path)) > 0
 
-func _complete_artemis_beta_check() -> void:
+func _complete_runtime_beta_check() -> void:
     iap_pending_beta_check_id = 0
     if iap_pending_beta_game.is_empty():
         return
     var pending_game: Dictionary = iap_pending_beta_game.duplicate(true)
     iap_pending_beta_game.clear()
     if not bool(iap_coffee_state.get("entitled", false)) and not _secret_coffee_active():
-        _deny_artemis_beta_launch()
+        _deny_runtime_beta_launch()
         return
     selected_game = pending_game
-    if (
-        _game_runtime_kind(String(selected_game.get("path", "")))
-        == RUNTIME_KIRIKIRI
-        and player.has_method("set_engine_option")
-    ):
-        player.set_engine_option("artemis_beta_allowed", "1")
     _start_selected_game_after_entitlements()
 
-func _deny_artemis_beta_launch() -> void:
+func _deny_runtime_beta_launch() -> void:
     iap_pending_beta_check_id = 0
     iap_pending_beta_game.clear()
-    if player != null and player.has_method("set_engine_option"):
-        player.set_engine_option("artemis_beta_allowed", "0")
     _show_system_alert(
-        _t("iap.artemis_unavailable"),
+        _t("iap.beta_runtime_unavailable"),
         _t("alert.warning_title")
     )
 
@@ -15584,6 +15560,9 @@ func _send_game_pointer_event(event_type: int, pointer_id: int, x: float, y: flo
             str(loading_panel != null and loading_panel.visible),
             active_runtime_kind,
         ]
+        # Desktop probes do not have the iOS device marker file, so keep the
+        # individual edge visible on stdout as well as in optional file logs.
+        print(trace_line)
         _write_probe_marker(trace_line)
         if perf_log_file != null:
             perf_log_file.store_line(trace_line)

--- a/apps/godot_app/tests/iap_catalog_limit_test.gd
+++ b/apps/godot_app/tests/iap_catalog_limit_test.gd
@@ -29,7 +29,8 @@ func _initialize() -> void:
     assert(not app._begin_iap_checked_access("game", games[1], "detail"))
     assert(app.iap_pending_launch.is_empty())
     assert(not app.modal_layer.visible)
-    assert(app._runtime_requires_beta_access(app.RUNTIME_ONSCRIPTER))
+    assert(not app._runtime_requires_beta_access(app.RUNTIME_ONSCRIPTER))
+    assert(app._runtime_requires_beta_access(app.RUNTIME_MINORI))
     assert(not app._runtime_requires_beta_access(app.RUNTIME_KIRIKIRI))
     assert(not app._beta_access_enforcement_enabled("Android"))
     assert(not app._beta_access_enforcement_enabled("iOS"))
@@ -48,7 +49,7 @@ func _initialize() -> void:
         assert(not String(app._t("iap.coffee.title")).is_empty())
         assert(not String(app._t("iap.coffee.desc")).is_empty())
         assert(not String(app._t("iap.coffee.active_until", ["2030-01-01"])).is_empty())
-        assert(not String(app._t("iap.artemis_unavailable")).is_empty())
+        assert(not String(app._t("iap.beta_runtime_unavailable")).is_empty())
 
     settings_action.free()
     app.modal_layer.free()

--- a/bridge/engine_api/src/engine_api_dispatch.cpp
+++ b/bridge/engine_api/src/engine_api_dispatch.cpp
@@ -76,11 +76,6 @@ struct DispatchHandle {
   std::string writable_path;
   std::string cache_path;
   std::string requested_runtime = "auto";
-#if defined(NDEBUG) && !defined(__ANDROID__)
-  bool artemis_beta_allowed = false;
-#else
-  bool artemis_beta_allowed = true;
-#endif
   std::unordered_map<std::string, std::string> pending_options;
   uint32_t surface_width = 0;
   uint32_t surface_height = 0;
@@ -192,16 +187,6 @@ engine_result_t Unsupported(DispatchHandle* handle, const char* operation) {
   handle->last_error = std::string("runtime provider does not implement ") + operation;
   SetThreadError(handle->last_error.c_str());
   return ENGINE_RESULT_NOT_SUPPORTED;
-}
-
-engine_result_t CheckArtemisBetaAccess(DispatchHandle* handle) {
-  if (handle->backend != BackendKind::kProvider || handle->provider == nullptr ||
-      Normalize(handle->provider->runtime_id_utf8) != "artemis" ||
-      handle->artemis_beta_allowed) {
-    return ENGINE_RESULT_OK;
-  }
-  handle->last_error = "Artemis runtime requires active beta access";
-  return ThreadError(ENGINE_RESULT_NOT_SUPPORTED, handle->last_error.c_str());
 }
 
 bool IsTextTranslationOption(const std::string& key) {
@@ -809,8 +794,6 @@ engine_result_t engine_open_game(engine_handle_t public_handle,
   }
   result = SelectBackendLocked(handle, game_root_path_utf8);
   if (result != ENGINE_RESULT_OK) return result;
-  result = CheckArtemisBetaAccess(handle);
-  if (result != ENGINE_RESULT_OK) return result;
   result = PrepareTextTranslationLocked(handle);
   if (result != ENGINE_RESULT_OK) return result;
   if (handle->backend == BackendKind::kLegacy) {
@@ -858,8 +841,6 @@ engine_result_t engine_open_game_async(engine_handle_t public_handle,
     }
     return ThreadError(result, handle->last_error.c_str());
   }
-  result = CheckArtemisBetaAccess(handle);
-  if (result != ENGINE_RESULT_OK) return result;
   result = PrepareTextTranslationLocked(handle);
   if (result != ENGINE_RESULT_OK) return result;
   if (handle->backend == BackendKind::kLegacy) {
@@ -1010,9 +991,8 @@ engine_result_t engine_set_option(engine_handle_t public_handle,
   std::lock_guard<std::recursive_mutex> guard(handle->mutex);
   const std::string key = Normalize(option->key_utf8);
   if (key == "artemis_beta_allowed") {
-    const std::string value = Normalize(option->value_utf8);
-    handle->artemis_beta_allowed =
-        value == "1" || value == "true" || value == "yes" || value == "on";
+    // Kept as a no-op for compatibility with older hosts. Artemis is now a
+    // generally available runtime and no longer accepts an entitlement gate.
     SetThreadError(nullptr);
     return ENGINE_RESULT_OK;
   }

--- a/bridge/engine_api/src/engine_input_queue_gate.h
+++ b/bridge/engine_api/src/engine_input_queue_gate.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <unordered_set>
 
 #include "engine_api.h"
@@ -17,29 +18,50 @@ class PrimaryClickQueueGate {
   bool should_enqueue(const engine_input_event_t& event) {
     const bool primary_pointer = event.button == 0;
     if (primary_pointer &&
-        event.type == ENGINE_INPUT_EVENT_POINTER_DOWN &&
-        (primary_down_pending_ ||
-         queued_primary_gestures_ >= kMaxQueuedPrimaryGestures)) {
-      suppressed_pointer_ids_.insert(event.pointer_id);
-      return false;
+        event.type == ENGINE_INPUT_EVENT_POINTER_DOWN) {
+      if (primary_down_pointer_id_.has_value()) {
+        // Godot can expose one physical press through both its global input
+        // callback and a Control callback. A duplicate DOWN for the pointer
+        // that already owns the press must not quarantine that same pointer:
+        // its following UP is the only edge that can close the accepted DOWN.
+        if (*primary_down_pointer_id_ != event.pointer_id) {
+          suppressed_pointer_ids_.insert(event.pointer_id);
+        }
+        return false;
+      }
+      if (queued_primary_gestures_ >= kMaxQueuedPrimaryGestures) {
+        suppressed_pointer_ids_.insert(event.pointer_id);
+        return false;
+      }
+
+      // Pointer ids are reused (the desktop mouse is always zero and the
+      // first mobile contact commonly is too). A missing UP from an older,
+      // rejected contact must not poison the next accepted gesture.
+      suppressed_pointer_ids_.erase(event.pointer_id);
+      primary_down_pointer_id_ = event.pointer_id;
+      return true;
     }
 
     if (primary_pointer &&
         event.type == ENGINE_INPUT_EVENT_POINTER_MOVE &&
-        suppressed_pointer_ids_.count(event.pointer_id) != 0) {
+        suppressed_pointer_ids_.count(event.pointer_id) != 0 &&
+        (!primary_down_pointer_id_.has_value() ||
+         *primary_down_pointer_id_ != event.pointer_id)) {
       return false;
     }
 
     if (primary_pointer && event.type == ENGINE_INPUT_EVENT_POINTER_UP) {
+      if (primary_down_pointer_id_.has_value() &&
+          *primary_down_pointer_id_ == event.pointer_id) {
+        primary_down_pointer_id_.reset();
+        suppressed_pointer_ids_.erase(event.pointer_id);
+        ++queued_primary_gestures_;
+        return true;
+      }
       if (suppressed_pointer_ids_.erase(event.pointer_id) != 0) {
         return false;
       }
-      if (!primary_down_pending_) return false;
-      primary_down_pending_ = false;
-      ++queued_primary_gestures_;
-    }
-    if (primary_pointer && event.type == ENGINE_INPUT_EVENT_POINTER_DOWN) {
-      primary_down_pending_ = true;
+      return false;
     }
     return true;
   }
@@ -51,14 +73,14 @@ class PrimaryClickQueueGate {
   }
 
   void reset() {
-    primary_down_pending_ = false;
+    primary_down_pointer_id_.reset();
     queued_primary_gestures_ = 0;
     suppressed_pointer_ids_.clear();
   }
 
  private:
   static constexpr size_t kMaxQueuedPrimaryGestures = 8;
-  bool primary_down_pending_ = false;
+  std::optional<int32_t> primary_down_pointer_id_;
   size_t queued_primary_gestures_ = 0;
   std::unordered_set<int32_t> suppressed_pointer_ids_;
 };

--- a/cpp/plugins/tjsNs0DataPack.cpp
+++ b/cpp/plugins/tjsNs0DataPack.cpp
@@ -1,5 +1,6 @@
 #include "tjsNs0DataPack.h"
 
+#include "kbadDataPack.h"
 #include "tjsArray.h"
 #include "tjsDictionary.h"
 
@@ -615,7 +616,15 @@ namespace {
 
 bool loadTjsNs0DataPackWithoutOuterIv(tTJSBinaryStream *stream,
                                       tTJSVariant *result) {
-    return TVPLoadTjsNs0DataPack(stream, result);
+    if(TVPLoadTjsNs0DataPack(stream, result))
+        return true;
+
+    // Dictionary.loadStruct has a single structured-loader slot. Keep KBAD
+    // save containers reachable after registering the ns0 decoder; otherwise
+    // they fall through to structured-text parsing and are evaluated as an
+    // invalid `(const)[KBAD...]` expression.
+    stream->SetPosition(0);
+    return TVPLoadKbadDataPack(stream, result);
 }
 
 } // namespace

--- a/tests/unit-tests/engine_api/diagnostics.cpp
+++ b/tests/unit-tests/engine_api/diagnostics.cpp
@@ -251,6 +251,75 @@ TEST_CASE("primary click queue gate preserves a cross-tick primary gesture") {
   REQUIRE(gate.should_enqueue(event));
 }
 
+TEST_CASE("primary click queue gate keeps the release after a duplicate down") {
+  aetherkiri::engine_api::PrimaryClickQueueGate gate;
+  engine_input_event_t event{};
+  event.struct_size = sizeof(event);
+  event.button = 0;
+  event.pointer_id = 0;
+
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+  gate.on_dequeued(event);
+
+  // macOS can route the same physical mouse event through two Godot input
+  // callbacks. Dropping the duplicate press must not also drop the release.
+  REQUIRE_FALSE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  REQUIRE(gate.should_enqueue(event));
+  gate.on_dequeued(event);
+
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+}
+
+TEST_CASE("primary click queue gate isolates a second pointer") {
+  aetherkiri::engine_api::PrimaryClickQueueGate gate;
+  engine_input_event_t event{};
+  event.struct_size = sizeof(event);
+  event.button = 0;
+  event.pointer_id = 4;
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+
+  event.pointer_id = 5;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+
+  event.pointer_id = 4;
+  REQUIRE(gate.should_enqueue(event));
+}
+
+TEST_CASE("primary click queue gate permits reused pointer ids") {
+  aetherkiri::engine_api::PrimaryClickQueueGate gate;
+  engine_input_event_t event{};
+  event.struct_size = sizeof(event);
+  event.button = 0;
+  event.pointer_id = 0;
+
+  // Fill the bounded complete-gesture queue.
+  for (size_t click = 0; click < 8; ++click) {
+    event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+    REQUIRE(gate.should_enqueue(event));
+    event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+    REQUIRE(gate.should_enqueue(event));
+  }
+
+  // Reject one contact and simulate losing its UP outside the window.
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE_FALSE(gate.should_enqueue(event));
+
+  // Once an old queued gesture is consumed, the reused desktop/touch pointer
+  // id must form a complete new gesture instead of inheriting quarantine.
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  gate.on_dequeued(event);
+  event.type = ENGINE_INPUT_EVENT_POINTER_DOWN;
+  REQUIRE(gate.should_enqueue(event));
+  event.type = ENGINE_INPUT_EVENT_POINTER_UP;
+  REQUIRE(gate.should_enqueue(event));
+}
+
 TEST_CASE("primary click queue gate preserves every secondary pointer edge") {
   aetherkiri::engine_api::PrimaryClickQueueGate gate;
   engine_input_event_t event{};
@@ -276,7 +345,7 @@ TEST_CASE("primary click queue gate preserves every secondary pointer edge") {
   gate.on_dequeued(queued_primary_release);
 }
 
-TEST_CASE("Artemis runtime is compiled but beta-gated in product builds") {
+TEST_CASE("Artemis runtime opens without a beta entitlement") {
   const engine_result_t registration =
       engine_register_runtime_provider(&kArtemisGateProvider);
   REQUIRE(registration == ENGINE_RESULT_OK);
@@ -286,16 +355,12 @@ TEST_CASE("Artemis runtime is compiled but beta-gated in product builds") {
   runtime_option.key_utf8 = "runtime";
   runtime_option.value_utf8 = "artemis";
   REQUIRE(engine_set_option(handle.value, &runtime_option) == ENGINE_RESULT_OK);
-#if defined(NDEBUG)
-  REQUIRE(engine_open_game(handle.value, ".artemis-debug-gate-test",
-                           "first.iet") == ENGINE_RESULT_NOT_SUPPORTED);
-  REQUIRE(std::string(engine_get_last_error(handle.value)) ==
-          "Artemis runtime requires active beta access");
+  // Older hosts may still send this option. A false value must no longer
+  // block the generally available runtime.
   engine_option_t beta_option{};
   beta_option.key_utf8 = "artemis_beta_allowed";
-  beta_option.value_utf8 = "1";
+  beta_option.value_utf8 = "0";
   REQUIRE(engine_set_option(handle.value, &beta_option) == ENGINE_RESULT_OK);
-#endif
   REQUIRE(engine_open_game(handle.value, ".artemis-debug-gate-test",
                            "first.iet") == ENGINE_RESULT_OK);
 }

--- a/tests/unit-tests/plugins/kbad-data-pack.cpp
+++ b/tests/unit-tests/plugins/kbad-data-pack.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "UtilStreams.h"
 #include "kbadDataPack.h"
+#include "tjsNs0DataPack.h"
 
 #include <cstdint>
 #include <string_view>
@@ -96,4 +98,15 @@ TEST_CASE("KBAD decoder rejects unrelated and truncated data") {
     };
     REQUIRE_THROWS(
         TVPDecodeKbadDataPack(truncated.data(), truncated.size(), &result));
+}
+
+TEST_CASE("registered structured loader accepts KBAD save containers") {
+    const std::vector<Byte> bytes = makePbdMetadataFixture();
+    tTVPMemoryStream stream(bytes.data(), static_cast<tjs_uint>(bytes.size()));
+    tTJSVariant root;
+
+    TVPRegisterTjsNs0DataPackLoader();
+    REQUIRE(TJS::TJSLoadStructuredDataPack(&stream, &root));
+    REQUIRE(root.Type() == tvtObject);
+    CHECK(getProperty(getIndex(root, 0), TJS_W("width")).AsInteger() == 1920);
 }


### PR DESCRIPTION
## Summary
- preserve the primary mouse release when macOS or iOS delivers a duplicate press edge, while keeping secondary pointers isolated
- preserve KBAD structured-save decoding when the ns0 loader owns the registered structured-loader slot
- make ONScripter and Artemis generally available without Coffee entitlement checks; Minori and WA2 retain their existing beta policy
- pin AetherInternal to the implementation from AetherKiri/AetherInternal#34

## Validation
- 5 focused CTest cases passed: KBAD registered loader, Artemis without entitlement, duplicate mouse down/release, secondary-pointer isolation, and pointer-id reuse
- Godot IAP catalog/runtime policy test passed
- complete iOS Debug build, development signing, device install, and launch succeeded on a paired iPad
- iOS Release engine_api and ONScripter runtime targets compiled successfully

## Cross-repository boundary
- private implementation and its focused test remain in AetherInternal: https://github.com/AetherKiri/AetherInternal/pull/34
- the public diff contains only generic engine/app behavior, public fallback coverage, and the verified gitlink
- workflows are unchanged; standard public CI artifacts may contain compiled Internal behavior when trusted combined CI is enabled