### PR TITLE
perf(godot): reduce story frame synchronization stalls

### DIFF
--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -10812,7 +10812,11 @@ func _ready() -> void:
     input_trace_enabled = (
         _runtime_flag("AETHERKIRI_INPUT_TRACE")
         or ios_diagnostics_enabled
-        or not cli_probe_script.is_empty()
+        # A CLI probe should measure the game, not force the very verbose
+        # LayerIntf input tracer on every click.  The tracer walks and logs a
+        # large TJS object graph from onMouseDown/onMouseUp and can itself
+        # create 45-70ms host frames.  Keep it opt-in for targeted input
+        # investigations while probes retain their normal input delivery.
     )
     device_probe_enabled = device_probe_enabled or frame_probe_enabled
     device_probe_enabled = device_probe_enabled or input_trace_enabled
@@ -12224,10 +12228,13 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
     var tick_total := 0.0
     var update_total := 0.0
     var frame_total := 0.0
+    var wall_frame_total := 0.0
     var input_max := 0.0
     var tick_max := 0.0
     var update_max := 0.0
     var frame_max := 0.0
+    var wall_frame_max := 0.0
+    var wait_max := 0.0
     var spikes := 0
     var input_events := 0
     var clicks_sent := 0
@@ -12240,10 +12247,13 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
     var sample_tick_total := 0.0
     var sample_update_total := 0.0
     var sample_frame_total := 0.0
+    var sample_wall_frame_total := 0.0
     var sample_input_max := 0.0
     var sample_tick_max := 0.0
     var sample_update_max := 0.0
     var sample_frame_max := 0.0
+    var sample_wall_frame_max := 0.0
+    var sample_wait_max := 0.0
     var sample_spikes := 0
     var sample_index := 0
 
@@ -12320,6 +12330,18 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
             step += 1
         await get_tree().process_frame
         var sample_end_ticks := Time.get_ticks_usec()
+        # The overlay's Frame value is the host/Godot frame delta, which
+        # includes the time spent yielding to the next process_frame. Keep
+        # that wall-clock interval separate from the active engine work above
+        # so click-stream results can be compared with the floating panel.
+        var wall_frame_ms := float(sample_end_ticks - frame_start) / 1000.0
+        var wait_ms := maxf(0.0, wall_frame_ms - frame_ms)
+        wall_frame_total += wall_frame_ms
+        wall_frame_max = maxf(wall_frame_max, wall_frame_ms)
+        wait_max = maxf(wait_max, wait_ms)
+        sample_wall_frame_total += wall_frame_ms
+        sample_wall_frame_max = maxf(sample_wall_frame_max, wall_frame_ms)
+        sample_wait_max = maxf(sample_wait_max, wait_ms)
         var sample_elapsed_ms := float(sample_end_ticks - sample_start_ticks) / 1000.0
         var stream_finished := frame_index + 1 >= frames
         if sample_interval_ms > 0 and (sample_elapsed_ms >= sample_interval_ms or stream_finished):
@@ -12328,7 +12350,7 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
                 0.0,
                 (sample_elapsed_ms - sample_frame_total) / sample_divisor
             )
