### PR TITLE
fix(compat): launch Artemis games and restore PackinOne flows

### DIFF
--- a/apps/godot_app/scripts/game_launch_entry.gd
+++ b/apps/godot_app/scripts/game_launch_entry.gd
@@ -2,6 +2,7 @@ extends RefCounted
 
 const FIELD := "launchFile"
 const SUPPORTED_EXTENSIONS := ["exe", "xp3"]
+const DIRECTORY_RUNTIME_KINDS := ["artemis", "minori", "onscripter", "siglus"]
 
 
 static func configured_relative_path(game: Dictionary) -> String:
@@ -22,6 +23,16 @@ static func resolve(game: Dictionary) -> String:
     if game_path.is_empty() or relative_path.is_empty():
         return game_path
     return game_path.path_join(relative_path).simplify_path()
+
+
+static func resolve_for_runtime(game: Dictionary, runtime_kind: String) -> String:
+    if runtime_uses_directory(runtime_kind):
+        return _normalize_path(String(game.get("path", "")).strip_edges()).simplify_path()
+    return resolve(game)
+
+
+static func runtime_uses_directory(runtime_kind: String) -> bool:
+    return DIRECTORY_RUNTIME_KINDS.has(runtime_kind.to_lower())
 
 
 static func is_supported_file(path: String) -> bool:

