### PR TITLE
fix: restore Live2D playback, gallery input and game rendering

### DIFF
--- a/apps/godot_app/scripts/game_metadata.gd
+++ b/apps/godot_app/scripts/game_metadata.gd
@@ -81,20 +81,30 @@ static func _first_file(root: String, extensions: Array) -> String:
     var dir := DirAccess.open(root)
     if dir == null:
         return ""
-    var fallback := ""
+    var executable_fallback := ""
+    var archive_fallback := ""
     dir.list_dir_begin()
     var entry := dir.get_next()
     while not entry.is_empty():
         if not dir.current_is_dir():
             var lower := entry.to_lower()
             if extensions.has("." + lower.get_extension()):
-                if lower.ends_with(".exe"):
+                # A KiriKiri Windows executable is not a readable storage
+                # file on macOS/iOS. Prefer the game's data archive whenever
+                # both a launcher and an XP3 archive are present.
+                if lower == "data.xp3":
+                    dir.list_dir_end()
                     return entry
-                if fallback.is_empty():
-                    fallback = entry
+                if lower.ends_with(".xp3"):
+                    if archive_fallback.is_empty():
+                        archive_fallback = entry
+                elif executable_fallback.is_empty():
+                    executable_fallback = entry
         entry = dir.get_next()
     dir.list_dir_end()
-    return fallback
+    if not archive_fallback.is_empty():
+        return archive_fallback
+    return executable_fallback
 
 static func _has_prefix(values: PackedStringArray, prefix: String) -> bool:
     for value in values:

--- a/apps/godot_app/scripts/game_metadata_test.gd
+++ b/apps/godot_app/scripts/game_metadata_test.gd
@@ -35,7 +35,13 @@ func _init() -> void:
     _write(kirikiri_root.path_join("system.ini"), "[Game]\nBOOT = startup.tjs\n")
     var kirikiri := GameMetadata.inspect(kirikiri_root)
     _expect_equal(String(kirikiri.engine), "kirikiri", "KiriKiri remains default")
-    _expect_equal(String(kirikiri.launchFile), "game.exe", "KiriKiri launcher retained")
+    _expect_equal(String(kirikiri.launchFile), "data.xp3", "KiriKiri archive preferred")
+
+    var exe_only_root := fixture_root.path_join("kirikiri_exe_only")
+    DirAccess.make_dir_recursive_absolute(exe_only_root)
+    _write(exe_only_root.path_join("game.exe"), "launcher")
+    var exe_only := GameMetadata.inspect(exe_only_root)
+    _expect_equal(String(exe_only.launchFile), "game.exe", "KiriKiri executable fallback")
 
     _remove_tree(fixture_root)
     if failures == 0:

--- a/cpp/core/base/StorageIntf.cpp
+++ b/cpp/core/base/StorageIntf.cpp
@@ -30,6 +30,7 @@
 #include "ncbind.hpp"
 #include "UtilStreams.h"
 #include "impl/ArchiveAutoPathOrder.h"
+#include "impl/GpuCompatScript.h"
 #include "spdlog/spdlog.h"
 
 #define TVP_DEFAULT_ARCHIVE_CACHE_NUM 128
@@ -39,26 +40,6 @@ static const tjs_char *TVP_AUTOPATH_CACHE_MISS_MARKER = TJS_W("\x01");
 static const char TVP_GFX_EFFECT_COMPAT_SCRIPT[] =
     "// AetherKiri gfxEffect.dll compatibility placeholder.\n"
     "try { Plugins.link(\"gfxEffect.dll\"); } catch(e) { }\n";
-static const char TVP_GPU_COMPAT_SCRIPT[] =
-    "// AetherKiri GPULayer/D3D compatibility placeholder.\n"
-    "try { Plugins.link(\"krkrgles.dll\"); } catch(e) { }\n"
-    "try { Plugins.link(\"krkrlive2d.dll\"); } catch(e) { }\n"
-    "try { Window.OGLDrawDevice = OGLDrawDevice; } catch(e) { }\n"
-    "try { Window.GLESAdaptor = GLESAdaptor; } catch(e) { }\n"
-    "function KAGWindow_createDrawDevice() {\n"
-    "    var dd = null;\n"
-    "    try { dd = new OGLDrawDevice(); } catch(e) { try { dd = new GLESAdaptor(); } catch(e2) { dd = null; } }\n"
-    "    try { if(dd !== null) dd.setScreenSize(this.width, this.height); } catch(e) { }\n"
-    "    try { this.gpuDrawDevice = dd; } catch(e) { }\n"
-    "    try { this.OGLDrawDevice = dd; } catch(e) { }\n"
-    "    try { this.GLESAdaptor = dd; } catch(e) { }\n"
-    "    try { return new global.Window.BasicDrawDevice(); } catch(e) { }\n"
-    "    try { return new global.Window.PassThroughDrawDevice(); } catch(e) { }\n"
-    "    return null;\n"
-    "}\n"
-    "try { KAGWindow.KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n"
-    "try { KAGWindow.prototype.KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n"
-    "try { KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n";
 static const char TVP_D3DEMOTE_COMPAT_PREFIX[] =
     "// AetherKiri D3DEmote/motion.tjs compatibility bridge.\n"
     "try { Plugins.link(\"emoteplayer.dll\"); } catch(e) { }\n";

--- a/cpp/core/base/impl/GpuCompatScript.h
+++ b/cpp/core/base/impl/GpuCompatScript.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Kept separately so the portable draw-device script contract can be tested
+// without starting a renderer or loading a game.
+inline constexpr char TVP_GPU_COMPAT_SCRIPT[] =
+    "// AetherKiri GPULayer/D3D compatibility placeholder.\n"
+    "try { Plugins.link(\"krkrgles.dll\"); } catch(e) { }\n"
+    "try { Plugins.link(\"krkrlive2d.dll\"); } catch(e) { }\n"
+    "try { Window.OGLDrawDevice = global.OGLDrawDevice; } catch(e) { }\n"
+    "try { Window.GLESAdaptor = global.GLESAdaptor; } catch(e) { }\n"
+    "function KAGWindow_createDrawDevice() {\n"
+    "    var dd = null;\n"
+    "    try { dd = new global.OGLDrawDevice(); } catch(e) { try { dd = new global.GLESAdaptor(); } catch(e2) { dd = null; } }\n"
+    "    try { if(dd !== null) dd.setScreenSize(this.width, this.height); } catch(e) { }\n"
+    "    try { this.gpuDrawDevice = dd; } catch(e) { }\n"
+    // Uppercase names are constructors used by script-owned lazy getters.
+    // Keep the instance in gpuDrawDevice and leave glesAdaptor to the script.
+    "    try { this.OGLDrawDevice = global.OGLDrawDevice; } catch(e) { }\n"
+    "    try { this.GLESAdaptor = global.GLESAdaptor; } catch(e) { }\n"
+    "    try { return new global.Window.BasicDrawDevice(); } catch(e) { }\n"
+    "    try { return new global.Window.PassThroughDrawDevice(); } catch(e) { }\n"
+    "    return null;\n"
+    "}\n"
+    "try { KAGWindow.KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n"
+    "try { KAGWindow.prototype.KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n"
+    "try { KAGWindow_createDrawDevice = KAGWindow_createDrawDevice; } catch(e) { }\n";

--- a/cpp/core/visual/LayerManager.cpp
+++ b/cpp/core/visual/LayerManager.cpp
@@ -1041,6 +1041,9 @@ void tTVPLayerManager::DetachPrimary() {
         NotifyPart(Primary);
         Primary = nullptr;
     }