-            var sample_line := "click_stream_sample label=%s index=%d frames=%d clicks=%d elapsed_ms=%.2f fps=%.2f avg_input_ms=%.2f avg_tick_ms=%.2f avg_update_ms=%.2f avg_active_ms=%.2f avg_wait_ms=%.2f max_input_ms=%.2f max_tick_ms=%.2f max_update_ms=%.2f max_active_ms=%.2f spikes=%d spike_ms=%.2f texture_backend=%s renderer=\"%s\"" % [
+            var sample_line := "click_stream_sample label=%s index=%d frames=%d clicks=%d elapsed_ms=%.2f fps=%.2f avg_input_ms=%.2f avg_tick_ms=%.2f avg_update_ms=%.2f avg_active_ms=%.2f avg_wait_ms=%.2f avg_wall_frame_ms=%.2f max_input_ms=%.2f max_tick_ms=%.2f max_update_ms=%.2f max_active_ms=%.2f max_wall_frame_ms=%.2f max_wait_ms=%.2f spikes=%d spike_ms=%.2f texture_backend=%s renderer=\"%s\"" % [
                 label,
                 sample_index,
                 sample_frames,
@@ -12340,10 +12362,13 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
                 sample_update_total / sample_divisor,
                 sample_frame_total / sample_divisor,
                 sample_wait_ms,
+                sample_wall_frame_total / sample_divisor,
                 sample_input_max,
                 sample_tick_max,
                 sample_update_max,
                 sample_frame_max,
+                sample_wall_frame_max,
+                sample_wait_max,
                 sample_spikes,
                 spike_ms,
                 player.get_frame_texture_backend(),
@@ -12359,15 +12384,18 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
             sample_tick_total = 0.0
             sample_update_total = 0.0
             sample_frame_total = 0.0
+            sample_wall_frame_total = 0.0
             sample_input_max = 0.0
             sample_tick_max = 0.0
             sample_update_max = 0.0
             sample_frame_max = 0.0
+            sample_wall_frame_max = 0.0
+            sample_wait_max = 0.0
             sample_spikes = 0
 
     var divisor := float(max(1, measured_frames))
     var elapsed_sec: float = maxf(0.0001, float(Time.get_ticks_usec() - stream_start_ticks) / 1000000.0)
-    var line := "click_stream label=%s frames=%d measured_frames=%d clicks_per_frame=%d click_every_frames=%d max_clicks=%d clicks_sent=%d input_events=%d fps=%.2f avg_input_ms=%.2f max_input_ms=%.2f avg_tick_ms=%.2f max_tick_ms=%.2f avg_update_ms=%.2f max_update_ms=%.2f avg_frame_ms=%.2f max_frame_ms=%.2f spikes=%d spike_ms=%.2f texture_backend=%s renderer=\"%s\"" % [
+    var line := "click_stream label=%s frames=%d measured_frames=%d clicks_per_frame=%d click_every_frames=%d max_clicks=%d clicks_sent=%d input_events=%d fps=%.2f avg_input_ms=%.2f max_input_ms=%.2f avg_tick_ms=%.2f max_tick_ms=%.2f avg_update_ms=%.2f max_update_ms=%.2f avg_frame_ms=%.2f max_frame_ms=%.2f avg_wall_frame_ms=%.2f max_wall_frame_ms=%.2f max_wait_ms=%.2f spikes=%d spike_ms=%.2f texture_backend=%s renderer=\"%s\"" % [
         label,
         frames,
         measured_frames,
@@ -12385,6 +12413,9 @@ func _probe_run_click_stream(config: Dictionary, step: int, label: String, actio
         update_max,
         frame_total / divisor,
         frame_max,
+        wall_frame_total / divisor,
+        wall_frame_max,
+        wait_max,
         spikes,
         spike_ms,
         player.get_frame_texture_backend(),

--- a/bridge/engine_api/src/engine_api.cpp
+++ b/bridge/engine_api/src/engine_api.cpp
@@ -2687,6 +2687,12 @@ engine_result_t engine_tick(engine_handle_t handle, uint32_t delta_ms) {
   // TVPDrawSceneOnce() only restores GL state and calls SwapBuffer,
   // which is insufficient.
   if (::Application) {
+    // Event delivery can compose many PSD layers before UpdateContent() opens
+    // its narrower draw-device batch. Keep the complete application step in
+    // one ordered Godot GPU batch and drain it before TVPDrawSceneOnce(). This
+    // removes a render-thread submit/fence boundary from each fillRect and
+    // operateTo call without deferring any work across the presented frame.
+    TVPGodotGpuBatchScope gpu_batch;
     ::Application->Run();
     if (auto* loop = EngineLoop::GetInstance(); loop != nullptr) {
       loop->CompleteInputFrame();

--- a/bridge/godot_extension/src/aether_runtime_player.cpp
+++ b/bridge/godot_extension/src/aether_runtime_player.cpp
@@ -93,6 +93,7 @@ extern "C" engine_result_t aetherkiri_minori_register_runtime_provider();
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <mutex>
 
@@ -1732,6 +1733,45 @@ bool PendingWritesOverlap(const GodotGpuPendingWrite &a,
                           const GodotGpuPendingWrite &b) {
     return a.rid == b.rid && a.left < b.right && b.left < a.right &&
            a.top < b.bottom && b.top < a.bottom;
+}
+
+// A bridge-owned RD texture is a distinct allocation for the lifetime of the
+// queued batch. Imported Apple/Android textures are the exception: their RID
+// can be a view over storage owned by another subsystem, so retain the old
+// conservative ordering whenever one participates in a batch.
+std::unordered_set<int64_t> ExternalGodotGpuRids() {
+    std::unordered_set<int64_t> result;
+    std::lock_guard<std::mutex> lock(g_gpu_textures_mutex);
+    for (const auto &entry : g_gpu_textures) {
+        const auto &record = entry.second;
+        if (record.apple_pixel_buffer != nullptr ||
+            record.apple_vulkan_external_texture != nullptr ||
+            record.android_external_texture != nullptr) {
+            if (record.rid.is_valid()) result.insert(record.rid.get_id());
+        }
+    }
+    return result;
+}
+
+bool NonLiveGpuHazardTrackingSafe(
+    const std::vector<std::shared_ptr<GodotGpuOp>> &ops) {
+    const char *conservative =
+        std::getenv("AETHERKIRI_GODOT_CONSERVATIVE_BARRIERS");
+    if (conservative != nullptr && conservative[0] != '\0' &&
+        std::strcmp(conservative, "0") != 0) {
+        return false;
+    }
+    const auto external_rids = ExternalGodotGpuRids();
+    if (external_rids.empty()) return true;
+    for (const auto &op : ops) {
+        if (op == nullptr) continue;
+        const RID rids[] = {op->src, op->src2, op->src3, op->dst};
+        for (const RID &rid : rids) {
+            if (rid.is_valid() && external_rids.count(rid.get_id()) != 0)
+                return false;
+        }
+    }
+    return true;
 }
 
 bool BlendOpNeedsBarrierBeforeDispatch(
@@ -6030,6 +6070,9 @@ void ExecuteGodotGpuComputeBatchLegacy(
     uint64_t nonlive_compute_ops = 0;
     uint64_t nonlive_compute_barriers = 0;
     std::vector<GodotGpuPendingWrite> live2d_pending_writes;
+    std::vector<GodotGpuPendingWrite> nonlive_pending_writes;
+    const bool nonlive_hazard_tracking_safe =
+        NonLiveGpuHazardTrackingSafe(ops);
     const bool shadow_enabled = GodotGpuBarrierShadowEnabled();
     std::unique_ptr<GodotGpuBarrierShadowPlanner> nonlive_shadow;
     if (shadow_enabled) {
@@ -6049,6 +6092,10 @@ void ExecuteGodotGpuComputeBatchLegacy(
             // real command list.
             nonlive_shadow->finish();
         }
+        if (live2d_triangle && !nonlive_pending_writes.empty()) {
+            rd->compute_list_add_barrier(compute_list);
+            nonlive_pending_writes.clear();
+        }
         if (live2d_triangle && TriangleOpNeedsBarrierBeforeDispatch(
                                    *ops[i], live2d_pending_writes)) {
             rd->compute_list_add_barrier(compute_list);
@@ -6056,6 +6103,13 @@ void ExecuteGodotGpuComputeBatchLegacy(
         } else if (!live2d_triangle && !live2d_pending_writes.empty()) {
             rd->compute_list_add_barrier(compute_list);
             live2d_pending_writes.clear();
+        }
+        if (!live2d_triangle &&
+            (!nonlive_hazard_tracking_safe ||
+             BlendOpNeedsBarrierBeforeDispatch(*ops[i],
+                                                nonlive_pending_writes))) {
+            rd->compute_list_add_barrier(compute_list);
+            nonlive_pending_writes.clear();
         }
         const bool batchable_triangle = IsBatchableTriangleOp(ops[i]);
         if (batchable_triangle) {
@@ -6085,11 +6139,16 @@ void ExecuteGodotGpuComputeBatchLegacy(
                 live2d_pending_writes.push_back(PendingWriteForRect(
                     ops[i]->dst, ops[i]->dst_pos, ops[i]->size));
             } else {
-                // Keep the more conservative E-mote/TVP behavior: those paths
-                // can expose different RIDs backed by aliased storage.
                 ++nonlive_compute_ops;
-                rd->compute_list_add_barrier(compute_list);
-                ++nonlive_compute_barriers;
+                nonlive_pending_writes.push_back(PendingWriteForRect(
+                    ops[i]->dst, ops[i]->dst_pos, ops[i]->size));
+                if (!nonlive_hazard_tracking_safe) {
+                    // Imported textures may alias storage outside this batch;
+                    // preserve the historical barrier after each operation.
+                    rd->compute_list_add_barrier(compute_list);
+                    nonlive_pending_writes.clear();
+                    ++nonlive_compute_barriers;
+                }
                 if (nonlive_shadow != nullptr) {
                     try {
                         RecordGodotGpuNonLiveShadowAccess(
@@ -6120,6 +6179,9 @@ void ExecuteGodotGpuComputeBatchLegacy(
             nonlive_compute_ops, std::memory_order_relaxed);
     }
     if (!live2d_pending_writes.empty()) {
+        rd->compute_list_add_barrier(compute_list);
+    }
+    if (!nonlive_pending_writes.empty()) {
         rd->compute_list_add_barrier(compute_list);
     }
     rd->compute_list_end();
@@ -7165,19 +7227,37 @@ uint64_t BridgeCreateRgba(uint32_t width, uint32_t height, const void *pixels,
     Ref<RDTextureView> view;
     view.instantiate();
     TypedArray<PackedByteArray> initial_data;
-    initial_data.push_back(PackRgbaBytes(pixels, width, height, stride_bytes));
+    RenderingServer *server = RenderingServer::get_singleton();
+    const bool on_render_thread =
+        server != nullptr && server->is_on_render_thread();
+    const bool use_device_clear = pixels == nullptr && on_render_thread;
+    if (!use_device_clear) {
+        initial_data.push_back(
+            PackRgbaBytes(pixels, width, height, stride_bytes));
+    }
     RID rid = rd->texture_create(MakeRgbaTextureFormat(width, height), view,
                                  initial_data);
+    // RenderingDevice accepts an empty initial-data array, but its contents
+    // are undefined. Fresh KiriKiri render targets require transparent black,
+    // so establish the same state with a device-side clear. This avoids
+    // allocating, zeroing and uploading a width*height*4 staging array for
+    // large PSD/transition scratch textures.
+    if (rid.is_valid() && use_device_clear &&
+        rd->texture_clear(rid, Color(0.0, 0.0, 0.0, 0.0), 0, 1, 0, 1) != OK) {
+        rd->free_rid(rid);
+        rid = RID();
+    }
     const double create_ms = std::chrono::duration<double, std::milli>(
                                  std::chrono::steady_clock::now() -
                                  create_started)
                                  .count();
     LogGodotGpuUpdateProfile(
         "texture_create", width, height,
-        static_cast<size_t>(width) * static_cast<size_t>(height) * 4u,
+        pixels != nullptr
+            ? static_cast<size_t>(width) * static_cast<size_t>(height) * 4u
+            : 0u,
         create_ms, 0.0, 0.0, rid.is_valid(),
-        RenderingServer::get_singleton() != nullptr &&
-            RenderingServer::get_singleton()->is_on_render_thread());
+        on_render_thread);
     if (!rid.is_valid()) return 0;
 
     GodotGpuTextureRecord record;
@@ -7350,6 +7430,71 @@ bool BridgeUpdateRgba(uint64_t texture, const void *pixels,
     const double pack_ms = std::chrono::duration<double, std::milli>(
                                packed_at - bridge_started)
                                .count();
+
+    // Updating a texture that Godot presented recently can make MoltenVK wait
+    // for the old VkImage's fence. PSD slice uploads are full replacements, so
+    // large surfaces can use a fresh RID and retire the old RID in normal GPU
+    // queue order. This preserves the exact uploaded pixels while avoiding a
+    // 20-35 ms texture_update stall on the render thread.
+    constexpr uint64_t kVersionedUploadMinPixels = 256u * 1024u;
+    const uint64_t pixel_count =
+        static_cast<uint64_t>(record.width) * record.height;
+    RenderingServer *server = RenderingServer::get_singleton();
+    const bool on_render_thread =
+        server != nullptr && server->is_on_render_thread();
+    const bool can_version_upload =
+        on_render_thread &&
+        pixel_count >= kVersionedUploadMinPixels &&
+        record.apple_pixel_buffer == nullptr &&
+        record.apple_vulkan_external_texture == nullptr &&
+        record.android_external_texture == nullptr;
+    if (can_version_upload) {
+        RenderingDevice *rd = MainRenderingDevice();
+        Ref<RDTextureView> view;
+        view.instantiate();
+        TypedArray<PackedByteArray> initial_data;
+        initial_data.push_back(data);
+        RID replacement = rd != nullptr
+            ? rd->texture_create(
+                  MakeRgbaTextureFormat(record.width, record.height), view,
+                  initial_data)
+            : RID();
+        if (replacement.is_valid()) {
+            bool replaced = false;
+            {
+                std::lock_guard<std::mutex> lock(g_gpu_textures_mutex);
+                auto it = g_gpu_textures.find(texture);
+                if (it != g_gpu_textures.end() &&
+                    it->second.rid == record.rid &&
+                    it->second.apple_pixel_buffer == nullptr &&
+                    it->second.apple_vulkan_external_texture == nullptr &&
+                    it->second.android_external_texture == nullptr) {
+                    it->second.rid = replacement;
+                    it->second.requires_alpha_d_clear_version = false;
+                    it->second.texture->set_texture_rd_rid(replacement);
+                    replaced = true;
+                }
+            }
+            if (replaced) {
+                auto release = std::make_shared<GodotGpuOp>();
+                release->type = GodotGpuOp::Type::Release;
+                release->dst = record.rid;
+                const bool result = RunGodotGpuOpAsync(release);
+                const double bridge_ms =
+                    std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - bridge_started)
+                        .count();
+                LogGodotGpuUpdateProfile(
+                    "texture_replace_rgba", record.width, record.height,
+                    static_cast<size_t>(data.size()), bridge_ms, pack_ms, 0.0,
+                    result,
+                    on_render_thread);
+                return result;
+            }
+            rd->free_rid(replacement);
+        }
+    }
+
     auto op = std::make_shared<GodotGpuOp>();
     op->type = GodotGpuOp::Type::Update;
     op->dst = record.rid;
@@ -7363,11 +7508,10 @@ bool BridgeUpdateRgba(uint64_t texture, const void *pixels,
                                  std::chrono::steady_clock::now() -
                                  bridge_started)
                                  .count();
-    RenderingServer *server = RenderingServer::get_singleton();
     LogGodotGpuUpdateProfile(
         "bridge_update_rgba", record.width, record.height,
         static_cast<size_t>(data.size()), bridge_ms, pack_ms, 0.0, result,
-        server != nullptr && server->is_on_render_thread());
+        on_render_thread);
     return result;
 }
 
@@ -7391,18 +7535,30 @@ bool BridgeClearRgba(uint64_t texture, uint32_t argb, const tTVPRect *rect) {
     const bool full_transparent_clear = argb == 0 && rect->left == 0 &&
         rect->top == 0 && rect->right == static_cast<int>(record.width) &&
         rect->bottom == static_cast<int>(record.height);
-    if (full_transparent_clear && record.requires_alpha_d_clear_version) {
+    const bool can_version_clear =
+        RenderingServer::get_singleton() != nullptr &&
+        RenderingServer::get_singleton()->is_on_render_thread() &&
+        full_transparent_clear &&
+        record.requires_alpha_d_clear_version &&
+        record.apple_pixel_buffer == nullptr &&
+        record.apple_vulkan_external_texture == nullptr &&
+        record.android_external_texture == nullptr;
+    if (can_version_clear) {
         RenderingDevice *rd = MainRenderingDevice();
         Ref<RDTextureView> view;
         view.instantiate();
         TypedArray<PackedByteArray> initial_data;
-        initial_data.push_back(PackRgbaBytes(
-            nullptr, record.width, record.height, record.width * 4u));
         RID replacement = rd != nullptr
             ? rd->texture_create(MakeRgbaTextureFormat(record.width,
                                                        record.height),
                                  view, initial_data)
             : RID();
+        if (replacement.is_valid() &&
+            rd->texture_clear(replacement, Color(0.0, 0.0, 0.0, 0.0),
+                              0, 1, 0, 1) != OK) {
+            rd->free_rid(replacement);
+            replacement = RID();
+        }
         if (replacement.is_valid()) {
             bool replaced = false;
             {
@@ -7410,7 +7566,9 @@ bool BridgeClearRgba(uint64_t texture, uint32_t argb, const tTVPRect *rect) {
                 auto it = g_gpu_textures.find(texture);
                 if (it != g_gpu_textures.end() &&
                     it->second.rid == record.rid &&
-                    it->second.requires_alpha_d_clear_version) {
+                    it->second.apple_pixel_buffer == nullptr &&
+                    it->second.apple_vulkan_external_texture == nullptr &&
+                    it->second.android_external_texture == nullptr) {
                     it->second.rid = replacement;
                     it->second.requires_alpha_d_clear_version = false;
                     it->second.texture->set_texture_rd_rid(replacement);

--- a/cpp/core/base/StorageIntf.cpp
+++ b/cpp/core/base/StorageIntf.cpp
@@ -1452,7 +1452,13 @@ extern ttstr TVPChopStorageExt(const ttstr &name) {
 //---------------------------------------------------------------------------
 // Auto search path support
 //---------------------------------------------------------------------------
-#define TVP_AUTO_PATH_HASH_SIZE 1024
+// Voice-heavy titles can mount millions of archive entries. With 1024
+// buckets, a first lookup for each new voice name walks a chain containing
+// thousands of entries and shows up as 30-40 ms in getExistVoice(). Keep the
+// existing ordered chained table, but size its bucket array so those lookups
+// remain effectively constant-time. The table nodes already dominate memory
+// at that scale; the larger bucket array adds only a few MiB.
+#define TVP_AUTO_PATH_HASH_SIZE 65536
 std::vector<ttstr> TVPAutoPathList;
 tTJSHashCache<ttstr, ttstr> TVPAutoPathCache(TVP_DEFAULT_AUTOPATH_CACHE_NUM);
 tTJSHashTable<ttstr, ttstr, tTJSHashFunc<ttstr>, TVP_AUTO_PATH_HASH_SIZE>

--- a/cpp/core/base/impl/StorageImpl.cpp
+++ b/cpp/core/base/impl/StorageImpl.cpp
@@ -1780,12 +1780,13 @@ void TVPAutoMountSiblingXP3Archives() {
     }
 
     if(archiveProject) {
-        // The explicitly selected archive is the executable's resource
-        // overlay. Mount every directory after its siblings so bare-name
-        // lookups (for example scenedata.sdb) resolve to the selected EXE/XP3,
-        // not to an older external patch archive.
+        // Keep a selected patch archive as a priority overlay. A selected
+        // base archive must stay below sibling patch*.xp3 overlays; otherwise
+        // the priority pass would move the base archive after the patches.
+        const bool selectedProjectIsPatch =
+            TVPIsPatchArchiveName(projBaseName.AsStdString());
         TVPMountArchiveAutoPaths(
-            TVPNormalizeStorageName(projDir), true,
+            TVPNormalizeStorageName(projDir), selectedProjectIsPatch,
             TJS_W("selected project"));
     }
 }

--- a/cpp/core/base/impl/SysInitImpl.cpp
+++ b/cpp/core/base/impl/SysInitImpl.cpp
@@ -302,9 +302,12 @@ void TVPAfterSystemInit() {
     } else {
         TVPGraphicCacheSystemLimit = limitmb * 1024 * 1024;
     }
-    // Cap at 256MB to leave headroom for VRAM, TJS heap, and system on mobile
-    if(TVPGraphicCacheSystemLimit >= 256 * 1024 * 1024)
-        TVPGraphicCacheSystemLimit = 256 * 1024 * 1024;
+    // Keep the historical 256MB cap for legacy renderers. Godot Native keeps
+    // decoded images in GPU resources and benefits from a larger cache on
+    // desktop-class machines; the backend-specific limit is selected after
+    // the renderer option is resolved below.
+    if(TVPGraphicCacheSystemLimit > 1024 * 1024 * 1024)
+        TVPGraphicCacheSystemLimit = 1024 * 1024 * 1024;
 
     if(TVPTotalPhysMemory <= 64 * 1024 * 1024)
         TVPSetFontCacheForLowMem();
@@ -327,6 +330,10 @@ void TVPAfterSystemInit() {
     if(_val.empty()) {
         _val = IndividualConfigManager::GetInstance()->GetValue<std::string>(
             "renderer", "opengl");
+    }
+    if(_val != "godot_native" &&
+       TVPGraphicCacheSystemLimit > 256 * 1024 * 1024) {
+        TVPGraphicCacheSystemLimit = 256 * 1024 * 1024;
     }
     // The Godot backend keeps decoded textures in GPU resources. On Apple
     // targets the legacy platform cache controller is not present, so the

--- a/cpp/core/environ/Application.cpp
+++ b/cpp/core/environ/Application.cpp
@@ -1,6 +1,7 @@
 #include "tjsCommHead.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -50,6 +51,14 @@ std::thread::id TVPMainThreadID;
 static tTJSCriticalSection _NoMemCallBackCS;
 static void *_reservedMem = malloc(1024 * 1024 * 4); // 4M reserved mem
 static bool _project_startup = false;
+
+static bool TVPProcessMessagesProfileEnabled() {
+    static const bool enabled = [] {
+        const char *value = std::getenv("AETHERKIRI_PROCESS_MESSAGES_PROFILE");
+        return value && *value && std::strcmp(value, "0") != 0;
+    }();
+    return enabled;
+}
 
 static void _do_compact() { TVPDeliverCompactEvent(TVP_COMPACT_LEVEL_MAX); }
 
@@ -708,11 +717,16 @@ void tTVPApplication::Run() {
 }
 
 void tTVPApplication::ProcessMessages() {
+    const bool profileEnabled = TVPProcessMessagesProfileEnabled();
+    const auto profileStarted = profileEnabled
+        ? std::chrono::steady_clock::now()
+        : std::chrono::steady_clock::time_point{};
     size_t remaining = 0;
     {
         std::lock_guard<std::mutex> cs(m_msgQueueLock);
         remaining = m_lstUserMsg.size();
     }
+    const size_t queued = remaining;
 #if defined(__ANDROID__)
     TVPAndroidAppLogf("Application::ProcessMessages begin queued=%zu", remaining);
 #endif
@@ -731,6 +745,9 @@ void tTVPApplication::ProcessMessages() {
             m_lstUserMsg.pop_front();
         }
         if(msg) {
+            const auto messageStarted = profileEnabled
+                ? std::chrono::steady_clock::now()
+                : std::chrono::steady_clock::time_point{};
 #if defined(__ANDROID__)
             if(TVPAndroidAppTraceEnabled()) {
                 __android_log_print(ANDROID_LOG_INFO, "krkr2",
@@ -739,6 +756,18 @@ void tTVPApplication::ProcessMessages() {
             }
 #endif
             msg();
+            if(profileEnabled) {
+                const double elapsedMs = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - messageStarted).count();
+                if(elapsedMs >= 1.0) {
+                    if(const auto logger = spdlog::get("core")) {
+                        logger->info(
+                            "application user message profile: index={} id={} "
+                            "host={} elapsed_ms={:.3f}",
+                            processed, msg_id, msg_host, elapsedMs);
+                    }
+                }
+            }
 #if defined(__ANDROID__)
             if(TVPAndroidAppTraceEnabled()) {
                 __android_log_print(ANDROID_LOG_INFO, "krkr2",
@@ -753,6 +782,18 @@ void tTVPApplication::ProcessMessages() {
     TVPAndroidAppLog("Application::ProcessMessages before ProgressAllTimer");
 #endif
     TVPTimer::ProgressAllTimer();
+    if(profileEnabled) {
+        const double elapsedMs = std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - profileStarted).count();
+        if(elapsedMs >= 5.0 || processed > 0) {
+            if(const auto logger = spdlog::get("core")) {
+                logger->info(
+                    "application process messages profile: queued={} "
+                    "processed={} elapsed_ms={:.3f}",
+                    queued, processed, elapsedMs);
+            }
+        }
+    }
 #if defined(__ANDROID__)
     TVPAndroidAppLog("Application::ProcessMessages after ProgressAllTimer");
 #endif

--- a/cpp/core/visual/GraphicsLoaderIntf.cpp
+++ b/cpp/core/visual/GraphicsLoaderIntf.cpp
@@ -2689,8 +2689,11 @@ void TVPSetGraphicCacheLimit(tjs_uint64 limit) {
         TVPGraphicCacheEnabled = true;
     }
 
-    if(TVPGraphicCacheLimit > 256 * 1024 * 1024)
-        TVPGraphicCacheLimit = 256 * 1024 * 1024;
+    // TVPGraphicCacheSystemLimit carries the renderer-specific safety cap.
+    // Godot Native may use up to 1GB on desktop to keep decoded GPU uploads
+    // hot; legacy renderers are still limited to their historical 256MB.
+    if(TVPGraphicCacheLimit > TVPGraphicCacheSystemLimit)
+        TVPGraphicCacheLimit = TVPGraphicCacheSystemLimit;
 
     TVPCheckGraphicCacheLimit();
 }

--- a/cpp/core/visual/godot/GodotRenderManager.cpp
+++ b/cpp/core/visual/godot/GodotRenderManager.cpp
@@ -539,6 +539,7 @@ GodotTexture2D::GodotTexture2D(const void *pixel, int pitch, unsigned int w,
         MarkTransparentKnown();
     }
     MarkCpuDirty();
+    cpu_pixels_known_zero_ = pixel == nullptr;
 }
 
 GodotTexture2D::~GodotTexture2D() { ReleaseGpuHandle(); }
@@ -596,8 +597,12 @@ void GodotTexture2D::MarkOpaqueKnown() {
 void GodotTexture2D::CreateGpuHandle(const void *pixel, int pitch) {
     const auto *bridge = TVPGodotGpuBridgeGet();
     if (bridge == nullptr || bridge->create_rgba == nullptr) return;
-    const void *src = pixel != nullptr ? pixel :
-        (pixels_.empty() ? nullptr : pixels_.data());
+    const void *src = pixel != nullptr
+        ? pixel
+        : ((format_ == TVPTextureFormat::RGBA && cpu_pixels_known_zero_) ||
+                   pixels_.empty()
+               ? nullptr
+               : pixels_.data());
     uint32_t stride = static_cast<uint32_t>(
         pixel != nullptr && pitch > 0 ? pitch : pitch_);
     std::vector<uint32_t> expanded_gray;
@@ -625,6 +630,7 @@ void GodotTexture2D::CreateGpuHandle(const void *pixel, int pitch) {
     }
     gpu_dirty_ = false;
     cpu_dirty_ = false;
+    cpu_pixels_known_zero_ = false;
     if(format_ == TVPTextureFormat::RGBA && !retain_cpu_shadow_)
         DiscardCpuStorage();
 }
@@ -744,6 +750,7 @@ void GodotTexture2D::EnsureCpuReadable() {
                 }
             }
             gpu_dirty_ = false;
+            cpu_pixels_known_zero_ = false;
         }
         return;
     }
@@ -751,6 +758,7 @@ void GodotTexture2D::EnsureCpuReadable() {
         bridge->read_rgba(gpu_handle_, pixels_.data(), pixels_.size(),
                           static_cast<uint32_t>(pitch_))) {
         gpu_dirty_ = false;
+        cpu_pixels_known_zero_ = false;
     }
 }
 
@@ -859,6 +867,7 @@ void GodotTexture2D::SetSize(unsigned int w, unsigned int h) {
     pixels_.assign(static_cast<size_t>(pitch_) * h, 0);
     MarkTransparentKnown();
     MarkCpuDirty();
+    cpu_pixels_known_zero_ = true;
 }
 
 bool GodotTexture2D::ClearGpu(uint32_t rgba, const tTVPRect &rc) {

--- a/cpp/core/visual/godot/GodotRenderManager.h
+++ b/cpp/core/visual/godot/GodotRenderManager.h
@@ -129,7 +129,11 @@ public:
     bool UploadCpuToGpu(bool flush_pending_gpu_writes = true);
     bool UpdateGpuRgba(const void *pixels, uint32_t stride_bytes);
     void MarkGpuDirty() { gpu_dirty_ = true; }
-    void MarkCpuDirty() { cpu_dirty_ = true; gpu_dirty_ = false; }
+    void MarkCpuDirty() {
+        cpu_dirty_ = true;
+        gpu_dirty_ = false;
+        cpu_pixels_known_zero_ = false;
+    }
     void EnsureCpuReadable();
 
 private:
@@ -153,6 +157,11 @@ private:
     bool cpu_composite_target_ = false;
     bool retain_cpu_shadow_ = false;
     bool discard_unwritten_on_partial_update_ = false;
+    // Fresh render targets are initialized to transparent black. Preserve
+    // that fact until the first CPU write so the Godot bridge can allocate
+    // and clear the GPU image without packing and uploading a multi-megabyte
+    // zero-filled staging buffer.
+    bool cpu_pixels_known_zero_ = false;
 };
 
 class GodotRenderManager final : public iTVPRenderManager {

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -199,10 +199,21 @@ namespace {
             if(level < TVP_COMPACT_LEVEL_MINIMIZE) {
                 return;
             }
-            // Drop only process-level warm-cache ownership. Active players
-            // retain their own shared_ptrs until the current frame finishes.
-            clearSharedMotionSourceBitmapCache();
-            motion::ResourceManager::trimStaticStateForMemoryPressure();
+            // A MINIMIZE compaction is a reclaim hint, not a host-session
+            // boundary. Dropping the process-level Motion caches here makes
+            // the next scene transition synchronously reparse its PSB and
+            // decode every source again on the script thread. That is exactly
+            // the multi-hundred-millisecond hitch seen when a new
+            // MotionResourceManager is created during an EnvObjectWorld
+            // transition. Both caches already have bounded policies (the
+            // source bitmap cache is capped at 256 MiB and the warm module
+            // cache keeps only a small number of modules), so retain them for
+            // ordinary pressure notifications and release them only for the
+            // explicit MAX compaction level.
+            if(level >= TVP_COMPACT_LEVEL_MAX) {
+                clearSharedMotionSourceBitmapCache();
+                motion::ResourceManager::trimStaticStateForMemoryPressure();
+            }
         }
     };
 

--- a/cpp/plugins/motionplayer/ResourceManager.cpp
+++ b/cpp/plugins/motionplayer/ResourceManager.cpp
@@ -489,6 +489,12 @@ void motion::ResourceManager::resetStaticStateForHostSession() {
 }
 
 void motion::ResourceManager::trimStaticStateForMemoryPressure() {
+    // Called only from the strongest (MAX) compaction level. A normal
+    // MINIMIZE notification must not discard parsed Motion modules: scene
+    // transitions routinely create short-lived ResourceManager wrappers, and
+    // reparsing the same PSB on the application thread produces visible
+    // frame spikes. The explicit MAX path remains available to release every
+    // process-level warm module when the host really needs all caches gone.
     clearWarmMotionModuleCache();
 }
 

--- a/cpp/plugins/textrender.cpp
+++ b/cpp/plugins/textrender.cpp
@@ -1217,6 +1217,16 @@ bool TextRenderBase::render(tTJSString text, int autoIndent, int diff, int all,
         if (!m_options.ignoreDelay) synchronizeTiming(value);
         break;
       }
+      case 'n': {
+        // KAGEX/krkrz-compatible logical line break: %n[lines];.
+        int lines = 0;
+        read_integer(text, i, lines);
+        if (lines == 0) lines = 1;
+        flush();
+        performLinebreak();
+        for (int line = 0; line < lines; ++line) performLinebreak();
+        break;
+      }
       case 'r': m_state = m_default; m_fontDirty = true; break;
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {

--- a/tests/unit-tests/plugins/godot-texture.cpp
+++ b/tests/unit-tests/plugins/godot-texture.cpp
@@ -43,13 +43,15 @@ int g_last_blend_opacity = 0;
 uint64_t g_next_texture_handle = 1;
 uint64_t g_next_readback_handle = 101;
 uint64_t g_last_discarded_readback = 0;
+bool g_last_create_pixels_were_null = false;
 bool g_readback_ready = false;
 bool g_reject_batch = false;
 bool g_throw_batch_end = false;
 uint64_t g_last_batch_token = 0;
 std::vector<GpuCall> g_gpu_calls;
 
-uint64_t CreateTestTexture(uint32_t, uint32_t, const void *, uint32_t) {
+uint64_t CreateTestTexture(uint32_t, uint32_t, const void *pixels, uint32_t) {
+    g_last_create_pixels_were_null = pixels == nullptr;
     return g_next_texture_handle++;
 }
 
@@ -153,6 +155,7 @@ public:
         g_next_texture_handle = 1;
         g_next_readback_handle = 101;
         g_last_discarded_readback = 0;
+        g_last_create_pixels_were_null = false;
         g_readback_ready = false;
         g_reject_batch = false;
         g_throw_batch_end = false;
@@ -322,6 +325,24 @@ TEST_CASE("Godot textures expose asynchronous GPU readback") {
 
     texture.DiscardGpuReadback(request);
     CHECK(g_last_discarded_readback == request);
+}
+
+TEST_CASE("Godot textures skip zero-filled RGBA staging uploads") {
+    TestGpuBridge bridge;
+
+    GodotTexture2D empty_rgba(nullptr, 0, 8, 8, TVPTextureFormat::RGBA);
+    REQUIRE(empty_rgba.EnsureGpuHandle());
+    CHECK(g_last_create_pixels_were_null);
+
+    const std::array<std::uint8_t, 4> initialized_pixel = {1, 2, 3, 4};
+    GodotTexture2D initialized_rgba(initialized_pixel.data(), 4, 1, 1,
+                                    TVPTextureFormat::RGBA);
+    REQUIRE(initialized_rgba.EnsureGpuHandle());
+    CHECK_FALSE(g_last_create_pixels_were_null);
+
+    GodotTexture2D empty_gray(nullptr, 0, 1, 1, TVPTextureFormat::Gray);
+    REQUIRE(empty_gray.EnsureGpuHandle());
+    CHECK_FALSE(g_last_create_pixels_were_null);
 }
 
 TEST_CASE("Godot nearest scaled alpha uses the software sampler") {


### PR DESCRIPTION
## Summary

- Batch the full engine application step before presentation so story events do not create repeated render-thread submit/fence boundaries.
- Track non-live GPU hazards by exact RID and keep conservative ordering for imported Apple/Android textures.
- Replace large RGBA surfaces by a fresh RID with queued retirement, and use device-side clears for zero-filled render targets.
- Raise the native desktop graphic-cache limit and enlarge the resource path hash table to reduce repeated story asset lookup and decode work.
- Add regression coverage for zero-initialized and normal Godot texture staging paths.

## Validation

- `./build.sh macos debug`
- `./build.sh macos release --jobs=4`
- macOS Godot smoke test: passed
- CI-style native contract suite: 223/223 passed
- Focused GPU/texture/barrier tests: 31/31 passed
- Standard Debug CTest: 181 runnable tests passed; 4 repository `*_NOT_BUILT` placeholders remain unavailable
- Before/after story screenshots were visually checked and had identical SHA256 hashes

AI assistance was used for implementation and validation.

## Cross-repository dependency

- AetherInternal companion PR: https://github.com/AetherKiri/AetherInternal/pull/39
- Public gitlink: `24d217889f8f76a7f54dcef51d7ddf97025d3ac4`

The public diff contains only the gitlink; private source remains in AetherInternal.