--- a/apps/godot_app/scripts/game_launch_entry_test.gd
+++ b/apps/godot_app/scripts/game_launch_entry_test.gd
@@ -21,6 +21,22 @@ func _init() -> void:
         "EXE launch path"
     )
     _expect_equal(
+        GameLaunchEntry.resolve_for_runtime(
+            {"path": root, GameLaunchEntry.FIELD: "开始游戏.exe"},
+            "artemis"
+        ),
+        root,
+        "Artemis directory launch path"
+    )
+    _expect_equal(
+        GameLaunchEntry.resolve_for_runtime(
+            {"path": root, GameLaunchEntry.FIELD: "开始游戏.exe"},
+            "kirikiri"
+        ),
+        exe_path,
+        "KiriKiri configured launch path"
+    )
+    _expect_equal(
         GameLaunchEntry.relative_path_for_selection(root, archive_path),
         "patch/data.xp3",
         "nested XP3 selection"

--- a/apps/godot_app/scripts/game_metadata.gd
+++ b/apps/godot_app/scripts/game_metadata.gd
@@ -21,15 +21,22 @@ static func inspect(path: String) -> Dictionary:
         return result
 
     var candidates: PackedStringArray = []
-    var launch := _first_file(root, [".exe", ".xp3"])
     var files := _file_names(root)
     if files.has("nscript.dat") or files.has("0.txt") or _has_prefix(files, "onscript.nt"):
         result.engine = RUNTIME_ONSCRIPTER
         result.signals.append("onscript-marker")
-    elif files.has("system.ini") and _contains_text(root.path_join("system.ini"), "Artemis"):
+    elif files.has("system.ini") and _is_artemis_package(
+        files,
+        _read_text(root.path_join("system.ini"))
+    ):
         result.engine = RUNTIME_ARTEMIS
         result.signals.append("artemis-system-ini")
         var ini := _read_text(root.path_join("system.ini"))
+        if (
+            _has_extension(files, "pfs")
+            and _value_after(ini, "BOOT").to_lower().ends_with(".iet")
+        ):
+            result.signals.append("artemis-pfs-boot")
         var save_path := _value_after(ini, "SAVEPATH")
         if not save_path.is_empty():
             candidates.append(save_path.replace("\\\\", "/").get_file())
@@ -39,8 +46,10 @@ static func inspect(path: String) -> Dictionary:
     else:
         result.signals.append("kirikiri-xp3-or-default")
 
-    if not launch.is_empty():
-        result.launchFile = launch
+    if result.engine == RUNTIME_KIRIKIRI:
+        var launch := _first_file(root, [".exe", ".xp3"])
+        if not launch.is_empty():
+            result.launchFile = launch
     for marker in ["README.md", "title.ini", "title.ks", "startup.tjs", "config.tjs"]:
         var marker_path := root.path_join(marker)
         if FileAccess.file_exists(marker_path):
@@ -93,20 +102,31 @@ static func _has_prefix(values: PackedStringArray, prefix: String) -> bool:
             return true
     return false
 
+static func _has_extension(values: PackedStringArray, extension: String) -> bool:
+    var normalized := extension.to_lower().trim_prefix(".")
+    for value in values:
+        if value.get_extension() == normalized:
+            return true
+    return false
+
+static func _is_artemis_package(files: PackedStringArray, ini: String) -> bool:
+    if ini.findn("Artemis") >= 0:
+        return true
+    var boot := _value_after(ini, "BOOT").replace("\\", "/")
+    return _has_extension(files, "pfs") and boot.to_lower().ends_with(".iet")
+
 static func _read_text(path: String) -> String:
     var file := FileAccess.open(path, FileAccess.READ)
     if file == null or file.get_length() > 1024 * 1024:
         return ""
     return file.get_as_text()
 
-static func _contains_text(path: String, needle: String) -> bool:
-    return _read_text(path).findn(needle) >= 0
-
 static func _value_after(text: String, key: String) -> String:
     for line in text.split("\n"):
         var trimmed := line.strip_edges()
-        if trimmed.begins_with(key) and trimmed.find("=") >= 0:
-            return trimmed.substr(trimmed.find("=") + 1).strip_edges()
+        var equals := trimmed.find("=")
+        if equals >= 0 and trimmed.left(equals).strip_edges().to_upper() == key.to_upper():
+            return trimmed.substr(equals + 1).strip_edges()
     return ""
 
 static func _extract_title_candidates(text: String) -> PackedStringArray:

--- a/apps/godot_app/scripts/game_metadata_test.gd
+++ b/apps/godot_app/scripts/game_metadata_test.gd
@@ -1,0 +1,87 @@
+extends SceneTree
+
+const GameMetadata = preload("res://scripts/game_metadata.gd")
+
+var failures := 0
+var fixture_root := ""
+
+
+func _init() -> void:
+    fixture_root = ProjectSettings.globalize_path(
+        "user://game_metadata_test_%d" % Time.get_ticks_usec()
+    )
+    DirAccess.make_dir_recursive_absolute(fixture_root)
+
+    var artemis_root := fixture_root.path_join("mobile_artemis")
+    DirAccess.make_dir_recursive_absolute(artemis_root)
+    _write(artemis_root.path_join("launcher.exe"), "launcher")
+    _write(artemis_root.path_join("root.pfs"), "pf fixture")
+    _write(
+        artemis_root.path_join("system.ini"),
+        "[ANDROID]\nWIDTH = 1024\nHEIGHT = 768\nboot = system/first.iet\n"
+    )
+    var artemis := GameMetadata.inspect(artemis_root)
+    _expect_equal(String(artemis.engine), "artemis", "PFS plus IET detection")
+    _expect_equal(String(artemis.launchFile), "", "Artemis ignores Windows launcher")
+    _expect_true(
+        Array(artemis.signals).has("artemis-pfs-boot"),
+        "structural Artemis signal"
+    )
+
+    var kirikiri_root := fixture_root.path_join("kirikiri")
+    DirAccess.make_dir_recursive_absolute(kirikiri_root)
+    _write(kirikiri_root.path_join("game.exe"), "launcher")
+    _write(kirikiri_root.path_join("data.xp3"), "archive")
+    _write(kirikiri_root.path_join("system.ini"), "[Game]\nBOOT = startup.tjs\n")
+    var kirikiri := GameMetadata.inspect(kirikiri_root)
+    _expect_equal(String(kirikiri.engine), "kirikiri", "KiriKiri remains default")
+    _expect_equal(String(kirikiri.launchFile), "game.exe", "KiriKiri launcher retained")
+
+    _remove_tree(fixture_root)
+    if failures == 0:
+        print("game_metadata_test: PASS")
+        quit(0)
+    else:
+        quit(1)
+
+
+func _write(path: String, contents: String) -> void:
+    var file := FileAccess.open(path, FileAccess.WRITE)
+    if file == null:
+        push_error("game_metadata_test: could not create %s" % path)
+        failures += 1
+        return
+    file.store_string(contents)
+
+
+func _remove_tree(path: String) -> void:
+    var dir := DirAccess.open(path)
+    if dir == null:
+        return
+    dir.list_dir_begin()
+    var entry := dir.get_next()
+    while not entry.is_empty():
+        var child := path.path_join(entry)
+        if dir.current_is_dir():
+            _remove_tree(child)
+        else:
+            DirAccess.remove_absolute(child)
+        entry = dir.get_next()
+    dir.list_dir_end()
+    DirAccess.remove_absolute(path)
+
+
+func _expect_equal(actual: String, expected: String, label: String) -> void:
+    if actual == expected:
+        return
+    push_error(
+        "game_metadata_test: %s: expected %s, got %s" % [label, expected, actual]
+    )
+    failures += 1
+
+
+func _expect_true(actual: bool, label: String) -> void:
+    if actual:
+        return
+    push_error("game_metadata_test: %s: expected true" % label)
+    failures += 1

--- a/apps/godot_app/scripts/game_metadata_test.gd.uid
+++ b/apps/godot_app/scripts/game_metadata_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cocnki6ix6udi

--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -10599,24 +10599,40 @@ func _start_selected_game_after_entitlements() -> void:
     active_runtime_kind = _game_runtime_kind(library_path)
     if not _switch_runtime_player(active_runtime_kind):
         return
+    var launch_uses_directory := GameLaunchEntry.runtime_uses_directory(
+        active_runtime_kind
+    )
     var raw_launch_file := String(selected_game.get(GameLaunchEntry.FIELD, "")).strip_edges()
-    if not raw_launch_file.is_empty() and not GameLaunchEntry.is_supported_file(raw_launch_file):
+    if (
+        not launch_uses_directory
+        and not raw_launch_file.is_empty()
+        and not GameLaunchEntry.is_supported_file(raw_launch_file)
+    ):
         _show_system_alert(
             _t("message.launch_file_unsupported"),
             _t("alert.warning_title")
         )
         return
     var relative_launch_file := GameLaunchEntry.configured_relative_path(selected_game)
-    if not raw_launch_file.is_empty() and relative_launch_file.is_empty():
+    if (
+        not launch_uses_directory
+        and not raw_launch_file.is_empty()
+        and relative_launch_file.is_empty()
+    ):
         _show_system_alert(
             _t("message.launch_file_outside_game"),
             _t("alert.warning_title")
         )
         return
-    var launch_path := library_path \
-        if active_runtime_kind in [RUNTIME_ONSCRIPTER, RUNTIME_MINORI] \
-        else GameLaunchEntry.resolve(selected_game)
-    if not relative_launch_file.is_empty() and not FileAccess.file_exists(launch_path):
+    var launch_path := GameLaunchEntry.resolve_for_runtime(
+        selected_game,
+        active_runtime_kind
+    )
+    if (
+        not launch_uses_directory
+        and not relative_launch_file.is_empty()
+        and not FileAccess.file_exists(launch_path)
+    ):
         _show_system_alert(
             _t("message.launch_file_missing", [relative_launch_file]),
             _t("alert.warning_title")
@@ -11830,7 +11846,7 @@ func _probe_open_game(config: Dictionary, target_game_path: String, backend_env:
     if not _switch_runtime_player(runtime_kind):
         _write_probe_marker("probe_open_game runtime_switch_failed kind=%s" % runtime_kind)
         return false
-    if runtime_kind == RUNTIME_ONSCRIPTER:
+    if GameLaunchEntry.runtime_uses_directory(runtime_kind):
         target_game_path = _game_runtime_root(target_game_path)
     selected_backend = ProbeConfig.backend(config, backend_env)
     if not selected_backend in BACKENDS:
@@ -13556,7 +13572,7 @@ func _on_open_game() -> void:
         render_errors += 1
         return
     active_runtime_kind = detected_runtime
-    if detected_runtime == RUNTIME_ONSCRIPTER:
+    if GameLaunchEntry.runtime_uses_directory(detected_runtime):
         path = _game_runtime_root(path)
         game_path.text = path
     _load_button_position_memory(path)

--- a/cpp/core/tjs2/tjsArray.cpp
+++ b/cpp/core/tjs2/tjsArray.cpp
@@ -536,6 +536,15 @@ namespace TJS {
                         }
                     }
                 }
+                if(!isbin) {
+                    stream->SetPosition(0);
+                    isbin = TJSLoadStructuredDataPack(stream, result);
+                    if(TJSArrayStructTraceEnabled()) {
+                        spdlog::info(
+                            "Array.loadStruct data-pack file={} loaded={}",
+                            name.AsStdString(), isbin);
+                    }
+                }
             } catch(...) {
                 delete stream;
                 throw;

--- a/cpp/plugins/kbadDataPack.cpp
+++ b/cpp/plugins/kbadDataPack.cpp
@@ -124,6 +124,25 @@ private:
         return value;
     }
 
