### PR TITLE
fix(motionplayer): repaint progressing motion frames

### DIFF
--- a/cpp/plugins/motionplayer/Player.h
+++ b/cpp/plugins/motionplayer/Player.h
@@ -681,6 +681,11 @@ namespace motion {
         double _cameraTargetX = 0, _cameraTargetY = 0, _cameraTargetZ = 0;
         bool _speed = true;           // Aligned to libkrkr2.so +1093: bool flag
         double _frameTickCount = 0.0;
+        // getCommandList() is polled by AnimKAGLayer after every progress()
+        // call to decide whether its backing Layer needs repainting.  The
+        // compatible list is a one-value ping-pong token, not a list of the
+        // motion's static source paths.
+        bool _commandListPulse = false;
         tjs_int _maskMode = 0;                         // libkrkr2.so +1148
         std::uint32_t _colorWeightPacked = 0xFF808080u; // libkrkr2.so +1156
         bool _independentLayerInherit = false;          // libkrkr2.so +1097

--- a/cpp/plugins/motionplayer/PlayerCore.cpp
+++ b/cpp/plugins/motionplayer/PlayerCore.cpp
@@ -925,6 +925,7 @@ namespace motion {
         _loopTime = 0.0;
         _clampedEvalTime = 0.0;
         _frameTickCount = 0.0;
+        _commandListPulse = false;
         _runtime->activeMotion.reset();
         _runtime->clearMotionBitmapCaches();
         _runtime->timelines.clear();

--- a/cpp/plugins/motionplayer/PlayerQuery.cpp
+++ b/cpp/plugins/motionplayer/PlayerQuery.cpp
@@ -1787,8 +1787,14 @@ namespace motion {
         if(!_runtime->activeMotion) {
             return detail::makeArray({});
         }
+        // AnimKAGLayer compares this value with its previous result and only
+        // invalidates the Layer when it changes.  Expose the progress
+        // ping-pong token expected by that protocol.  Returning the static
+        // source-path list leaves the first transparent frame of fade-in
+        // motions resident forever because that list does not change while
+        // opacity, transforms and nested timelines advance.
         return detail::makeArray(
-            detail::stringsToVariants(activeSourceCandidates()));
+            {tTJSVariant(static_cast<tjs_int>(_commandListPulse ? 1 : 0))});
     }
 
     bool Player::getD3DAvailable() { return true; }

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -13969,6 +13969,11 @@ namespace motion {
         if(!_speed) {
             return;
         }
+        // Toggle the command-list token on every accepted progress call,
+        // including progress(0).  KAG uses that token solely as a dirty
+        // signal before scheduling onPaint; the evaluated frame itself stays
+        // in the retained node tree below.
+        _commandListPulse = !_commandListPulse;
         const bool hasNativeBackend = _nativeBackend != nullptr;
         _layersDirty = !hasNativeBackend;
         if(!_completedEndedTimelineRenderHoldLabel.empty()) {

--- a/tests/unit-tests/plugins/motionplayer-dll.cpp
+++ b/tests/unit-tests/plugins/motionplayer-dll.cpp
@@ -2169,6 +2169,40 @@ TEST_CASE("motionplayer non-loop motion clips finish at sync boundary") {
     REQUIRE(autoPlayer.getProgressCompat() == Catch::Approx(1.0));
 }
 
+TEST_CASE("motionplayer command list invalidates after every progress call") {
+    auto snapshot = std::make_shared<motion::detail::MotionSnapshot>();
+    snapshot->path = "unit/fade-in-title.psb";
+    snapshot->mainTimelineLabels.push_back("show");
+    snapshot->timelineTotalFrames["show"] = 60.0;
+    snapshot->sourceCandidates.push_back("src/title/menu_bg");
+
+    auto &clip = snapshot->clipsByLabel["show"];
+    clip.label = "show";
+    clip.totalFrames = 60.0;
+    clip.sourceCandidates.push_back("src/title/menu_bg");
+
+    motion::Player player;
+    player.loadFromSnapshot(snapshot);
+    player.playTimeline(TJS_W("show"), motion::PlayFlagForce);
+
+    const auto initial = player.getCommandList();
+    REQUIRE(variantCount(initial) == 1);
+    REQUIRE(getIndex(initial, 0).Type() == tvtInteger);
+    CHECK(getIndex(initial, 0).AsInteger() == 0);
+
+    // Zero-delta progress is used for hover/selector changes and must still
+    // request a repaint even though the playback clock does not advance.
+    player.frameProgress(0.0);
+    const auto afterZeroDelta = player.getCommandList();
+    REQUIRE(variantCount(afterZeroDelta) == 1);
+    CHECK(getIndex(afterZeroDelta, 0).AsInteger() == 1);
+
+    player.frameProgress(1.0);
+    const auto afterNextFrame = player.getCommandList();
+    REQUIRE(variantCount(afterNextFrame) == 1);
+    CHECK(getIndex(afterNextFrame, 0).AsInteger() == 0);
+}
+
 TEST_CASE("motionplayer title source clone prefers authored static clip") {
     auto snapshot = std::make_shared<motion::detail::MotionSnapshot>();
     snapshot->path = "motion/title_bg.psb";


### PR DESCRIPTION
## Summary

- expose a changing command-list token after each accepted motion progress call
- repaint retained motion layers while opacity, transforms, and nested timelines advance
- cover zero-delta and subsequent-frame invalidation with a focused unit test

## Validation

- reproduced the DRACU-RIOT title black frame with the JSON probe
- verified the title renders after the fix
- built and code-sign verified the macOS x86_64 Debug app
- git diff --check passes

## Scope

This is a public-only engine compatibility change. The private package gitlink is unchanged and no private source is included in this diff.