### PR TITLE
fix(doinaka): remove startup stripes and RPG black screen

### DIFF
--- a/cpp/core/movie/ffmpeg/VideoCodecFFmpeg.cpp
+++ b/cpp/core/movie/ffmpeg/VideoCodecFFmpeg.cpp
@@ -380,13 +380,14 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints,
                        0);
     }
 
-    while(avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0) {
-        // trying set lowres to 0
-        if(pCodec->max_lowres < m_pCodecContext->lowres) {
-            m_pCodecContext->lowres = pCodec->max_lowres;
-            if(avcodec_open2(m_pCodecContext, pCodec, nullptr) >= 0)
-                break;
-        }
+    // Negotiate lowres before opening the decoder. avcodec_open2() derives
+    // width/height from coded_width/coded_height before it rejects an
+    // unsupported lowres value. Retrying that partially initialized context
+    // with lowres=0 leaves stale half-size dimensions (notably for WMV3), so
+    // later YUV conversion reads the full-size planes with the wrong layout.
+    m_pCodecContext->lowres =
+        std::min<int>(m_pCodecContext->lowres, pCodec->max_lowres);
+    if(avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0) {
         //    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Unable
         //    to open codec");
         avcodec_free_context(&m_pCodecContext);

--- a/cpp/core/visual/LayerManager.cpp
+++ b/cpp/core/visual/LayerManager.cpp
@@ -863,6 +863,16 @@ void tTVPLayerManager::SetHoldAlpha(bool b) {
     static_cast<tTVPDestTexture *>(DrawBuffer)->SetHoldAlpha(b);
 }
 
+void tTVPLayerManager::ClearDrawBufferForAlpha() {
+    if(!DrawBuffer || HoldAlpha)
+        return;
+    tjs_int width = 0;
+    tjs_int height = 0;
+    if(!GetPrimaryLayerSize(width, height) || width <= 0 || height <= 0)
+        return;
+    DrawBuffer->Fill(tTVPRect(0, 0, width, height), 0x00000000u);
+}
+
 tTVPBaseTexture *tTVPLayerManager::EnsureDrawBufferSize(
     tjs_int w, tjs_int h, bool clear_on_resize) {
     if(w <= 0 || h <= 0)
@@ -872,9 +882,10 @@ tTVPBaseTexture *tTVPLayerManager::EnsureDrawBufferSize(
     // only updates part of the primary surface. KiriKiri defines those pixels
     // from the opaque primary layer's neutral color; a hard-coded black clear
     // leaks a black edge through otherwise valid transparent title artwork.
-    const tjs_uint32 clear_color = Primary
-        ? (Primary->GetNeutralColor() & 0x00ffffffu) | 0xff000000u
-        : 0xff000000u;
+    const tjs_uint32 neutral_color =
+        Primary ? (Primary->GetNeutralColor() & 0x00ffffffu) : 0;
+    const tjs_uint32 clear_color = HoldAlpha ? neutral_color | 0xff000000u
+                                             : neutral_color;
 
     const tjs_uint target_w = static_cast<tjs_uint>(w);
     const tjs_uint target_h = static_cast<tjs_uint>(h);
@@ -983,8 +994,20 @@ void tTVPLayerManager::DrawCompleted(const tTVPRect &destrect,
         return;
     }
 
-    DrawBuffer->Blt(destrect.left, destrect.top, bmp, cliprect, type, opacity,
-                    HoldAlpha);
+    // A D2D manager is an alpha-preserving composition surface even when
+    // one of its source layers advertises ltOpaque.  The generic layer-type
+    // overload maps that combination to CopyOpaqueImage, which deliberately
+    // forces alpha to 255; an untouched/transparent opaque layer then becomes
+    // opaque black and covers a lower manager (the RPG map in particular).
+    // Copy the source pixels verbatim for this manager so zero-alpha regions
+    // stay transparent while genuinely opaque pixels remain opaque.
+    if(!HoldAlpha && DesiredLayerType == ltAlpha && type == ltOpaque) {
+        DrawBuffer->Blt(destrect.left, destrect.top, bmp, cliprect, bmCopy,
+                         opacity, false);
+    } else {
+        DrawBuffer->Blt(destrect.left, destrect.top, bmp, cliprect, type,
+                         opacity, HoldAlpha);
+    }
     notify_bitmap_owner();
 #endif
 }

--- a/cpp/core/visual/LayerManager.h
+++ b/cpp/core/visual/LayerManager.h
@@ -334,6 +334,10 @@ public:
         DesiredLayerType = type;
     }
     void SetHoldAlpha(bool b);
+    // D2D multi-manager composition uses transparent pixels outside the
+    // manager's actual content.  Clear an already allocated target when the
+    // draw device switches this manager to alpha-preserving output.
+    void ClearDrawBufferForAlpha();
 
 public: // methods from tTVPDrawable
     tTVPBaseTexture *GetDrawTargetBitmap(const tTVPRect &rect,


### PR DESCRIPTION
Fixes `/Users/liuyu/gal/doinaka_brother_aetherkiri` on Godot Native.

Changes:
- negotiate FFmpeg lowres before `avcodec_open2()` so WMV startup frames keep the coded dimensions instead of using stale half-size layout data;
- keep transparent pixels when an alpha-preserving D2D manager receives an `ltOpaque` source, preventing the base manager from covering the RPG map with opaque black;
- initialize/clear alpha manager buffers transparently.

Validation:
- macOS x64 Debug build completed successfully;
- JSON probe: startup animation, START, JUMP, YES; Godot Native and Debug CPU both rendered the complete map, characters, HUD, and menu; no plugin load failures.

Paired private implementation PR: https://github.com/AetherKiri/AetherInternal/pull/38

The public diff contains no private source; `packages/AetherInternal` is pinned to `4271ebad517da5392c774b91fecbdfa937de27c8`.