+    tTJSVariant readOctet(std::size_t byteCount) {
+        require(byteCount);
+        if(byteCount >
+           static_cast<std::size_t>(std::numeric_limits<tjs_uint>::max()))
+            throw std::runtime_error("KBAD octet is too large");
+
+        tTJSVariantOctet *octet = TJSAllocVariantOctet(
+            byteCount == 0 ? nullptr : data_ + position_,
+            static_cast<tjs_uint>(byteCount));
+        if(!octet)
+            throw std::runtime_error("cannot create KBAD octet");
+        position_ += byteCount;
+
+        tTJSVariant value;
+        value = octet;
+        octet->Release();
+        return value;
+    }
+
     tTJSVariant decodeValue(std::size_t depth) {
         if(depth > KBAD_MAX_DEPTH)
             throw std::runtime_error("KBAD nesting is too deep");
@@ -180,12 +199,10 @@ private:
         case 0xd3:
             return tTJSVariant(static_cast<tTVInteger>(
                 static_cast<std::int64_t>(readU64())));
-        case 0xd9:
-            return tTJSVariant(ttstr(readString(readU8())));
         case 0xda:
-            return tTJSVariant(ttstr(readString(readU16())));
+            return readOctet(readU16());
         case 0xdb:
-            return tTJSVariant(ttstr(readString(readU32())));
+            return readOctet(readU32());
         case 0xdc:
             return decodeArray(readU16(), depth + 1);
         case 0xdd:
@@ -195,6 +212,8 @@ private:
         case 0xdf:
             return decodeMap(readU32(), depth + 1);
         default:
+            if(type >= 0xd4 && type <= 0xd9)
+                return readOctet(type - 0xd4);
             throw std::runtime_error("unsupported KBAD type");
         }
     }

