### PR TITLE
fix(library): launch Artemis packages by directory

### DIFF
--- a/apps/godot_app/scripts/game_launch_entry.gd
+++ b/apps/godot_app/scripts/game_launch_entry.gd
@@ -2,6 +2,7 @@ extends RefCounted
 
 const FIELD := "launchFile"
 const SUPPORTED_EXTENSIONS := ["exe", "xp3"]
+const DIRECTORY_RUNTIME_KINDS := ["artemis", "minori", "onscripter", "siglus"]
 
 
 static func configured_relative_path(game: Dictionary) -> String:
@@ -22,6 +23,16 @@ static func resolve(game: Dictionary) -> String:
     if game_path.is_empty() or relative_path.is_empty():
         return game_path
     return game_path.path_join(relative_path).simplify_path()
+
+
+static func resolve_for_runtime(game: Dictionary, runtime_kind: String) -> String:
+    if runtime_uses_directory(runtime_kind):
+        return _normalize_path(String(game.get("path", "")).strip_edges()).simplify_path()
+    return resolve(game)
+
+
+static func runtime_uses_directory(runtime_kind: String) -> bool:
+    return DIRECTORY_RUNTIME_KINDS.has(runtime_kind.to_lower())
 
 
 static func is_supported_file(path: String) -> bool:

--- a/apps/godot_app/scripts/game_launch_entry_test.gd
+++ b/apps/godot_app/scripts/game_launch_entry_test.gd
@@ -21,6 +21,22 @@ func _init() -> void:
         "EXE launch path"
     )
     _expect_equal(
+        GameLaunchEntry.resolve_for_runtime(
+            {"path": root, GameLaunchEntry.FIELD: "开始游戏.exe"},
+            "artemis"
+        ),
+        root,
+        "Artemis directory launch path"
+    )
+    _expect_equal(
+        GameLaunchEntry.resolve_for_runtime(
+            {"path": root, GameLaunchEntry.FIELD: "开始游戏.exe"},
+            "kirikiri"
+        ),
+        exe_path,
+        "KiriKiri configured launch path"
+    )
+    _expect_equal(
         GameLaunchEntry.relative_path_for_selection(root, archive_path),
         "patch/data.xp3",
         "nested XP3 selection"

--- a/apps/godot_app/scripts/game_metadata.gd
+++ b/apps/godot_app/scripts/game_metadata.gd
@@ -21,15 +21,22 @@ static func inspect(path: String) -> Dictionary:
         return result
 
     var candidates: PackedStringArray = []
-    var launch := _first_file(root, [".exe", ".xp3"])
     var files := _file_names(root)
     if files.has("nscript.dat") or files.has("0.txt") or _has_prefix(files, "onscript.nt"):
         result.engine = RUNTIME_ONSCRIPTER
         result.signals.append("onscript-marker")
-    elif files.has("system.ini") and _contains_text(root.path_join("system.ini"), "Artemis"):
+    elif files.has("system.ini") and _is_artemis_package(
+        files,
+        _read_text(root.path_join("system.ini"))
+    ):
         result.engine = RUNTIME_ARTEMIS
         result.signals.append("artemis-system-ini")
         var ini := _read_text(root.path_join("system.ini"))
+        if (
+            _has_extension(files, "pfs")
+            and _value_after(ini, "BOOT").to_lower().ends_with(".iet")
+        ):
+            result.signals.append("artemis-pfs-boot")
         var save_path := _value_after(ini, "SAVEPATH")
         if not save_path.is_empty():
             candidates.append(save_path.replace("\\\\", "/").get_file())
@@ -39,8 +46,10 @@ static func inspect(path: String) -> Dictionary:
     else:
         result.signals.append("kirikiri-xp3-or-default")
 
-    if not launch.is_empty():
-        result.launchFile = launch
+    if result.engine == RUNTIME_KIRIKIRI:
+        var launch := _first_file(root, [".exe", ".xp3"])
+        if not launch.is_empty():
+            result.launchFile = launch
     for marker in ["README.md", "title.ini", "title.ks", "startup.tjs", "config.tjs"]:
         var marker_path := root.path_join(marker)
         if FileAccess.file_exists(marker_path):
@@ -93,20 +102,31 @@ static func _has_prefix(values: PackedStringArray, prefix: String) -> bool:
             return true
     return false
 
+static func _has_extension(values: PackedStringArray, extension: String) -> bool:
+    var normalized := extension.to_lower().trim_prefix(".")
+    for value in values:
+        if value.get_extension() == normalized:
+            return true
+    return false
+
+static func _is_artemis_package(files: PackedStringArray, ini: String) -> bool:
+    if ini.findn("Artemis") >= 0:
+        return true
+    var boot := _value_after(ini, "BOOT").replace("\\", "/")
+    return _has_extension(files, "pfs") and boot.to_lower().ends_with(".iet")
+
 static func _read_text(path: String) -> String:
     var file := FileAccess.open(path, FileAccess.READ)
     if file == null or file.get_length() > 1024 * 1024:
         return ""
     return file.get_as_text()
 
-static func _contains_text(path: String, needle: String) -> bool:
-    return _read_text(path).findn(needle) >= 0
-
 static func _value_after(text: String, key: String) -> String:
     for line in text.split("\n"):
         var trimmed := line.strip_edges()
-        if trimmed.begins_with(key) and trimmed.find("=") >= 0:
-            return trimmed.substr(trimmed.find("=") + 1).strip_edges()
+        var equals := trimmed.find("=")
+        if equals >= 0 and trimmed.left(equals).strip_edges().to_upper() == key.to_upper():
+            return trimmed.substr(equals + 1).strip_edges()
     return ""
 
 static func _extract_title_candidates(text: String) -> PackedStringArray:

--- a/apps/godot_app/scripts/game_metadata_test.gd
+++ b/apps/godot_app/scripts/game_metadata_test.gd
@@ -1,0 +1,87 @@
+extends SceneTree
+
+const GameMetadata = preload("res://scripts/game_metadata.gd")
+
+var failures := 0
+var fixture_root := ""
+
+
+func _init() -> void:
+    fixture_root = ProjectSettings.globalize_path(
+        "user://game_metadata_test_%d" % Time.get_ticks_usec()
+    )
+    DirAccess.make_dir_recursive_absolute(fixture_root)
+
+    var artemis_root := fixture_root.path_join("mobile_artemis")
+    DirAccess.make_dir_recursive_absolute(artemis_root)
+    _write(artemis_root.path_join("launcher.exe"), "launcher")
+    _write(artemis_root.path_join("root.pfs"), "pf fixture")
+    _write(
+        artemis_root.path_join("system.ini"),
+        "[ANDROID]\nWIDTH = 1024\nHEIGHT = 768\nboot = system/first.iet\n"
+    )
+    var artemis := GameMetadata.inspect(artemis_root)
+    _expect_equal(String(artemis.engine), "artemis", "PFS plus IET detection")
+    _expect_equal(String(artemis.launchFile), "", "Artemis ignores Windows launcher")
+    _expect_true(
+        Array(artemis.signals).has("artemis-pfs-boot"),
+        "structural Artemis signal"
+    )
+
+    var kirikiri_root := fixture_root.path_join("kirikiri")
+    DirAccess.make_dir_recursive_absolute(kirikiri_root)
+    _write(kirikiri_root.path_join("game.exe"), "launcher")
+    _write(kirikiri_root.path_join("data.xp3"), "archive")
+    _write(kirikiri_root.path_join("system.ini"), "[Game]\nBOOT = startup.tjs\n")
+    var kirikiri := GameMetadata.inspect(kirikiri_root)
+    _expect_equal(String(kirikiri.engine), "kirikiri", "KiriKiri remains default")
+    _expect_equal(String(kirikiri.launchFile), "game.exe", "KiriKiri launcher retained")
+
+    _remove_tree(fixture_root)
+    if failures == 0:
+        print("game_metadata_test: PASS")
+        quit(0)
+    else:
+        quit(1)
+
+
+func _write(path: String, contents: String) -> void:
+    var file := FileAccess.open(path, FileAccess.WRITE)
+    if file == null:
+        push_error("game_metadata_test: could not create %s" % path)
+        failures += 1
+        return
+    file.store_string(contents)
+
+
+func _remove_tree(path: String) -> void:
+    var dir := DirAccess.open(path)
+    if dir == null:
+        return
+    dir.list_dir_begin()
+    var entry := dir.get_next()
+    while not entry.is_empty():
+        var child := path.path_join(entry)
+        if dir.current_is_dir():
+            _remove_tree(child)
+        else:
+            DirAccess.remove_absolute(child)
+        entry = dir.get_next()
+    dir.list_dir_end()
+    DirAccess.remove_absolute(path)
+
+
+func _expect_equal(actual: String, expected: String, label: String) -> void:
+    if actual == expected:
+        return
+    push_error(
+        "game_metadata_test: %s: expected %s, got %s" % [label, expected, actual]
+    )
+    failures += 1
+
+
+func _expect_true(actual: bool, label: String) -> void:
+    if actual:
+        return
+    push_error("game_metadata_test: %s: expected true" % label)
+    failures += 1

--- a/apps/godot_app/scripts/game_metadata_test.gd.uid
+++ b/apps/godot_app/scripts/game_metadata_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cocnki6ix6udi

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -10599,24 +10599,40 @@ func _start_selected_game_after_entitlements() -> void:
     active_runtime_kind = _game_runtime_kind(library_path)
     if not _switch_runtime_player(active_runtime_kind):
         return
+    var launch_uses_directory := GameLaunchEntry.runtime_uses_directory(
+        active_runtime_kind
+    )
     var raw_launch_file := String(selected_game.get(GameLaunchEntry.FIELD, "")).strip_edges()
-    if not raw_launch_file.is_empty() and not GameLaunchEntry.is_supported_file(raw_launch_file):
+    if (
+        not launch_uses_directory
+        and not raw_launch_file.is_empty()
+        and not GameLaunchEntry.is_supported_file(raw_launch_file)
+    ):
         _show_system_alert(
             _t("message.launch_file_unsupported"),
             _t("alert.warning_title")
         )
         return
     var relative_launch_file := GameLaunchEntry.configured_relative_path(selected_game)
-    if not raw_launch_file.is_empty() and relative_launch_file.is_empty():
+    if (
+        not launch_uses_directory
+        and not raw_launch_file.is_empty()
+        and relative_launch_file.is_empty()
+    ):
         _show_system_alert(
             _t("message.launch_file_outside_game"),
             _t("alert.warning_title")
         )
         return
-    var launch_path := library_path \
-        if active_runtime_kind in [RUNTIME_ONSCRIPTER, RUNTIME_MINORI] \
-        else GameLaunchEntry.resolve(selected_game)
-    if not relative_launch_file.is_empty() and not FileAccess.file_exists(launch_path):
+    var launch_path := GameLaunchEntry.resolve_for_runtime(
+        selected_game,
+        active_runtime_kind
+    )
+    if (
+        not launch_uses_directory
+        and not relative_launch_file.is_empty()
+        and not FileAccess.file_exists(launch_path)
+    ):
         _show_system_alert(
             _t("message.launch_file_missing", [relative_launch_file]),
             _t("alert.warning_title")
@@ -11830,7 +11846,7 @@ func _probe_open_game(config: Dictionary, target_game_path: String, backend_env:
     if not _switch_runtime_player(runtime_kind):
         _write_probe_marker("probe_open_game runtime_switch_failed kind=%s" % runtime_kind)
         return false
-    if runtime_kind == RUNTIME_ONSCRIPTER:
+    if GameLaunchEntry.runtime_uses_directory(runtime_kind):
         target_game_path = _game_runtime_root(target_game_path)
     selected_backend = ProbeConfig.backend(config, backend_env)
     if not selected_backend in BACKENDS:
@@ -13556,7 +13572,7 @@ func _on_open_game() -> void:
         render_errors += 1
         return
     active_runtime_kind = detected_runtime
-    if detected_runtime == RUNTIME_ONSCRIPTER:
+    if GameLaunchEntry.runtime_uses_directory(detected_runtime):
         path = _game_runtime_root(path)
         game_path.text = path
     _load_button_position_memory(path)


### PR DESCRIPTION
## Summary

- detect Artemis installations structurally from a PFS archive and an IET boot entry, including mobile-only `system.ini` files
- ignore Windows launcher executables for directory-based runtimes and normalize direct executable probe paths back to the game root
- preserve configured executable and XP3 launch entries for KiriKiri games

## Validation

- `game_metadata_test.gd`: PASS
- `game_launch_entry_test.gd`: PASS
- full macOS x64 Debug build: PASS
- JSON render probe using the original `Aikagi3.exe` failure entry: selected Artemis, executed `system/first.iet`, and rendered the startup frame

## Scope

This is a public launch/metadata fix only. `packages/AetherInternal` and `.github/workflows` are unchanged.