+    // Preserve the active-gesture marker: an ensuing release must not target
+    // a replacement primary tree, but must not retain the detached tree either.
+    LeftPointerDownOwner.Clear();
 }
 //---------------------------------------------------------------------------
 bool tTVPLayerManager::GetPrimaryLayerSize(tjs_int &w, tjs_int &h) const {
@@ -1446,6 +1449,12 @@ bool tTVPLayerManager::IsTitleMenuControlPoint(tjs_int x, tjs_int y) {
     return left_title_controls || right_title_controls || far_right_switcher;
 }
 
+bool tTVPLayerManager::IsLeftPointerGestureTarget(tTJSNI_BaseLayer *layer) const {
+    return !LeftPointerGestureActive ||
+        (layer && LeftPointerDownOwner.Type() == tvtObject &&
+         layer->GetOwnerNoAddRef() == LeftPointerDownOwner.AsObjectNoAddRef());
+}
+
 void tTVPLayerManager::PrimaryClick(tjs_int x, tjs_int y) {
     if(SuppressCurrentTitleMenuPointerGesture) {
         if(TVPInputTraceEnabled()) {
@@ -1459,6 +1468,14 @@ void tTVPLayerManager::PrimaryClick(tjs_int x, tjs_int y) {
     tTJSNI_BaseLayer *l = GetClickableLayerAt(x, y);
     TVPTraceLayerHit("click", x, y, l);
     TVPTraceLayersAt(this, "click-stack", x, y);
+    if(!IsLeftPointerGestureTarget(l)) {
+        if(TVPInputTraceEnabled()) {
+            spdlog::info(
+                "LayerManager suppress cross-layer gesture click primary=({}, {})",
+                x, y);
+        }
+        return;
+    }
     if(l /*&& CaptureOwner == l*/) {
         if(TVPIsCgPreviewPresentationLayer(l)) {
             if(TVPInputTraceEnabled()) {
@@ -1487,10 +1504,9 @@ void tTVPLayerManager::PrimaryClick(tjs_int x, tjs_int y) {
             // captured layer's onMouseUp handler.  PrimaryClick is delivered
             // before PrimaryMouseUp on the Godot host, so evaluating the
             // bound expression here as well toggles state twice (open, then
-            // immediately closed).  Only synthesize the click when the
-            // button appeared after mouse-down and therefore does not own the
-            // capture; that case has no matching button mouse-up to dispatch
-            // its expression.
+            // immediately closed). Only synthesize for click-only dispatch or
+            // the original button when it explicitly released capture. A
+            // button revealed by this gesture must not receive its release.
             if(CaptureOwner == l) {
                 if(TVPInputTraceEnabled()) {
                     spdlog::info(
@@ -1527,7 +1543,7 @@ void tTVPLayerManager::PrimaryClick(tjs_int x, tjs_int y) {
 void tTVPLayerManager::PrimaryDoubleClick(tjs_int x, tjs_int y) {
     tTJSNI_BaseLayer *l = GetClickableLayerAt(x, y);
     TVPTraceLayersAt(this, "double-click-stack", x, y);
-    if(l /*&& CaptureOwner == l*/) {
+    if(l && IsLeftPointerGestureTarget(l)) {
         l->FromPrimaryCoordinates(x, y);
         l->FireDoubleClick(x, y);
     }
@@ -1535,6 +1551,10 @@ void tTVPLayerManager::PrimaryDoubleClick(tjs_int x, tjs_int y) {
 //---------------------------------------------------------------------------
 void tTVPLayerManager::PrimaryMouseDown(tjs_int x, tjs_int y,
                                         tTVPMouseButton mb, tjs_uint32 flags) {
+    if(mb == mbLeft) {
+        LeftPointerGestureActive = true;
+        LeftPointerDownOwner.Clear();
+    }
     if(mb == mbLeft && !IsTitleMenuControlPoint(x, y)) {
         tTJSNI_BaseLayer *title_hit = GetClickableLayerAt(x, y);
         if(IsTitleMenuInputState(title_hit) &&
@@ -1559,6 +1579,9 @@ void tTVPLayerManager::PrimaryMouseDown(tjs_int x, tjs_int y,
     TVPTraceLayerHit("down", x, y, l);
     TVPTraceLayersAt(this, "down-stack", x, y);
     SuppressCurrentTitleMenuPointerGesture = false;
+    if(mb == mbLeft && l) {
+        LeftPointerDownOwner = tTJSVariant(l->GetOwnerNoAddRef());
+    }
     if(l) {
         l->FromPrimaryCoordinates(x, y);
         ReleaseCaptureCalled = false;
@@ -1584,6 +1607,8 @@ void tTVPLayerManager::PrimaryMouseDown(tjs_int x, tjs_int y,
 void tTVPLayerManager::PrimaryMouseUp(tjs_int x, tjs_int y, tTVPMouseButton mb,
                                       tjs_uint32 flags) {
     if(mb == mbLeft && SuppressCurrentTitleMenuPointerGesture) {
+        LeftPointerGestureActive = false;
+        LeftPointerDownOwner.Clear();
         if(TVPInputTraceEnabled()) {
             spdlog::info(
                 "LayerManager suppress title repeat mouseup primary=({}, {})",
@@ -1599,6 +1624,29 @@ void tTVPLayerManager::PrimaryMouseUp(tjs_int x, tjs_int y, tTVPMouseButton mb,
         l = GetClickableLayerAt(x, y);
     TVPTraceLayerHit("up", x, y, l);
     TVPTraceLayersAt(this, "up-stack", x, y);
+
+    const bool matching_gesture =
+        mb != mbLeft || IsLeftPointerGestureTarget(l);
+    tTJSVariant pointer_down_owner;
+    if(mb == mbLeft) {
+        // Hold the owner through dispatch, but finish bookkeeping before a
+        // script handler can start another gesture or detach the layer tree.
+        pointer_down_owner = LeftPointerDownOwner;
+        LeftPointerDownOwner.Clear();
+        LeftPointerGestureActive = false;
+    }
+    if(!matching_gesture) {
+        if(TVPInputTraceEnabled()) {
+            spdlog::info(
+                "LayerManager suppress cross-layer gesture mouseup primary=({}, {})",
+                x, y);
+        }
+        if(!TVPIsAnyMouseButtonPressedInShiftStateFlags(flags)) {
+            ReleaseCapture();
+            PrimaryMouseMove(x, y, flags);
+        }
+        return;
+    }
 
     const int orig_x = x;
     const int orig_y = y;

--- a/cpp/core/visual/LayerManager.h
+++ b/cpp/core/visual/LayerManager.h
@@ -272,6 +272,12 @@ class tTVPLayerManager : public iTVPLayerManager, public tTVPDrawable {
                                     //!< for this layer manager
 
     tTJSNI_BaseLayer *CaptureOwner;
+    // Capture may be released by a page transition during onMouseDown. Keep
+    // the original gesture target alive until mouse-up so its release cannot
+    // activate a control on the newly revealed page.
+    bool LeftPointerGestureActive = false;
+    tTJSVariant LeftPointerDownOwner;
+    bool IsLeftPointerGestureTarget(tTJSNI_BaseLayer *layer) const;
     tTJSNI_BaseLayer *LastMouseMoveSent;
     std::vector<tTVPTouchCaptureLayer>
         TouchCapture; //!< 同時タッチ数は多くても10点程度なのでvectorで持つ(ほぼ1or2点)

--- a/cpp/core/visual/impl/DrawDeviceGLESModule.h
+++ b/cpp/core/visual/impl/DrawDeviceGLESModule.h
@@ -15,10 +15,21 @@ using CreateKrkrGLESModuleObjectFn = tjs_error (*)(tTJSVariant *, tjs_int, tjs_i
 using ModuleName = std::basic_string<tjs_char>;
 using ModuleStore = std::unordered_map<uintptr_t, std::unordered_map<ModuleName, tTJSVariant>>;
 
+#if defined(__APPLE__)
+extern "C" tjs_error TVPKrkrGLESCreateModuleObject(tTJSVariant *, tjs_int,
+                                                    tjs_int);
+#endif
+
 inline tjs_error TryCreateModuleViaKrkrGLES(tTJSVariant *result, tjs_int width,
                                             tjs_int height) {
 #if defined(_WIN32)
     return TJS_E_MEMBERNOTFOUND;
+#elif defined(__APPLE__)
+    // iOS statically links the compatibility plugin into the application.
+    // dlsym(RTLD_DEFAULT, ...) cannot discover symbols that are not exported
+    // from the final executable, so the old code silently selected the no-op
+    // module and skipped the capture callback used by Live2D games.
+    return TVPKrkrGLESCreateModuleObject(result, width, height);
 #else
     void *sym = dlsym(RTLD_DEFAULT, "TVPKrkrGLESCreateModuleObject");
     if(!sym) return TJS_E_MEMBERNOTFOUND;
@@ -257,12 +268,29 @@ inline void ClearCachedModulesForDevice(void *device) {
 inline void EnsureWindowGLESAdaptor(tTVPDrawDevice *device) {
     if(!device) return;
     iTVPWindow *window = device->GetWindowInterface();
-    if(!window) return;
+    // Legacy KAGWindow keeps its GPU draw device in the script-level
+    // KAGWindowBase class property. That object is a valid draw device but is
+    // not the native Window draw-device slot, so it has no iTVPWindow owner.
+    // The main window is the corresponding presentation target for this
+    // compatibility path; use it only as an owner fallback. Native devices
+    // still take their exact per-window binding above.
+    if(!window) {
+        window = TVPMainWindow;
+        if(!window) return;
+    }
     iTJSDispatch2 *windowObj = window->GetWindowDispatch();
     if(!windowObj) return;
 
     tTJSVariant adaptor;
-    windowObj->PropGet(0, TJS_W("glesAdaptor"), nullptr, &adaptor, windowObj);
+    try {
+        windowObj->PropGet(0, TJS_W("glesAdaptor"), nullptr, &adaptor,
+                           windowObj);
+    } catch(...) {
+        windowObj->Release();
+        throw;
+    }
+    // GetWindowDispatch returns an owned reference.
+    windowObj->Release();
 }
 
 template<typename DeviceT>

--- a/cpp/plugins/GlesCaptureUtils.h
+++ b/cpp/plugins/GlesCaptureUtils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "tjs.h"
+
+namespace aetherkiri::plugins::gles {
+
+inline bool IsCallable(const tTJSVariant *value) {
+    if(!value || value->Type() != tvtObject) return false;
+    const auto closure = value->AsObjectClosureNoAddRef();
+    return closure.Object &&
+           closure.IsInstanceOf(0, nullptr, nullptr, TJS_W("Function"),
+                                nullptr) == TJS_S_TRUE;
+}
+
+inline int CaptureCallbackIndex(tjs_int count, tTJSVariant **args) {
+    if(!args) return -1;
+    if(count > 0 && IsCallable(args[0])) return 0;
+    if(count > 1 && IsCallable(args[1])) return 1;
+    return -1;
+}
+
+// Native capture(targetLayer, callback, context, flags) invokes
+// callback(width, height, context). The target is the render destination,
+// not a callback argument. Also accept the callback-first convenience form.
+inline tjs_error InvokeCaptureCallback(tjs_int width, tjs_int height,
+                                       tjs_int count, tTJSVariant **args) {
+    const int index = CaptureCallbackIndex(count, args);
+    if(index < 0) return TJS_S_OK;
+    const auto callback = args[index]->AsObjectClosureNoAddRef();
+    tTJSVariant widthValue(width > 0 ? width : 1920);
+    tTJSVariant heightValue(height > 0 ? height : 1080);
+    tTJSVariant context;
+    if(count > index + 1 && args[index + 1]) context = *args[index + 1];
+    tTJSVariant *callbackArgs[] = {&widthValue, &heightValue, &context};
+    return callback.FuncCall(0, nullptr, nullptr, nullptr, 3, callbackArgs,
+                             nullptr);
+}
+
+} // namespace aetherkiri::plugins::gles

--- a/cpp/plugins/dummy_plugin_stubs.cpp
+++ b/cpp/plugins/dummy_plugin_stubs.cpp
@@ -4,6 +4,7 @@
 #include "LayerImpl.h"
 #include "BitmapIntf.h"
 #include "ScriptMgnIntf.h"
+#include "GlesCaptureUtils.h"
 #include "motionplayer/Player.h"
 
 #include <algorithm>
@@ -256,6 +257,16 @@ static bool GlesCompatGetObjectProperty(const tTJSVariant &object,
     iTJSDispatch2 *dispatch = object.AsObjectNoAddRef();
     return TJS_SUCCEEDED(dispatch->PropGet(
         TJS_IGNOREPROP, name, nullptr, &result, dispatch));
+}
+
+static bool GlesCompatGetDispatchProperty(iTJSDispatch2 *object,
+                                          const tjs_char *name,
+                                          tTJSVariant &result) {
+    result.Clear();
+    if(!object || !name)
+        return false;
+    return TJS_SUCCEEDED(object->PropGet(
+        TJS_IGNOREPROP, name, nullptr, &result, object));
 }
 
 static void GlesCompatSetObjectProperty(iTJSDispatch2 *object,
@@ -523,9 +534,23 @@ static iTJSDispatch2 *GlesCompatResolveLayerDispatch(const tTJSVariant &value,
     if(depth > 4 || value.Type() != tvtObject || !value.AsObjectNoAddRef())
         return nullptr;
 
-    iTJSDispatch2 *object = value.AsObjectNoAddRef();
-    if(GlesCompatIsLayerDispatch(object))
-        return object;
+    iTJSDispatch2 *base = value.AsObjectNoAddRef();
+    const auto closure = value.AsObjectClosureNoAddRef();
+    iTJSDispatch2 *candidates[] = {
+        base,
+        closure.ObjThis,
+        closure.Object,
+        nullptr,
+    };
+
+    // A TJS object-valued argument is a closure, not necessarily a bare
+    // dispatch. On some hosts Layer is carried by ObjThis while Object is the
+    // method/function dispatch. Checking only AsObjectNoAddRef() therefore
+    // makes layer discovery dependent on the platform's closure layout.
+    for(auto *candidate : candidates) {
+        if(GlesCompatIsLayerDispatch(candidate))
+            return candidate;
+    }
 
     static const tjs_char *kExplicitLayerProps[] = {
         TJS_W("targetLayer"), TJS_W("_targetLayer"),
@@ -539,15 +564,22 @@ static iTJSDispatch2 *GlesCompatResolveLayerDispatch(const tTJSVariant &value,
     };
 
     auto tryProps = [&](const tjs_char *const *props) -> iTJSDispatch2 * {
-        for(int i = 0; props[i]; ++i) {
-            tTJSVariant prop;
-            if(!GlesCompatGetObjectProperty(value, props[i], prop) ||
-               prop.Type() != tvtObject || !prop.AsObjectNoAddRef() ||
-               prop.AsObjectNoAddRef() == object) {
+        for(auto *candidate : candidates) {
+            if(!candidate)
                 continue;
+            for(int i = 0; props[i]; ++i) {
+                tTJSVariant prop;
+                if(!GlesCompatGetDispatchProperty(candidate, props[i], prop) ||
+                   prop.Type() != tvtObject || !prop.AsObjectNoAddRef() ||
+                   prop.AsObjectNoAddRef() == candidate ||
+                   prop.AsObjectNoAddRef() == base) {
+                    continue;
+                }
+                if(auto *resolved =
+                       GlesCompatResolveLayerDispatch(prop, depth + 1)) {
+                    return resolved;
+                }
             }
-            if(auto *resolved = GlesCompatResolveLayerDispatch(prop, depth + 1))
-                return resolved;
         }
         return nullptr;
     };
@@ -926,23 +958,44 @@ static tjs_error GlesCompatRenderCb(tTJSVariant *result, tjs_int,
     return TJS_S_OK;
 }
 
+static int GlesCompatCaptureCallbackIndex(tjs_int numparams,
+                                          tTJSVariant **param) {
+    return aetherkiri::plugins::gles::CaptureCallbackIndex(numparams, param);
+}
+
+static tjs_error GlesCompatInvokeCaptureCallback(tjs_int width, tjs_int height,
+                                                 tjs_int numparams,
+                                                 tTJSVariant **param) {
+    return aetherkiri::plugins::gles::InvokeCaptureCallback(
+        width, height, numparams, param);
+}
+
 static tjs_error GlesCompatCaptureCb(tTJSVariant *result, tjs_int numparams,
                                      tTJSVariant **param,
                                      iTJSDispatch2 *objthis) {
     LogGlesCompatArgsOnce(TJS_W("capture"), numparams, param);
+    const tjs_error callbackResult = GlesCompatInvokeCaptureCallback(
+        1920, 1080, numparams, param);
+    if(TJS_FAILED(callbackResult)) return callbackResult;
     iTJSDispatch2 *layerDispatch = GlesCompatFindLayerInParams(numparams, param);
+    if(!layerDispatch)
+        layerDispatch = g_glesCompatRegisteredLayer;
     if(layerDispatch)
         g_glesCompatRegisteredLayer = layerDispatch;
 	    GlesCompatRegisterRenderable(
 	        numparams, param, reinterpret_cast<uintptr_t>(objthis),
 	        TJS_W("capture"));
 	    GlesCompatRenderMotionPlayers(TJS_W("capture"));
-	    if(layerDispatch)
-	        GlesCompatRenderGodotLive2D(layerDispatch);
-	    GlesCompatIncrementRenderCount(objthis);
+    if(layerDispatch)
+        GlesCompatRenderGodotLive2D(layerDispatch);
+    GlesCompatIncrementRenderCount(objthis);
     if(result) {
-        if(numparams > 0 && param && param[0])
-            *result = *param[0];
+        const int callbackIndex =
+            GlesCompatCaptureCallbackIndex(numparams, param);
+        const int targetIndex = callbackIndex == 0 ? 1 : 0;
+        if(targetIndex >= 0 && targetIndex < numparams && param &&
+           param[targetIndex])
+            *result = *param[targetIndex];
         else
             *result = true;
     }
@@ -1161,8 +1214,14 @@ public:
     static tjs_error captureCb(tTJSVariant *result, tjs_int numparams,
                                tTJSVariant **param, GLESAdaptor *self) {
         LogGlesCompatArgsOnce(TJS_W("adaptor.capture"), numparams, param);
+        const tjs_error callbackResult = GlesCompatInvokeCaptureCallback(
+            self ? self->screenWidth_ : 0,
+            self ? self->screenHeight_ : 0, numparams, param);
+        if(TJS_FAILED(callbackResult)) return callbackResult;
         iTJSDispatch2 *layerDispatch =
             GlesCompatFindLayerInParams(numparams, param);
+        if(!layerDispatch)
+            layerDispatch = g_glesCompatRegisteredLayer;
         if(layerDispatch)
             g_glesCompatRegisteredLayer = layerDispatch;
 	    GlesCompatRegisterRenderable(
@@ -1171,11 +1230,15 @@ public:
 	    GlesCompatRenderMotionPlayers(TJS_W("adaptor.capture"));
 	    if(layerDispatch)
 	        GlesCompatRenderGodotLive2D(layerDispatch);
-	    if(self)
-	        ++self->renderCount_;
+        if(self)
+            ++self->renderCount_;
         if(result) {
-            if(numparams > 0 && param && param[0])
-                *result = *param[0];
+            const int callbackIndex =
+                GlesCompatCaptureCallbackIndex(numparams, param);
+            const int targetIndex = callbackIndex == 0 ? 1 : 0;
+            if(targetIndex >= 0 && targetIndex < numparams && param &&
+               param[targetIndex])
+                *result = *param[targetIndex];
             else
                 *result = true;
         }
@@ -1429,12 +1492,6 @@ NCB_REGISTER_CLASS(OGLDrawDevice) {
     NCB_METHOD_RAW_CALLBACK(finalize, &OGLDrawDevice::finalizeCb, 0);
 }
 
-static tjs_error GlesCompatDrawDeviceGetModuleCb(tTJSVariant *result,
-                                                 tjs_int, tTJSVariant **,
-                                                 iTJSDispatch2 *) {
-    return CreateGlesCompatModule(result, 0, 0);
-}
-
 static void GlesCompatPostRegist() {
     try {
         TVPExecuteExpression(
@@ -1460,12 +1517,10 @@ static void GlesCompatPreUnregist() {
 NCB_POST_REGIST_CALLBACK(GlesCompatPostRegist);
 NCB_PRE_UNREGIST_CALLBACK(GlesCompatPreUnregist);
 
-NCB_ATTACH_FUNCTION_WITHTAG(getModule, WindowPassThroughDrawDeviceGlesCompat,
-                            Window.PassThroughDrawDevice,
-                            GlesCompatDrawDeviceGetModuleCb);
-NCB_ATTACH_FUNCTION_WITHTAG(getModule, WindowBasicDrawDeviceGlesCompat,
-                            Window.BasicDrawDevice,
-                            GlesCompatDrawDeviceGetModuleCb);
+// BasicDrawDevice/PassThroughDrawDevice own getModule. Their implementation
+// initializes the owning window's GLES adaptor before creating the module.
+// Replacing it here skips that lifecycle step, so script glesCapture returns
+// void and never submits a frame.
 #endif
 
 #undef NCB_MODULE_NAME

--- a/cpp/plugins/krkrgles.cpp
+++ b/cpp/plugins/krkrgles.cpp
@@ -7,6 +7,7 @@
 #include "EventIntf.h"
 #include "WindowIntf.h"
 #include "ScriptAliasUtils.h"
+#include "GlesCaptureUtils.h"
 #include "motionplayer/Player.h"
 #include <spdlog/spdlog.h>
 #include <algorithm>
@@ -147,11 +148,11 @@ static bool InstallDrawDeviceScriptAliases() {
                 installed = aetherkiri::plugins::EnsureGlobalObjectMember(
                                 target, TJS_W("gpuDrawDevice"), gpuDevice) ||
                             installed;
-                installed = aetherkiri::plugins::EnsureGlobalObjectMember(
-                                target, TJS_W("OGLDrawDevice"), gpuDevice) ||
+                installed = ForceMirrorGlobalToMember(
+                                target, TJS_W("OGLDrawDevice")) ||
                             installed;
-                installed = aetherkiri::plugins::EnsureGlobalObjectMember(
-                                target, TJS_W("GLESAdaptor"), gpuDevice) ||
+                installed = ForceMirrorGlobalToMember(
+                                target, TJS_W("GLESAdaptor")) ||
                             installed;
             }
         }
@@ -1890,19 +1891,13 @@ static void InvokeLoadIfPresent(tTJSVariant &obj, tjs_int n, tTJSVariant **p,
 // ---------------------------------------------------------------------------
 // Capture-callback invoker (capture → callback → render → copyLayer)
 // ---------------------------------------------------------------------------
+static int CaptureCallbackIndex(tjs_int n, tTJSVariant **p) {
+    return aetherkiri::plugins::gles::CaptureCallbackIndex(n, p);
+}
+
 static tjs_error InvokeCaptureCallback(const char *tag, tjs_int w, tjs_int h,
                                        tjs_int n, tTJSVariant **p) {
-    if (n <= 1 || !p || !p[1] || p[1]->Type() != tvtObject) return TJS_S_OK;
-    tTJSVariantClosure cb = p[1]->AsObjectClosureNoAddRef();
-    if (!cb.Object) return TJS_S_OK;
-    tTJSVariant target;
-    if (n > 0 && p[0]) target = *p[0];
-    tTJSVariant wv(w), hv(h), uv, fv;
-    if (n > 2 && p[2]) uv = *p[2];
-    if (n > 3 && p[3]) fv = *p[3];
-    tTJSVariant *args[] = { &target, &wv, &hv, &uv, &fv };
-    tjs_int argc = (n > 3) ? 5 : 4;
-    return cb.FuncCall(0, nullptr, nullptr, nullptr, argc, args, nullptr);
+    return aetherkiri::plugins::gles::InvokeCaptureCallback(w, h, n, p);
 }
 
 // ---------------------------------------------------------------------------
@@ -2103,8 +2098,12 @@ public:
     static tjs_error captureCb(tTJSVariant *r, tjs_int n, tTJSVariant **p, GLESModule *s) {
         tjs_int w = NormalizeExtent(s ? s->screenWidth_ : 0, 1920);
         tjs_int h = NormalizeExtent(s ? s->screenHeight_ : 0, 1080);
-        InvokeCaptureCallback("GLESModule.capture", w, h, n, p);
-        if (r) *r = (n > 0 && p) ? *p[0] : tTJSVariant(true);
+        const tjs_error er = InvokeCaptureCallback("GLESModule.capture", w, h, n, p);
+        if (TJS_FAILED(er)) return er;
+        const int callbackIndex = CaptureCallbackIndex(n, p);
+        const int targetIndex = callbackIndex == 0 ? 1 : 0;
+        if (r) *r = (targetIndex >= 0 && targetIndex < n && p && p[targetIndex])
+                       ? *p[targetIndex] : tTJSVariant(true);
         return TJS_S_OK;
     }
 
@@ -2225,32 +2224,6 @@ extern "C" tjs_error TVPKrkrGLESCreateModuleObject(tTJSVariant *result,
 }
 
 // ---------------------------------------------------------------------------
-// DrawDevice getModule callback
-// ---------------------------------------------------------------------------
-static tjs_error DrawDeviceGetModuleCb(tTJSVariant *r, tjs_int n, tTJSVariant **p,
-                                       iTJSDispatch2 *objthis) {
-    static std::unordered_map<uintptr_t, std::unordered_map<ModuleName, tTJSVariant>> s_mod;
-    const ModuleName mn = NormalizeModuleName(n, p);
-    const uintptr_t key = reinterpret_cast<uintptr_t>(objthis);
-    if (key) {
-        auto dit = s_mod.find(key);
-        if (dit != s_mod.end()) {
-            auto mit = dit->second.find(mn);
-            if (mit != dit->second.end() && mit->second.Type() == tvtObject &&
-                mit->second.AsObjectNoAddRef())
-            { if (r) *r = mit->second; return TJS_S_OK; }
-        }
-    }
-    tTJSVariant created;
-    tjs_error er = CreateModuleObject(&created);
-    if (TJS_FAILED(er)) { if (r) r->Clear(); return er; }
-    if (key && created.Type() == tvtObject && created.AsObjectNoAddRef())
-        s_mod[key][mn] = created;
-    if (r) *r = created;
-    return TJS_S_OK;
-}
-
-// ---------------------------------------------------------------------------
 // GLESAdaptor — per-window adaptor that proxies to the module
 // ---------------------------------------------------------------------------
 class GLESAdaptor {
@@ -2328,8 +2301,12 @@ public:
     static tjs_error captureCb(tTJSVariant *r, tjs_int n, tTJSVariant **p, GLESAdaptor *s) {
         tjs_int w = NormalizeExtent(s ? s->screenWidth_ : 0, 1920);
         tjs_int h = NormalizeExtent(s ? s->screenHeight_ : 0, 1080);
-        InvokeCaptureCallback("GLESAdaptor.capture", w, h, n, p);
-        if (r) *r = (n > 0 && p) ? *p[0] : tTJSVariant(true);
+        const tjs_error er = InvokeCaptureCallback("GLESAdaptor.capture", w, h, n, p);
+        if (TJS_FAILED(er)) return er;
+        const int callbackIndex = CaptureCallbackIndex(n, p);
+        const int targetIndex = callbackIndex == 0 ? 1 : 0;
+        if (r) *r = (targetIndex >= 0 && targetIndex < n && p && p[targetIndex])
+                       ? *p[targetIndex] : tTJSVariant(true);
         return TJS_S_OK;
     }
 
@@ -2657,10 +2634,7 @@ NCB_REGISTER_CLASS(OGLDrawDevice) {
     NCB_METHOD_RAW_CALLBACK(finalize, &OGLDrawDevice::finalizeCb, 0);
 }
 
-NCB_ATTACH_FUNCTION_WITHTAG(getModule, WindowPassThroughDrawDevice,
-                            Window.PassThroughDrawDevice, DrawDeviceGetModuleCb);
-NCB_ATTACH_FUNCTION_WITHTAG(getModule, WindowBasicDrawDevice,
-                            Window.BasicDrawDevice, DrawDeviceGetModuleCb);
+// Keep the built-in draw devices' getModule lifecycle and module cache.
 
 extern "C" void TVPRegisterKrkrGLESPluginAnchor() {
     ncbAutoRegister::RegisterInternalPluginEntry(

--- a/cpp/plugins/motionplayer/Player.h
+++ b/cpp/plugins/motionplayer/Player.h
@@ -717,6 +717,11 @@ namespace motion {
         bool _autoProgressHasLastTick = false;
         bool _autoProgressRegistered = false;
         bool _autoProgressRendering = false;
+        // A selector hover clears the retained target before repainting it.
+        // Do not let the normal raster throttle drop that repaint, or the
+        // cleared target can be presented as a one-frame black/transparent
+        // flash while the pointer moves between buttons.
+        bool _forceMotionRasterRender = false;
         tTJSVariant _presentationHoldLayer;
         tjs_uint64 _presentationHoldUntilTick = 0;
         tjs_uint64 _presentationHoldLastTick = 0;

--- a/cpp/plugins/motionplayer/PlayerQuery.cpp
+++ b/cpp/plugins/motionplayer/PlayerQuery.cpp
@@ -2746,6 +2746,9 @@ namespace motion {
                     target = tryResolveLayerDispatch(targetValue);
                 }
                 if(target) {
+                    const bool previousForceRasterRender =
+                        renderOwner->_forceMotionRasterRender;
+                    renderOwner->_forceMotionRasterRender = true;
                     renderOwner->_autoProgressRendering = true;
                     try {
                         // The normal selector frame may be translucent. Clear
@@ -2789,6 +2792,8 @@ namespace motion {
                                 variableKey);
                         }
                     }
+                    renderOwner->_forceMotionRasterRender =
+                        previousForceRasterRender;
                     renderOwner->_autoProgressRendering = false;
                 }
             }

--- a/cpp/plugins/motionplayer/PlayerRender.cpp
+++ b/cpp/plugins/motionplayer/PlayerRender.cpp
@@ -8748,8 +8748,17 @@ namespace motion {
             }
             return false;
         }
-        TVPGodotGpuBatchScope gpuBatch(
-            _runtime->isEmoteMode && _runtime->renderCommands.size() > 1);
+        // A selector hover can call renderToLayer directly from the input
+        // event, before Window::UpdateContent has opened its outer batch.  If
+        // this scope is restricted to E-mote, every PSB button draw is
+        // submitted as a separate Godot GPU transaction; on the title page
+        // that turns a harmless 15-command repaint into a visible stall and
+        // can expose the cleared intermediate surface for one frame.  The
+        // bridge preserves ordering and handles nested scopes, so batch every
+        // multi-command motion render here (it is a no-op on non-Godot
+        // backends).  This keeps the clear + all compositing operations
+        // atomic from the host presenter's point of view.
+        TVPGodotGpuBatchScope gpuBatch(_runtime->renderCommands.size() > 1);
 
         // The same evaluated command list can be submitted through
         // renderToLayer, SeparateLayerAdaptor, and D3DAdaptor during a KAG
@@ -12615,7 +12624,8 @@ namespace motion {
             rasterNowUs - _runtime->lastMotionRasterPublishUs <
                 rasterThrottleUs;
         auto *cachedRasterLayer = resolveNativeLayer(renderLayerObject);
-        if(!_runtime->isEmoteMode && !skipUpdate && rasterThrottleUs != 0 &&
+        if(!_forceMotionRasterRender && !_runtime->isEmoteMode && !skipUpdate &&
+           rasterThrottleUs != 0 &&
            sameRasterTarget && cachedRasterLayer &&
            cachedRasterLayer->GetHasImage()) {
             _runtime->lastCanvas =

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -53,3 +53,10 @@ if(AETHERKIRI_INTERNAL_ENABLED AND COMMAND aetherinternal_extend_krkr2plugin_tes
 endif()
 
 catch_discover_tests(motionplayer-dll)
+
+# Isolate registration-order tests from the shared plugin world used by the
+# larger suite: these deliberately load and unload the graphics module.
+add_executable(gles-load-order main.cpp gles-load-order.cpp)
+target_link_libraries(gles-load-order PRIVATE Catch2::Catch2 krkr2core
+    ${_KRKR2PLUGIN_LINK_ITEM})
+catch_discover_tests(gles-load-order)

--- a/tests/unit-tests/plugins/CMakeLists.txt
+++ b/tests/unit-tests/plugins/CMakeLists.txt
@@ -60,3 +60,8 @@ add_executable(gles-load-order main.cpp gles-load-order.cpp)
 target_link_libraries(gles-load-order PRIVATE Catch2::Catch2 krkr2core
     ${_KRKR2PLUGIN_LINK_ITEM})
 catch_discover_tests(gles-load-order)
+
+add_executable(layer-pointer-gesture main.cpp layer-pointer-gesture.cpp)
+target_link_libraries(layer-pointer-gesture PRIVATE Catch2::Catch2 krkr2core
+    ${_KRKR2PLUGIN_LINK_ITEM})
+catch_discover_tests(layer-pointer-gesture)

--- a/tests/unit-tests/plugins/gles-load-order.cpp
+++ b/tests/unit-tests/plugins/gles-load-order.cpp
@@ -1,0 +1,113 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "BasicDrawDevice.h"
+#include "ScriptMgnIntf.h"
+#include "WindowIntf.h"
+#include "ncbind.hpp"
+
+extern tTJS *TVPScriptEngine;
+
+namespace {
+class GlesRuntime {
+public:
+    GlesRuntime() {
+        TVPScriptEngine = new tTJS();
+        auto *window = TVPCreateNativeClass_Window();
+        auto *device = new tTJSNC_BasicDrawDevice();
+        tTJSVariant windowValue(window);
+        deviceClass = tTJSVariant(device);
+        window->Release();
+        device->Release();
+        window->PropSet(TJS_MEMBERENSURE | TJS_STATICMEMBER, TJS_W("BasicDrawDevice"), nullptr,
+                         &deviceClass, window);
+        window->PropSet(TJS_MEMBERENSURE | TJS_STATICMEMBER, TJS_W("PassThroughDrawDevice"), nullptr,
+                         &deviceClass, window);
+        auto *global = TVPScriptEngine->GetGlobalNoAddRef();
+        global->PropSet(TJS_MEMBERENSURE, TJS_W("Window"), nullptr,
+                         &windowValue, global);
+        ncbAutoRegister::AllRegist();
+    }
+    ~GlesRuntime() {
+        ncbAutoRegister::UnloadModule(TJS_W("krkrgles.dll"));
+        deviceClass.Clear();
+        TVPScriptEngine->Release();
+        TVPScriptEngine = nullptr;
+    }
+    tTJSVariant deviceClass;
+};
+
+tTJSVariant moduleMethod(const tTJSVariant &object) {
+    tTJSVariant method;
+    auto *dispatch = object.AsObjectNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(dispatch->PropGet(TJS_IGNOREPROP,
+                                            TJS_W("getModule"), nullptr,
+                                            &method, dispatch)));
+    REQUIRE(method.Type() == tvtObject);
+    return method;
+}
+
+TEST_CASE("draw-device modules initialize the owning window's lazy adaptor",
+          "[gles][owner]") {
+    GlesRuntime runtime;
+    REQUIRE(ncbAutoRegister::LoadModule(TJS_W("krkrgles.dll")));
+    tTJSVariant initialized;
+    REQUIRE_NOTHROW(TVPScriptEngine->ExecScript(TJS_W(
+        "class CaptureBaseWindow extends Window {\n"
+        "  function CaptureBaseWindow() { super.Window(); }\n"
+        "}\n"
+        "class CaptureWindow extends CaptureBaseWindow {\n"
+        "  function CaptureWindow() { super.CaptureBaseWindow(); }\n"
+        "  var _adaptor, initializeCount = 0;\n"
+        "  property glesAdaptor { getter() {\n"
+        "    if(_adaptor === void) {\n"
+        "      initializeCount++;\n"
+        "      _adaptor = new global.GLESAdaptor(this);\n"
+        "    }\n"
+        "    return _adaptor;\n"
+        "  } }\n"
+        "  property drawDevice {\n"
+        "    getter() { return global.CaptureBaseWindow.drawDevice; }\n"
+        "    setter(value) { global.CaptureBaseWindow.drawDevice = value; }\n"
+        "  }\n"
+        "}\n"
+        "var owner = new CaptureWindow();\n"
+        "owner.drawDevice = new Window.BasicDrawDevice();\n"
+        "owner.drawDevice.getModule('live2d');\n"
+        "var initialized = owner.initializeCount;\n"
+        "invalidate owner;\n"
+        "return initialized;\n"), &initialized));
+    CHECK(initialized.AsInteger() == 1);
+}
+
+tTJSVariant createDrawDevice(const tTJSVariant &deviceClass) {
+    iTJSDispatch2 *created = nullptr;
+    auto *klass = deviceClass.AsObjectNoAddRef();
+    REQUIRE(TJS_SUCCEEDED(klass->CreateNew(0, nullptr, nullptr, &created,
+                                          0, nullptr, klass)));
+    REQUIRE(created != nullptr);
+    tTJSVariant result(created, created);
+    created->Release();
+    return result;
+}
+} // namespace
+
+TEST_CASE("GLES loading preserves the built-in draw-device module lifecycle",
+          "[gles][load-order]") {
+    GlesRuntime runtime;
+    const tTJSVariant nativeMethod = moduleMethod(runtime.deviceClass);
+    tTJSVariant earlyDevice;
+    SECTION("graphics module loads before the first window") {
+        REQUIRE(ncbAutoRegister::LoadModule(TJS_W("krkrgles.dll")));
+    }
+    SECTION("graphics module loads after a window's device exists") {
+        earlyDevice = createDrawDevice(runtime.deviceClass);
+        REQUIRE(ncbAutoRegister::LoadModule(TJS_W("krkrgles.dll")));
+        CHECK(moduleMethod(earlyDevice).AsObjectNoAddRef() ==
+              nativeMethod.AsObjectNoAddRef());
+    }
+    CHECK(moduleMethod(runtime.deviceClass).AsObjectNoAddRef() ==
+          nativeMethod.AsObjectNoAddRef());
+    const tTJSVariant lateDevice = createDrawDevice(runtime.deviceClass);
+    CHECK(moduleMethod(lateDevice).AsObjectNoAddRef() ==
+          nativeMethod.AsObjectNoAddRef());
+}

--- a/tests/unit-tests/plugins/layer-pointer-gesture.cpp
+++ b/tests/unit-tests/plugins/layer-pointer-gesture.cpp
@@ -1,0 +1,184 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "LayerImpl.h"
+#include "LayerManager.h"
+#include "ScriptMgnIntf.h"
+#include "StorageIntf.h"
+#include "SysInitIntf.h"
+#include "SystemControl.h"
+#include "WindowIntf.h"
+#include "tvpgl.h"
+
+extern tTJS *TVPScriptEngine;
+
+namespace {
+class PointerRuntime {
+public:
+    PointerRuntime() {
+        TVPInitTVPGL();
+        TVPSetCurrentDirectory(TJS_W("file://./"));
+        TVPSetCommandLine(TJS_W("renderer"), TJS_W("software"));
+        TVPProjectDir = TJS_W("file://./");
+        systemControl = std::make_unique<tTVPSystemControl>();
+        TVPSystemControl = systemControl.get();
+        TVPScriptEngine = new tTJS();
+        auto *global = TVPScriptEngine->GetGlobalNoAddRef();
+        auto install = [global](const tjs_char *name, iTJSDispatch2 *klass) {
+            tTJSVariant value(klass);
+            global->PropSet(TJS_MEMBERENSURE, name, nullptr, &value, global);
+            klass->Release();
+        };
+        install(TJS_W("Window"), TVPCreateNativeClass_Window());
+        install(TJS_W("Layer"), TVPCreateNativeClass_Layer());
+        run(TJS_W(
+            "var clicks = 0, ups = 0, downs = 0, doubles = 0;\n"
+            "var releasesCapture = false, revealOnDown = false;\n"
+            "var window = new Window();\n"
+            "class ReplaySurface extends Layer {\n"
+            "  function ReplaySurface(window) { super.Layer(window, null); }\n"
+            "  function onMouseDown(x, y, button, flags) {\n"
+            "    if(global.revealOnDown) {\n"
+            "      global.button.visible = true; releaseCapture();\n"
+            "    }\n"
+            "  }\n"
+            "}\n"
+            "var primary = new ReplaySurface(window);\n"
+            "primary.setSize(640, 480);\n"
+            "class Button extends Layer {\n"
+            "  function Button(window, parent) {\n"
+            "    super.Layer(window, parent);\n"
+            "    setSize(640, 480); hitThreshold = 0; name = 'gallery';\n"
+            "  }\n"
+            "  var exp = 'clicks++', onclick = 'clicks++', pressed = false;\n"
+            "  function _evalOnClick() { global.clicks++; }\n"
+            "  function onDoubleClick(x, y) { global.doubles++; }\n"
+            "  function onMouseDown(x, y, button, flags) {\n"
+            "    global.downs++; pressed = true;\n"
+            "    if(global.releasesCapture) releaseCapture();\n"
+            "  }\n"
+            "  function onMouseUp(x, y, button, flags) {\n"
+            "    global.ups++;\n"
+            "    if(pressed && !global.releasesCapture) global.clicks++;\n"
+            "    pressed = false;\n"
+            "  }\n"
+            "}\n"
+            "var button = new Button(window, primary);\n"
+            "button.visible = false;\n"));
+        tTJSVariant value;
+        TVPScriptEngine->EvalExpression(TJS_W("primary"), &value);
+        auto *layer = tTJSNI_Layer::FromVariant(value);
+        REQUIRE(layer != nullptr);
+        manager = layer->GetManager();
+        REQUIRE(manager != nullptr);
+    }
+
+    ~PointerRuntime() {
+        run(TJS_W("invalidate button; invalidate primary; invalidate window;"));
+        TVPScriptEngine->Release();
+        TVPScriptEngine = nullptr;
+        TVPSystemControl = nullptr;
+        TVPSystemControlAlive = false;
+    }
+
+    void run(const tjs_char *script) { TVPScriptEngine->ExecScript(script); }
+    tjs_int value(const tjs_char *expression) {
+        tTJSVariant result;
+        TVPScriptEngine->EvalExpression(expression, &result);
+        return result.AsInteger();
+    }
+    void down() { manager->PrimaryMouseDown(300, 200, mbLeft, 0); }
+    void clickAndUp() {
+        manager->PrimaryClick(300, 200);
+        manager->PrimaryMouseUp(300, 200, mbLeft, 0);
+    }
+
+    tTVPLayerManager *manager = nullptr;
+
+private:
+    std::unique_ptr<tTVPSystemControl> systemControl;
+};
+} // namespace
+
+TEST_CASE("a release cannot activate a button revealed after mouse-down",
+          "[input][gallery][gesture]") {
+    PointerRuntime runtime;
+    SECTION("the replay ends in the mouse-down handler") {
+        runtime.run(TJS_W("revealOnDown = true;"));
+        runtime.down();
+    }
+    SECTION("the replay ends between down and release") {
+        runtime.down();
+        runtime.manager->ReleaseCapture();
+        runtime.run(TJS_W("button.visible = true;"));
+    }
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("clicks")) == 0);
+    CHECK(runtime.value(TJS_W("ups")) == 0);
+
+    // The menu must remain interactive on the following complete gesture.
+    runtime.down();
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("downs")) == 1);
+    CHECK(runtime.value(TJS_W("ups")) == 1);
+    CHECK(runtime.value(TJS_W("clicks")) == 1);
+}
+
+TEST_CASE("a normal captured button dispatches once on mouse-up",
+          "[input][gesture]") {
+    PointerRuntime runtime;
+    runtime.run(TJS_W("button.visible = true;"));
+    runtime.down();
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("clicks")) == 1);
+    CHECK(runtime.value(TJS_W("ups")) == 1);
+}
+
+TEST_CASE("a button that releases capture can still finish its own click",
+          "[input][gesture]") {
+    PointerRuntime runtime;
+    runtime.run(TJS_W("button.visible = true; releasesCapture = true;"));
+    runtime.down();
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("clicks")) == 1);
+    CHECK(runtime.value(TJS_W("ups")) == 1);
+}
+
+TEST_CASE("explicit click-only dispatch remains available",
+          "[input][gesture]") {
+    PointerRuntime runtime;
+    runtime.run(TJS_W("button.visible = true;"));
+    runtime.manager->PrimaryClick(300, 200);
+    CHECK(runtime.value(TJS_W("clicks")) == 1);
+}
+
+TEST_CASE("invalidating the pressed layer does not redirect its release",
+          "[input][gesture][lifetime]") {
+    PointerRuntime runtime;
+    runtime.run(TJS_W(
+        "button.visible = true;\n"
+        "var overlay = new Layer(window, primary);\n"
+        "overlay.setSize(640, 480); overlay.hitThreshold = 0;\n"
+        "overlay.visible = true;\n"));
+    runtime.down();
+    runtime.manager->ReleaseCapture();
+    runtime.run(TJS_W("invalidate overlay; overlay = void;"));
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("clicks")) == 0);
+    CHECK(runtime.value(TJS_W("ups")) == 0);
+    runtime.down();
+    runtime.clickAndUp();
+    CHECK(runtime.value(TJS_W("clicks")) == 1);
+}
+
+TEST_CASE("a synthetic double-click cannot cross the active gesture target",
+          "[input][gesture]") {
+    PointerRuntime runtime;
+    runtime.run(TJS_W("revealOnDown = true;"));
+    runtime.down();
+    runtime.manager->PrimaryDoubleClick(300, 200);
+    runtime.manager->PrimaryMouseUp(300, 200, mbLeft, 0);
+    CHECK(runtime.value(TJS_W("doubles")) == 0);
+    runtime.manager->PrimaryDoubleClick(300, 200);
+    CHECK(runtime.value(TJS_W("doubles")) == 1);
+}

--- a/tests/unit-tests/tjs2/CMakeLists.txt
+++ b/tests/unit-tests/tjs2/CMakeLists.txt
@@ -4,9 +4,15 @@ project(TestTJS2 LANGUAGES CXX)
 add_executable(tjs2-missing
     missing.cpp
     variant-array-stack.cpp
+    gles-contract.cpp
     main.cpp
     stubs.cpp
     ${KRKR2CORE_PATH}/plugin/PluginCallTracer.cpp
+)
+
+target_include_directories(tjs2-missing PRIVATE
+    "${KRKR2CORE_PATH}/base/impl"
+    "${CMAKE_SOURCE_DIR}/cpp/plugins"
 )
 
 target_link_libraries(tjs2-missing

--- a/tests/unit-tests/tjs2/gles-contract.cpp
+++ b/tests/unit-tests/tjs2/gles-contract.cpp
@@ -1,0 +1,87 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "tjs.h"
+#include "GpuCompatScript.h"
+#include "GlesCaptureUtils.h"
+
+#include <memory>
+
+namespace {
+struct EngineReleaser {
+    void operator()(tTJS *engine) const { engine->Release(); }
+};
+
+} // namespace
+
+TEST_CASE("GPU companion script preserves adaptor constructor and lazy getter", "[gles]") {
+    std::unique_ptr<tTJS, EngineReleaser> engine(new tTJS());
+    REQUIRE_NOTHROW(engine->ExecScript(TJS_W(
+        "class GLESAdaptor {\n"
+        "  function GLESAdaptor(owner) {}\n"
+        "  function setScreenSize(w, h) {}\n"
+        "}\n"
+        "class OGLDrawDevice { function setScreenSize(w, h) {} }\n"
+        "class BasicDrawDevice {}\n"
+        "class Window {}\n"
+        "Window.BasicDrawDevice = BasicDrawDevice;\n"
+        "class KAGWindow extends Window {\n"
+        "  var width = 1920, height = 1080, getterCalls = 0;\n"
+        "  var _glesAdaptor;\n"
+        "  property glesAdaptor { getter() {\n"
+        "    getterCalls++;\n"
+        "    if(_glesAdaptor === void) _glesAdaptor = new GLESAdaptor(this);\n"
+        "    return _glesAdaptor;\n"
+        "  } }\n"
+        "}\n")));
+    REQUIRE_NOTHROW(engine->ExecScript(ttstr(TVP_GPU_COMPAT_SCRIPT)));
+    tTJSVariant result;
+    REQUIRE_NOTHROW(engine->ExecScript(TJS_W(
+        "var owner = new KAGWindow();\n"
+        "owner.KAGWindow_createDrawDevice();\n"
+        "return owner.getterCalls;\n"), &result));
+    CHECK(result.AsInteger() == 0);
+    REQUIRE_NOTHROW(engine->EvalExpression(
+        TJS_W("owner.GLESAdaptor instanceof 'Class'"), &result));
+    CHECK(result.AsInteger() == 1);
+    REQUIRE_NOTHROW(engine->EvalExpression(
+        TJS_W("owner.glesAdaptor instanceof 'GLESAdaptor'"), &result));
+    CHECK(result.AsInteger() == 1);
+    REQUIRE_NOTHROW(engine->EvalExpression(TJS_W("owner.getterCalls"), &result));
+    CHECK(result.AsInteger() == 1);
+}
+
+TEST_CASE("GLES capture separates destination from callback dimensions and context", "[gles]") {
+    std::unique_ptr<tTJS, EngineReleaser> engine(new tTJS());
+    tTJSVariant callback, target, context, result;
+    REQUIRE_NOTHROW(engine->ExecScript(TJS_W(
+        "var calls = 0, width, height, received;\n"
+        "function onCapture(w, h, data) {\n"
+        "  calls++; width = w; height = h; received = data;\n"
+        "}\n")));
+    engine->EvalExpression(TJS_W("onCapture"), &callback);
+    engine->EvalExpression(TJS_W("%[destination: 1]"), &target);
+    engine->EvalExpression(TJS_W("%[background: 73]"), &context);
+    tTJSVariant flags(1);
+    tTJSVariant *args[] = {&target, &callback, &context, &flags};
+    REQUIRE(aetherkiri::plugins::gles::CaptureCallbackIndex(4, args) == 1);
+    REQUIRE(aetherkiri::plugins::gles::InvokeCaptureCallback(1280, 720, 4, args) == TJS_S_OK);
+    engine->EvalExpression(TJS_W("width == 1280 && height == 720 && received.background == 73 && calls == 1"), &result);
+    CHECK(result.AsInteger() == 1);
+
+    tTJSVariant *directArgs[] = {&callback, &context};
+    REQUIRE(aetherkiri::plugins::gles::InvokeCaptureCallback(1920, 1080, 2, directArgs) == TJS_S_OK);
+    engine->EvalExpression(TJS_W("width == 1920 && height == 1080 && received.background == 73 && calls == 2"), &result);
+    CHECK(result.AsInteger() == 1);
+
+    // A missing background must remain void, not become the destination.
+    REQUIRE(aetherkiri::plugins::gles::InvokeCaptureCallback(1280, 720, 2, args) == TJS_S_OK);
+    engine->EvalExpression(TJS_W("received === void && calls == 3"), &result);
+    CHECK(result.AsInteger() == 1);
+
+    // Layers and dictionaries are objects, but are not callbacks.
+    tTJSVariant *noCallback[] = {&target, &context};
+    CHECK(aetherkiri::plugins::gles::CaptureCallbackIndex(2, noCallback) == -1);
+    CHECK(aetherkiri::plugins::gles::InvokeCaptureCallback(1280, 720, 2, noCallback) == TJS_S_OK);
+    engine->EvalExpression(TJS_W("calls"), &result);
+    CHECK(result.AsInteger() == 3);
+}


### PR DESCRIPTION
## Summary

Submit all five remaining locally committed compatibility fixes on top of current main. This follows the already merged doinaka PR #190; that fix is retained and is not resubmitted.

- Restore the portable GLES capture callback contract and draw-device initialization/lifetime, including the statically linked Apple path used for Live2D playback.
- Keep a mouse release tied to its original layer so ending a gallery replay cannot accidentally activate a newly revealed control.
- Prefer `data.xp3` and other XP3 archives to Windows launchers when discovering KiriKiri games.
- Pin the paired Internal fix that preserves the outgoing CG's alpha during transitions.
- Force and batch selector repaints so moving between motion-based title controls does not expose a cleared intermediate frame.

These cover the reported iPad Live2D playback, gallery input, XP3 startup, LOVE³ CG transition, and DRACU-RIOT! title-hover regressions.

## Recovered commits

The original authors and five independent public commits are preserved:

| Original commit | New commit | Fix |
| --- | --- | --- |
| `01dcecbd` | `1ca9d889` | GLES capture and draw-device lifecycle |
| `b9f22910` | `81932be6` | Gallery pointer-gesture ownership |
| `141174ca` | `315697cb` | Prefer XP3 archive discovery |
| `b5ce8fbe` | `dc136d4f` | CG transition alpha dependency |
| `2607c31c` | `ec506c13` | Motion selector black flash |

Only the submodule resolutions change during transplantation, selecting rebased Internal commits that descend from current Internal main. All public source/test patches match the original changes.

## Paired Internal PR

- https://github.com/AetherKiri/AetherInternal/pull/40
- Exact public gitlink: `d0ac39072b12ffcb85f159782ca8518625fa881f`
- The SHA is the merge commit now reachable from AetherInternal `main`.
- Previously merged doinaka and PackinOne fixes are retained, not replayed.

Merge Internal first. If squash/rebase changes its SHA, update the public pin to the resulting main commit and rerun CI before merging this PR.

The branch has since merged the latest public `upstream/main` (`636ce6de92174165716d448a8d654be95e3856cd`) and resolved the submodule conflict by selecting the merged Internal `main` commit above.

## Validation

- Local focused targets rebuilt successfully with Internal enabled.
- GLES callback/script contracts: 21 assertions in 2 cases passed.
- GLES load-order/lifecycle contracts: 30 assertions in 2 cases passed.
- Pointer gesture/lifetime contracts: 34 assertions in 6 cases passed.
- Godot game-metadata test run from this clean public worktree: PASS.
- `git diff --check`: PASS.
- The exact clean PR head will be validated by the existing Android, Web, iOS, and macOS workflow, including macOS Debug and the native contract suite. Local focused C++ checks above used the existing local build tree; they are not represented as a fresh full-app test of this new head.

## Scope and distribution

No workflows, game packages, saves, local paths, logs, generated products, or unrelated worktree changes are included. Private implementation stays in AetherInternal; the public diff contains generic engine behavior, tests, and the gitlink only. The existing trusted same-repository CI intentionally publishes application binaries containing compiled Internal behavior; public build logs and binary artifacts do not provide absolute confidentiality.