--- a/tests/unit-tests/plugins/kbad-data-pack.cpp
+++ b/tests/unit-tests/plugins/kbad-data-pack.cpp
@@ -1,10 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include "BinaryStream.h"
 #include "UtilStreams.h"
 #include "kbadDataPack.h"
+#include "tjsArray.h"
 #include "tjsNs0DataPack.h"
 
+#include <array>
+#include <chrono>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <initializer_list>
 #include <string_view>
 #include <vector>
@@ -12,6 +18,67 @@
 namespace {
 
 using Byte = std::uint8_t;
+
+class TemporaryFile {
+public:
+    TemporaryFile() {
+        const auto unique = std::chrono::steady_clock::now()
+                                .time_since_epoch()
+                                .count();
+        path = std::filesystem::temp_directory_path() /
+               ("aetherkiri-array-struct-" + std::to_string(unique) +
+                ".ksd");
+    }
+
+    ~TemporaryFile() {
+        std::error_code error;
+        std::filesystem::remove(path, error);
+    }
+
+    std::filesystem::path path;
+};
+
+class BinaryStreamFactoryScope {
+public:
+    BinaryStreamFactoryScope() : previous(TJS::TJSCreateBinaryStreamForRead) {
+        TJS::TJSCreateBinaryStreamForRead = &TVPCreateBinaryStreamForRead;
+    }
+
+    ~BinaryStreamFactoryScope() {
+        TJS::TJSCreateBinaryStreamForRead = previous;
+    }
+
+private:
+    decltype(TJS::TJSCreateBinaryStreamForRead) previous;
+};
+
+bool loadSyntheticStructuredPack(tTJSBinaryStream *stream,
+                                 tTJSVariant *result) {
+    static constexpr std::array<Byte, 8> signature = {
+        'A', 'K', 'P', 'K', '1', '0', '0', 0,
+    };
+    if(!stream || stream->GetSize() != signature.size())
+        return false;
+
+    std::array<Byte, signature.size()> bytes{};
+    stream->SetPosition(0);
+    if(stream->Read(bytes.data(), static_cast<tjs_uint>(bytes.size())) !=
+           bytes.size() ||
+       bytes != signature)
+        return false;
+    if(result)
+        *result = static_cast<tTVInteger>(42);
+    return true;
+}
+
+class StructuredLoaderScope {
+public:
+    StructuredLoaderScope() {
+        TJS::TJSSetStructuredDataPackLoader(&loadSyntheticStructuredPack);
+    }
+
+    ~StructuredLoaderScope() { TVPRegisterTjsNs0DataPackLoader(); }
+};
 
 void appendString(std::vector<Byte> &bytes, std::string_view value) {
     REQUIRE(value.size() <= 31);
@@ -148,4 +215,37 @@ TEST_CASE("registered structured loader accepts KBAD save containers") {
     REQUIRE(TJS::TJSLoadStructuredDataPack(&stream, &root));
     REQUIRE(root.Type() == tvtObject);
     CHECK(getProperty(getIndex(root, 0), TJS_W("width")).AsInteger() == 1920);
+}
+
+TEST_CASE("Array.loadStruct delegates non-native binary data packs") {
+    const std::vector<Byte> bytes = {
+        'A', 'K', 'P', 'K', '1', '0', '0', 0,
+    };
+    TemporaryFile file;
+    BinaryStreamFactoryScope streamFactory;
+    StructuredLoaderScope structuredLoader;
+    {
+        std::ofstream output(file.path, std::ios::binary);
+        REQUIRE(output.good());
+        output.write(reinterpret_cast<const char *>(bytes.data()),
+                     static_cast<std::streamsize>(bytes.size()));
+        REQUIRE(output.good());
+    }
+
+    iTJSDispatch2 *arrayClass = nullptr;
+    iTJSDispatch2 *array = TJSCreateArrayObject(&arrayClass);
+    REQUIRE(array != nullptr);
+    REQUIRE(arrayClass != nullptr);
+    tTJSVariant filename(ttstr(file.path.string()));
+    tTJSVariant *params[] = { &filename };
+    tTJSVariant root;
+    const tjs_error error = arrayClass->FuncCall(
+        0, TJS_W("loadStruct"), nullptr, &root, 1, params, array);
+    array->Release();
+    arrayClass->Release();
+
+    INFO("Array.loadStruct error=" << error);
+    REQUIRE(TJS_SUCCEEDED(error));
+    REQUIRE(root.Type() == tvtInteger);
+    CHECK(root.AsInteger() == 42);
 }

--- a/tests/unit-tests/plugins/kbad-data-pack.cpp
+++ b/tests/unit-tests/plugins/kbad-data-pack.cpp
@@ -5,6 +5,7 @@
 #include "tjsNs0DataPack.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <string_view>
 #include <vector>
 
@@ -25,6 +26,15 @@ void appendU16(std::vector<Byte> &bytes, std::uint16_t value) {
     bytes.push_back(0xcd);
     bytes.push_back(static_cast<Byte>(value));
     bytes.push_back(static_cast<Byte>(value >> 8));
+}
+
+void appendRaw16(std::vector<Byte> &bytes,
+                 std::initializer_list<Byte> value) {
+    REQUIRE(value.size() <= 0xffff);
+    bytes.push_back(0xda);
+    bytes.push_back(static_cast<Byte>(value.size()));
+    bytes.push_back(static_cast<Byte>(value.size() >> 8));
+    bytes.insert(bytes.end(), value);
 }
 
 tTJSVariant getIndex(const tTJSVariant &object, tjs_int index) {
@@ -84,6 +94,35 @@ TEST_CASE("KBAD data packs decode PBD canvas and layer metadata") {
     const tTJSVariant layer = getIndex(root, 1);
     CHECK(ttstr(getProperty(layer, TJS_W("name"))) == TJS_W("com"));
     CHECK(getProperty(layer, TJS_W("visible")).AsInteger() == 1);
+}
+
+TEST_CASE("KBAD data packs preserve fixed and length-prefixed octets") {
+    std::vector<Byte> bytes = { 'K', 'B', 'A', 'D', '1', '0', '0', 0 };
+    bytes.push_back(0x92); // two octets
+    bytes.push_back(0xd9); // five-byte fixed octet
+    bytes.insert(bytes.end(), { 0x00, 0x7f, 0x80, 0xfe, 0xff });
+    appendRaw16(bytes, { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60 });
+
+    tTJSVariant root;
+    REQUIRE(TVPDecodeKbadDataPack(bytes.data(), bytes.size(), &root));
+
+    const tTJSVariant fixed = getIndex(root, 0);
+    REQUIRE(fixed.Type() == tvtOctet);
+    const tTJSVariantOctet *fixedOctet = fixed.AsOctetNoAddRef();
+    REQUIRE(fixedOctet != nullptr);
+    REQUIRE(fixedOctet->GetLength() == 5);
+    CHECK(std::vector<Byte>(fixedOctet->GetData(),
+                            fixedOctet->GetData() + fixedOctet->GetLength()) ==
+          std::vector<Byte>{ 0x00, 0x7f, 0x80, 0xfe, 0xff });
+
+    const tTJSVariant raw16 = getIndex(root, 1);
+    REQUIRE(raw16.Type() == tvtOctet);
+    const tTJSVariantOctet *raw16Octet = raw16.AsOctetNoAddRef();
+    REQUIRE(raw16Octet != nullptr);
+    REQUIRE(raw16Octet->GetLength() == 6);
+    CHECK(std::vector<Byte>(raw16Octet->GetData(),
+                            raw16Octet->GetData() + raw16Octet->GetLength()) ==
+          std::vector<Byte>{ 0x10, 0x20, 0x30, 0x40, 0x50, 0x60 });
 }
 
 TEST_CASE("KBAD decoder rejects unrelated and truncated data") {


### PR DESCRIPTION
## Summary

- detect Artemis packages from their archive and boot-entry structure and launch directory-based runtimes correctly
- preserve configured executable and XP3 launch entries for KiriKiri games
- decode PackinOne structured save payloads through the generic KBAD loader
- route Array.loadStruct binary payloads through registered data-pack loaders
- restore WebP-backed portrait slices through the paired private implementation

## Validation

- game_metadata_test.gd: PASS
- game_launch_entry_test.gd: PASS
- 4 focused C++ regression cases: PASS (41 assertions)
- combined public/private x86_64 sources and tests compile
- macOS x86_64 Debug application build completed on the patch chain
- JSON-probe runtime reproduction verified directory launch, continue/return-title, and saved portrait rendering flows

## Internal dependency

- merged AetherInternal PR: https://github.com/AetherKiri/AetherInternal/pull/37
- pinned commit: `bdac206101fdd5294f25ffdfd7acc0e6ffc91230`
- the pinned commit is permanently reachable from AetherInternal main through merge commit `7e9244c71cf757896e776a597c695a77d43dc0bb`

This PR supersedes #182 so all related public compatibility fixes can be merged together.