### PR TITLE
perf(rfvp): render frames through the Godot GPU bridge

### DIFF
--- a/apps/godot_app/scripts/main.gd
+++ b/apps/godot_app/scripts/main.gd
@@ -3713,6 +3713,9 @@ func _apply_engine_options() -> void:
         player.set_engine_option("rfvp_encoding", GameLaunchEntry.rfvp_encoding(
             selected_game, OS.get_environment("AETHERKIRI_RFVP_ENCODING")
         ))
+        var rfvp_renderer := OS.get_environment("AETHERKIRI_RFVP_RENDERER").strip_edges().to_lower()
+        if not rfvp_renderer.is_empty():
+            player.set_engine_option("rfvp_renderer", rfvp_renderer)
 
 func _apply_frame_enhancement_settings() -> void:
     if player == null or not player.has_method("set_frame_enhancement_enabled"):
@@ -11889,7 +11892,14 @@ func _run_cli_script_probe() -> void:
         _refresh_known_games_for_auto_start()
         var game := _find_known_game_by_query(target_game_path)
         if not game.is_empty():
-            target_game_path = String(game.get("path", target_game_path))
+            var library_path := String(game.get("path", target_game_path))
+            if FileAccess.file_exists(library_path):
+                target_game_path = library_path
+            else:
+                var runtime_kind := String(game.get("engine", "")).strip_edges().to_lower()
+                if runtime_kind.is_empty():
+                    runtime_kind = _game_runtime_kind(library_path)
+                target_game_path = GameLaunchEntry.resolve_for_runtime(game, runtime_kind)
         else:
             target_game_path = _resolve_game_path(target_game_path)
     _write_probe_marker("cli_probe target requested=%s resolved=%s" % [requested_game_path, target_game_path])

--- a/apps/godot_app/scripts/sequence_perf_probe.gd
+++ b/apps/godot_app/scripts/sequence_perf_probe.gd
@@ -30,6 +30,9 @@ func _initialize() -> void:
         return
 
     player.set_render_backend(ProbeConfig.backend(config, "AETHERKIRI_PROBE_BACKEND"))
+    var rfvp_renderer := OS.get_environment("AETHERKIRI_RFVP_RENDERER").strip_edges().to_lower()
+    if not rfvp_renderer.is_empty():
+        player.set_engine_option("rfvp_renderer", rfvp_renderer)
     var surface_size: Vector2i = ProbeConfig.surface_size(config)
     player.set_surface_size(surface_size.x, surface_size.y)
 
@@ -82,6 +85,7 @@ func _initialize() -> void:
     ])
 
     if OS.get_environment("AETHERKIRI_PROBE_SKIP_DESTROY") != "1":
+        rect.texture = null
         player.destroy_engine()
     quit(0)
 

--- a/bridge/godot_extension/src/aether_runtime_player.cpp
+++ b/bridge/godot_extension/src/aether_runtime_player.cpp
@@ -3088,6 +3088,29 @@ vec4 load_bilinear_premul(ivec2 limit, vec2 edge_coord,
     return clamp(premul, vec4(0.0), vec4(1.0));
 }
 
+vec4 load_nearest(ivec2 limit, vec2 edge_coord,
+                  bool source_premultiplied) {
+    ivec2 pos = clamp(ivec2(floor(edge_coord)), ivec2(0), limit);
+    vec4 color = imageLoad(src_img, pos);
+    if (source_premultiplied && color.a > 0.00001) {
+        color.rgb /= color.a;
+    }
+    return clamp(color, vec4(0.0), vec4(1.0));
+}
+
+vec4 load_straight_linear(ivec2 limit, vec2 edge_coord) {
+    vec2 center_coord = clamp(edge_coord - vec2(0.5), vec2(0.0), vec2(limit));
+    ivec2 p0 = ivec2(floor(center_coord));
+    ivec2 p1 = clamp(p0 + ivec2(1), ivec2(0), limit);
+    vec2 f = clamp(fract(center_coord), vec2(0.0), vec2(1.0));
+    vec4 c00 = imageLoad(src_img, p0);
+    vec4 c10 = imageLoad(src_img, ivec2(p1.x, p0.y));
+    vec4 c01 = imageLoad(src_img, ivec2(p0.x, p1.y));
+    vec4 c11 = imageLoad(src_img, p1);
+    return clamp(mix(mix(c00, c10, f.x), mix(c01, c11, f.x), f.y),
+                 vec4(0.0), vec4(1.0));
+}
+
 float premul_luma(vec4 color) {
     vec3 straight = color.a > 0.00001
         ? color.rgb / color.a : vec3(0.0);
@@ -3598,7 +3621,11 @@ void main() {
         (uint(pc.color0.z) & 0x40000000u) != 0u;
     bool source_premultiplied =
         (uint(pc.color0.z) & 0x20000000u) != 0u;
-    int blend_flags = int(uint(pc.color0.z) & 0x1fffffffu);
+    bool source_nearest =
+        (uint(pc.color0.z) & 0x10000000u) != 0u;
+    bool source_straight_linear =
+        (uint(pc.color0.z) & 0x04000000u) != 0u;
+    int blend_flags = int(uint(pc.color0.z) & 0x03ffffffu);
     bool mask_write = (blend_flags & 131072) != 0;
     bool tvp_blend = !mask_write && (blend_flags & 65536) != 0;
     int tvp_blend_mode = blend_flags & 65535;
@@ -3635,9 +3662,12 @@ void main() {
             vec2 source_dy =
                 source10 * ((d2.x - d0.x) / area) +
                 source20 * ((d0.x - d1.x) / area);
-            vec4 src = load_minified(
-                src_limit, src_pos_f, source_dx, source_dy,
-                preserve_detail, source_premultiplied);
+            vec4 src = source_nearest
+                ? load_nearest(src_limit, src_pos_f, source_premultiplied)
+                : source_straight_linear
+                    ? load_straight_linear(src_limit, src_pos_f)
+                    : load_minified(src_limit, src_pos_f, source_dx, source_dy,
+                                    preserve_detail, source_premultiplied);
             if (tvp_blend) {
                 uint d = pack_u8(vec4_to_u8(dst));
                 uint s = pack_u8(vec4_to_u8(src));
@@ -8918,6 +8948,9 @@ public:
         batch_callbacks.begin_batch = BridgeBeginBatch;
         batch_callbacks.end_batch = BridgeEndBatch;
         engine_register_godot_gpu_batch_bridge(&batch_callbacks);
+#if defined(AETHERKIRI_WITH_RFVP)
+        aetherkiri::rfvp::RegisterGpuBridge(&callbacks, &batch_callbacks);
+#endif
         TVPGodotGpuExternalTextureCallbacks external_texture_callbacks{};
         external_texture_callbacks.struct_size =
             sizeof(external_texture_callbacks);
@@ -12161,6 +12194,9 @@ void DeinitializeAetherRuntime(ModuleInitializationLevel level) {
     engine_register_godot_gpu_batch_bridge(nullptr);
     engine_register_godot_gpu_external_texture_bridge(nullptr);
     engine_register_godot_gpu_bridge(nullptr);
+#if defined(AETHERKIRI_WITH_RFVP)
+    aetherkiri::rfvp::RegisterGpuBridge(nullptr, nullptr);
+#endif
 #if defined(AETHERKIRI_INTERNAL_FRAME_EFFECTS)
     UnregisterAetherInternalFrameEffects();
 #endif

--- a/bridge/rfvp_runtime/CMakeLists.txt
+++ b/bridge/rfvp_runtime/CMakeLists.txt
@@ -71,7 +71,9 @@ add_library(aether_rfvp_runtime STATIC src/rfvp_runtime_provider.cpp)
 target_compile_features(aether_rfvp_runtime PUBLIC cxx_std_17)
 set_target_properties(aether_rfvp_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(aether_rfvp_runtime PUBLIC include
-    "${AETHERKIRI_RFVP_PROJECT_ROOT}/bridge/engine_api/include")
+    "${AETHERKIRI_RFVP_PROJECT_ROOT}/bridge/engine_api/include"
+    PRIVATE
+    "${AETHERKIRI_RFVP_PROJECT_ROOT}/cpp/core/visual/godot")
 target_link_libraries(aether_rfvp_runtime PUBLIC aether_rfvp_rust)
 if(APPLE)
     target_link_libraries(aether_rfvp_runtime PUBLIC

--- a/bridge/rfvp_runtime/README.md
+++ b/bridge/rfvp_runtime/README.md
@@ -2,7 +2,9 @@
 
 This is an opt-in native provider for FVP HCB games, using the pinned
 `packages/rfvp` submodule. It implements `engine_runtime_provider_v1_t`; Godot
-presents CPU-rendered RGBA frames and owns the window and input coordinates.
+presents the native-resolution frame and owns the window and input coordinates.
+The default `auto` renderer sends RFVP's scene traversal through AetherKiri's
+Godot GPU Bridge when RenderingDevice is available, with a software fallback.
 It does not launch the Windows executable or the standalone rfvp application.
 
 ## Build
@@ -51,6 +53,12 @@ the small generated workspace, not all upstream console and tool packages.
 - Script-driven save/load uses VM/state snapshots and CPU thumbnails. Legacy
   standalone native save/load dialogs are not implemented and return an
   explicit error. Exit requests return control to the application host.
+- `rfvp_renderer=auto|gpu|cpu` is a pre-open engine option. `auto` is the
+  default, `gpu` requires the Godot GPU Bridge, and `cpu` is useful for visual
+  comparison. The app-level developer override is
+  `AETHERKIRI_RFVP_RENDERER`. Normal GPU presentation stays on-device; a
+  readback occurs only when the host explicitly requests RGBA pixels, such as
+  for save thumbnails or screenshots.
 - New RFVS payloads use a version-2 envelope to preserve active motions, sprite
   and snow animations, and text-reveal coroutine linkage. Version-1 snapshots
   remain readable, but missing playback state in old files cannot be recovered
@@ -68,7 +76,8 @@ crate is a Rust static library behind a private C ABI;
 no Rust layout crosses the engine-provider ABI.
 
 The rfvp crate uses full optimization even in the development profile, retaining
-debug assertions. CPU rendering skips zero-opacity quads and rasterizes
+debug assertions. Release builds use ThinLTO and one code-generation unit. CPU
+rendering skips zero-opacity quads and rasterizes
 axis-aligned quads once, avoiding redundant triangle scans and a double-blended
 translucent diagonal. Rotated/sheared geometry retains the triangle path.
 
@@ -88,7 +97,8 @@ snapshot, then loads it: completing a write must release its request without
 discarding the pre-menu payload. Another fixture saves during a fade and checks
 that the animation reaches its destination after load. Rust regressions cover
 V1/V2 round trips, malformed payloads, fixed-buffer lengths, text waiters,
-opacity culling, translucent diagonals and sampling/clipping/flipping parity.
+opacity culling, translucent diagonals, sampling/clipping/flipping parity, and
+the lazy GPU texture, batching, readback and cleanup contract.
 Godot's input mapping regression covers rfvp
 at a mismatched presentation size while preserving KiriKiri's surface mapping.
 Games open on a native worker thread, matching the application's asynchronous

--- a/bridge/rfvp_runtime/cmake/PrepareRfvpSources.cmake
+++ b/bridge/rfvp_runtime/cmake/PrepareRfvpSources.cmake
@@ -24,7 +24,7 @@ function(aetherkiri_prepare_rfvp root output)
     file(COPY "${root}/packages/rfvp/LICENSE" "${root}/packages/rfvp/README.md"
          DESTINATION "${output}")
     file(WRITE "${output}/Cargo.toml"
-        "[workspace]\nresolver = \"3\"\nmembers = [\"crates/*\"]\n[profile.dev]\ndebug = 0\nopt-level = 1\nincremental = false\n[profile.dev.package.rfvp]\nopt-level = 3\n[profile.release]\ndebug = 0\n")
+        "[workspace]\nresolver = \"3\"\nmembers = [\"crates/*\"]\n[profile.dev]\ndebug = 0\nopt-level = 1\nincremental = false\n[profile.dev.package.rfvp]\nopt-level = 3\n[profile.release]\ndebug = 0\nlto = \"thin\"\ncodegen-units = 1\n")
     configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../Cargo.lock" "${output}/Cargo.lock" COPYONLY)
     set(src "${output}/crates/rfvp/src")
     rfvp_replace("${output}/crates/rfvp/Cargo.toml"
@@ -74,6 +74,24 @@ function(aetherkiri_prepare_rfvp root output)
         file(COPY "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../rust/${helper}.rs" DESTINATION "${target_dir}")
         file(APPEND "${src}/${target}" "\ninclude!(\"${helper}.rs\");\n")
     endforeach()
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "    framebuffer: SoftFramebuffer,\n    stats: SoftRendererStats,"
+        "    framebuffer: SoftFramebuffer,\n    stats: SoftRendererStats,\n    host_gpu: Option<HostGpuRenderer>,")
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "            stats: SoftRendererStats::default(),\n        })"
+        "            stats: SoftRendererStats::default(),\n            host_gpu: None,\n        })")
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "        self.stats = SoftRendererStats::default();\n        self.framebuffer.clear_rgba(0, 0, 0, 255);"
+        "        self.stats = SoftRendererStats::default();\n        if !self.begin_host_gpu_frame() {\n            self.framebuffer.clear_rgba(0, 0, 0, 255);\n        }")
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "        let graphs = motion.graphs();\n        let snow_motions = motion.snow_motions();"
+        "        let graphs = motion.graphs();\n        self.prune_host_gpu_graphs(graphs);\n        let snow_motions = motion.snow_motions();")
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "        }\n\n        Ok(())\n    }\n\n    fn dissolve_color"
+        "        }\n\n        self.finish_host_gpu_frame();\n        Ok(())\n    }\n\n    fn dissolve_color")
+    rfvp_replace("${src}/soft_render/renderer.rs"
+        "        self.raster_triangle(v0, v1, v2, texture);\n        self.raster_triangle(v2, v1, v3, texture);"
+        "        if !self.try_host_gpu_quad(v0, v1, v2, v3, texture) {\n            self.raster_triangle(v0, v1, v2, texture);\n            self.raster_triangle(v2, v1, v3, texture);\n        }")
     # The common axis-aligned case needs one clipped rectangle, not two
     # overlapping triangle scans. Keep rotated/sheared quads on the old path.
     rfvp_replace("${src}/soft_render/renderer.rs"

--- a/bridge/rfvp_runtime/include/rfvp_host.h
+++ b/bridge/rfvp_runtime/include/rfvp_host.h
@@ -1,21 +1,63 @@
 #pragma once
 #include <stddef.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 // Private C ABI between the C++ provider and the pinned Rust adapter.
 #ifdef __cplusplus
 extern "C" {
 #endif
-void* aether_rfvp_new(void);
+#define AETHER_RFVP_GPU_CALLBACKS_API_VERSION 0x01000000u
+
+typedef struct aether_rfvp_gpu_rect_t {
+    int32_t left;
+    int32_t top;
+    int32_t right;
+    int32_t bottom;
+} aether_rfvp_gpu_rect_t;
+
+typedef struct aether_rfvp_gpu_point_t {
+    double x;
+    double y;
+} aether_rfvp_gpu_point_t;
+
+typedef struct aether_rfvp_gpu_callbacks_t {
+    uint32_t struct_size;
+    uint32_t api_version;
+    uint64_t (*create_rgba)(uint32_t width, uint32_t height,
+                            const void* pixels, uint32_t stride_bytes);
+    void (*release_texture)(uint64_t texture);
+    bool (*update_rgba)(uint64_t texture, const void* pixels,
+                        uint32_t stride_bytes,
+                        const aether_rfvp_gpu_rect_t* rect);
+    bool (*clear_rgba)(uint64_t texture, uint32_t rgba,
+                       const aether_rfvp_gpu_rect_t* rect);
+    bool (*draw_triangles)(uint64_t dst, uint64_t src,
+                           uint32_t triangle_count,
+                           const aether_rfvp_gpu_rect_t* clip_rect,
+                           const aether_rfvp_gpu_point_t* dst_points,
+                           const aether_rfvp_gpu_point_t* src_points,
+                           float opacity, uint32_t blend_mode);
+    bool (*read_rgba)(uint64_t texture, void* out_pixels,
+                      size_t out_pixels_size, uint32_t stride_bytes);
+    uint64_t (*begin_batch)(void);
+    bool (*end_batch)(uint64_t batch_token);
+    bool (*flush)(void);
+} aether_rfvp_gpu_callbacks_t;
+
+void* aether_rfvp_new(const aether_rfvp_gpu_callbacks_t* gpu_callbacks);
 void aether_rfvp_free(void* runtime);
 int32_t aether_rfvp_probe(const char* path);
 int32_t aether_rfvp_open(void* runtime, const char* path, const char* script,
-    const char* writable, const char* font, const char* encoding);
+    const char* writable, const char* font, const char* encoding,
+    const char* renderer);
 int32_t aether_rfvp_tick(void* runtime, uint32_t delta_ms);
 int32_t aether_rfvp_pause(void* runtime, uint32_t paused);
 int32_t aether_rfvp_input(void* runtime, uint32_t kind, double x, double y,
     int32_t button, int32_t key, uint32_t modifiers, double wheel);
 int32_t aether_rfvp_frame(void* runtime, uint32_t* width, uint32_t* height, uint64_t* serial);
+int32_t aether_rfvp_gpu_frame(void* runtime, uint64_t* texture,
+    uint32_t* width, uint32_t* height, uint64_t* serial);
 int32_t aether_rfvp_read(void* runtime, void* pixels, size_t size);
 const char* aether_rfvp_error(void* runtime);
 uint32_t aether_rfvp_log(char* output, size_t size);

--- a/bridge/rfvp_runtime/include/rfvp_runtime_provider.h
+++ b/bridge/rfvp_runtime/include/rfvp_runtime_provider.h
@@ -1,5 +1,10 @@
 #pragma once
 
+struct TVPGodotGpuBridgeCallbacks;
+struct TVPGodotGpuBatchCallbacks;
+
 namespace aetherkiri::rfvp {
 void RegisterRuntimeProvider();
+void RegisterGpuBridge(const TVPGodotGpuBridgeCallbacks* callbacks,
+                       const TVPGodotGpuBatchCallbacks* batch_callbacks);
 }

--- a/bridge/rfvp_runtime/rust/aetherkiri_host.rs
+++ b/bridge/rfvp_runtime/rust/aetherkiri_host.rs
@@ -36,6 +36,67 @@ use std::{
 };
 
 const MAX_SCRIPT: u64 = 64 * 1024 * 1024;
+const HOST_GPU_CALLBACKS_API_VERSION: u32 = 0x01000000;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct HostGpuRect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct HostGpuPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct HostGpuCallbacks {
+    pub(crate) struct_size: u32,
+    pub(crate) api_version: u32,
+    pub create_rgba: Option<unsafe extern "C" fn(u32, u32, *const c_void, u32) -> u64>,
+    pub release_texture: Option<unsafe extern "C" fn(u64)>,
+    pub update_rgba:
+        Option<unsafe extern "C" fn(u64, *const c_void, u32, *const HostGpuRect) -> bool>,
+    pub clear_rgba: Option<unsafe extern "C" fn(u64, u32, *const HostGpuRect) -> bool>,
+    pub draw_triangles: Option<
+        unsafe extern "C" fn(
+            u64,
+            u64,
+            u32,
+            *const HostGpuRect,
+            *const HostGpuPoint,
+            *const HostGpuPoint,
+            f32,
+            u32,
+        ) -> bool,
+    >,
+    pub read_rgba: Option<unsafe extern "C" fn(u64, *mut c_void, usize, u32) -> bool>,
+    pub begin_batch: Option<unsafe extern "C" fn() -> u64>,
+    pub end_batch: Option<unsafe extern "C" fn(u64) -> bool>,
+    pub flush: Option<unsafe extern "C" fn() -> bool>,
+}
+impl HostGpuCallbacks {
+    fn valid(&self) -> bool {
+        self.struct_size >= std::mem::size_of::<Self>() as u32
+            && self.api_version == HOST_GPU_CALLBACKS_API_VERSION
+            && self.create_rgba.is_some()
+            && self.release_texture.is_some()
+            && self.update_rgba.is_some()
+            && self.clear_rgba.is_some()
+            && self.draw_triangles.is_some()
+            && self.read_rgba.is_some()
+            && self.begin_batch.is_some()
+            && self.end_batch.is_some()
+            && self.flush.is_some()
+    }
+}
+
 static ROOTS: Mutex<Option<(PathBuf, PathBuf)>> = Mutex::new(None);
 pub fn game_root() -> Option<PathBuf> {
     ROOTS.lock().unwrap().as_ref().map(|r| r.0.clone())
@@ -193,7 +254,15 @@ struct Core {
     _roots: RootsGuard,
 }
 impl Core {
-    fn new(path: &Path, startup: &str, writable: &Path, font: &str, nls: Nls) -> Result<Self> {
+    fn new(
+        path: &Path,
+        startup: &str,
+        writable: &Path,
+        font: &str,
+        nls: Nls,
+        gpu: Option<HostGpuCallbacks>,
+        require_gpu: bool,
+    ) -> Result<Self> {
         ensure!(
             !writable.as_os_str().is_empty(),
             "A writable save directory is required"
@@ -233,7 +302,15 @@ impl Core {
             current_scene: Some(Box::<AnzuScene>::default()),
         };
         scene.apply_scene_action(SceneAction::Start, &mut world);
-        let renderer = create_soft_renderer(size.0, size.1, PixelFormat::Rgba8)?;
+        let mut renderer = create_soft_renderer(size.0, size.1, PixelFormat::Rgba8)?;
+        let gpu_installed = gpu.is_some_and(|callbacks| renderer.install_host_gpu(callbacks));
+        ensure!(
+            !require_gpu || gpu_installed,
+            "Godot GPU Bridge is unavailable for rfvp"
+        );
+        if gpu.is_some() && !gpu_installed {
+            log::warn!("rfvp GPU renderer initialization failed; using CPU fallback");
+        }
         Ok(Self {
             world,
             parser,
@@ -307,6 +384,10 @@ impl Core {
                 w > 0 && h > 0 && w <= 4096 && h <= 4096,
                 "Invalid save thumbnail size"
             );
+            ensure!(
+                self.renderer.sync_host_gpu_framebuffer(),
+                "Read rfvp GPU frame for save thumbnail"
+            );
             let source = image::RgbaImage::from_raw(
                 self.size.0,
                 self.size.1,
@@ -372,6 +453,7 @@ impl Drop for Core {
 
 struct Session {
     core: Option<Core>,
+    gpu: Option<HostGpuCallbacks>,
     error: CString,
     poisoned: bool,
 }
@@ -412,10 +494,15 @@ unsafe fn call(p: *mut c_void, f: impl FnOnce(&mut Session) -> Result<i32>) -> i
     }
 }
 #[no_mangle]
-pub extern "C" fn aether_rfvp_new() -> *mut c_void {
+pub unsafe extern "C" fn aether_rfvp_new(gpu_callbacks: *const HostGpuCallbacks) -> *mut c_void {
     let _ = log::set_logger(&LOGGER).map(|_| log::set_max_level(log::LevelFilter::Info));
+    let gpu = gpu_callbacks
+        .as_ref()
+        .copied()
+        .filter(HostGpuCallbacks::valid);
     Box::into_raw(Box::new(Session {
         core: None,
+        gpu,
         error: CString::default(),
         poisoned: false,
     }))
@@ -447,15 +534,25 @@ pub unsafe extern "C" fn aether_rfvp_open(
     writable: *const c_char,
     font: *const c_char,
     encoding: *const c_char,
+    renderer: *const c_char,
 ) -> i32 {
     call(p, |s| {
         ensure!(s.core.is_none(), "Close the current game before reopening");
+        let renderer = string(renderer)?;
+        let (gpu, require_gpu) = match renderer {
+            "auto" => (s.gpu, false),
+            "gpu" => (s.gpu, true),
+            "cpu" => (None, false),
+            _ => return Err(anyhow!("rfvp renderer must be auto, gpu or cpu")),
+        };
         s.core = Some(Core::new(
             Path::new(string(path)?),
             string(script)?,
             Path::new(string(writable)?),
             string(font)?,
             Nls::from_str(string(encoding)?)?,
+            gpu,
+            require_gpu,
         )?);
         Ok(0)
     })
@@ -574,12 +671,37 @@ pub unsafe extern "C" fn aether_rfvp_frame(
     })
 }
 #[no_mangle]
+pub unsafe extern "C" fn aether_rfvp_gpu_frame(
+    p: *mut c_void,
+    texture: *mut u64,
+    w: *mut u32,
+    h: *mut u32,
+    serial: *mut u64,
+) -> i32 {
+    if texture.is_null() || w.is_null() || h.is_null() || serial.is_null() {
+        return -1;
+    }
+    call(p, |s| {
+        let c = s.core()?;
+        let Some(handle) = c.renderer.host_gpu_texture() else {
+            return Ok(-3);
+        };
+        *texture = handle;
+        *w = c.size.0;
+        *h = c.size.1;
+        *serial = c.serial;
+        Ok(0)
+    })
+}
+#[no_mangle]
 pub unsafe extern "C" fn aether_rfvp_read(p: *mut c_void, output: *mut c_void, size: usize) -> i32 {
     if output.is_null() {
         return -1;
     }
     call(p, |s| {
-        let bytes = s.core()?.renderer.framebuffer().pixels();
+        let renderer = &mut s.core()?.renderer;
+        ensure!(renderer.sync_host_gpu_framebuffer(), "Read rfvp GPU frame");
+        let bytes = renderer.framebuffer().pixels();
         ensure!(size >= bytes.len(), "Frame buffer is too small");
         ptr::copy_nonoverlapping(bytes.as_ptr(), output.cast(), bytes.len());
         Ok(0)

--- a/bridge/rfvp_runtime/rust/soft_render_host.rs
+++ b/bridge/rfvp_runtime/rust/soft_render_host.rs
@@ -1,6 +1,570 @@
 // SPDX-License-Identifier: MPL-2.0
 // Included in the software renderer's module in the build-tree overlay.
+use crate::aetherkiri_host::{HostGpuCallbacks, HostGpuPoint, HostGpuRect};
+
+const HOST_GPU_BLEND_ALPHA_D: u32 = 2;
+const HOST_GPU_TRIANGLE_TVP_BLEND: u32 = 0x0001_0000;
+const HOST_GPU_TRIANGLE_SOURCE_NEAREST: u32 = 0x1000_0000;
+const HOST_GPU_TRIANGLE_SOURCE_STRAIGHT_LINEAR: u32 = 0x0400_0000;
+
+#[derive(Debug)]
+struct HostGpuTexture {
+    handle: u64,
+    generation: u64,
+    width: u32,
+    height: u32,
+    tint: [u8; 3],
+}
+
+#[derive(Debug)]
+struct HostGpuDrawBatch {
+    source: u64,
+    clip: HostGpuRect,
+    rects: Vec<HostGpuRect>,
+    dst: Vec<HostGpuPoint>,
+    src: Vec<HostGpuPoint>,
+    opacity: f32,
+    opacity_bits: u32,
+    blend: u32,
+}
+
+#[derive(Debug)]
+struct HostGpuRenderer {
+    callbacks: HostGpuCallbacks,
+    target: u64,
+    width: u32,
+    height: u32,
+    batch_token: u64,
+    frame_active: bool,
+    failed: bool,
+    pending: Option<HostGpuDrawBatch>,
+    graph_cache: std::collections::HashMap<u16, HostGpuTexture>,
+    color_cache: std::collections::HashMap<u32, u64>,
+}
+
+impl HostGpuRenderer {
+    fn new(callbacks: HostGpuCallbacks, width: u32, height: u32) -> Self {
+        Self {
+            callbacks,
+            // Core construction happens on the runtime's asynchronous startup
+            // thread. Delay RenderingDevice access until the first host tick,
+            // which runs on Godot's main thread.
+            target: 0,
+            width,
+            height,
+            batch_token: 0,
+            frame_active: false,
+            failed: false,
+            pending: None,
+            graph_cache: std::collections::HashMap::new(),
+            color_cache: std::collections::HashMap::new(),
+        }
+    }
+
+    fn begin_frame(&mut self) -> bool {
+        if self.frame_active {
+            return false;
+        }
+        if self.target == 0 {
+            self.target = unsafe {
+                self.callbacks.create_rgba.unwrap()(
+                    self.width,
+                    self.height,
+                    std::ptr::null(),
+                    self.width.saturating_mul(4),
+                )
+            };
+            if self.target == 0 {
+                return false;
+            }
+        }
+        self.failed = false;
+        self.batch_token = unsafe { self.callbacks.begin_batch.unwrap()() };
+        if self.batch_token == 0 {
+            return false;
+        }
+        self.frame_active = true;
+        let rect = HostGpuRect {
+            left: 0,
+            top: 0,
+            right: self.width as i32,
+            bottom: self.height as i32,
+        };
+        if !unsafe { self.callbacks.clear_rgba.unwrap()(self.target, 0xff00_0000, &rect) } {
+            self.failed = true;
+        }
+        true
+    }
+
+    fn end_frame(&mut self) -> bool {
+        if !self.frame_active {
+            return false;
+        }
+        self.flush_draws();
+        self.frame_active = false;
+        let token = std::mem::take(&mut self.batch_token);
+        let ended = unsafe { self.callbacks.end_batch.unwrap()(token) };
+        ended && !self.failed
+    }
+
+    fn release(&self, handle: u64) {
+        if handle != 0 {
+            unsafe { self.callbacks.release_texture.unwrap()(handle) };
+        }
+    }
+
+    fn flush_draws(&mut self) {
+        let Some(batch) = self.pending.take() else {
+            return;
+        };
+        if !unsafe {
+            self.callbacks.draw_triangles.unwrap()(
+                self.target,
+                batch.source,
+                (batch.dst.len() / 3) as u32,
+                &batch.clip,
+                batch.dst.as_ptr(),
+                batch.src.as_ptr(),
+                batch.opacity,
+                batch.blend,
+            )
+        } {
+            self.failed = true;
+        }
+    }
+
+    fn enqueue_draw(
+        &mut self,
+        source: u64,
+        clip: HostGpuRect,
+        dst: &[HostGpuPoint; 6],
+        src: &[HostGpuPoint; 6],
+        opacity: f32,
+        blend: u32,
+    ) {
+        let opacity = opacity.clamp(0.0, 1.0);
+        let opacity_bits = opacity.to_bits();
+        let can_append = self.pending.as_ref().is_some_and(|batch| {
+            let union = HostGpuRect {
+                left: batch.clip.left.min(clip.left),
+                top: batch.clip.top.min(clip.top),
+                right: batch.clip.right.max(clip.right),
+                bottom: batch.clip.bottom.max(clip.bottom),
+            };
+            let area = |rect: &HostGpuRect| {
+                u64::from((rect.right - rect.left).max(0) as u32)
+                    * u64::from((rect.bottom - rect.top).max(0) as u32)
+            };
+            let disjoint = batch.rects.iter().all(|other| {
+                clip.right <= other.left
+                    || clip.left >= other.right
+                    || clip.bottom <= other.top
+                    || clip.top >= other.bottom
+            });
+            let covered_area = batch.rects.iter().map(area).sum::<u64>() + area(&clip);
+            batch.source == source
+                && batch.opacity_bits == opacity_bits
+                && batch.blend == blend
+                // The TVP shader stops after the first covering triangle, so
+                // only disjoint quads can share one dispatch without changing
+                // authored blend order. Bound the union as well: scattered
+                // snowflakes must not turn into a full-screen dispatch.
+                && disjoint
+                && area(&union) <= covered_area.saturating_mul(4)
+                && batch.dst.len() + dst.len() <= 16 * 6
+        });
+        if !can_append {
+            self.flush_draws();
+            self.pending = Some(HostGpuDrawBatch {
+                source,
+                clip,
+                rects: Vec::with_capacity(16),
+                dst: Vec::with_capacity(64 * 3),
+                src: Vec::with_capacity(64 * 3),
+                opacity,
+                opacity_bits,
+                blend,
+            });
+        }
+        let batch = self.pending.as_mut().unwrap();
+        batch.clip.left = batch.clip.left.min(clip.left);
+        batch.clip.top = batch.clip.top.min(clip.top);
+        batch.clip.right = batch.clip.right.max(clip.right);
+        batch.clip.bottom = batch.clip.bottom.max(clip.bottom);
+        batch.rects.push(clip);
+        batch.dst.extend_from_slice(dst);
+        batch.src.extend_from_slice(src);
+    }
+
+    fn prune_graphs(&mut self, graphs: &[GraphBuff]) {
+        let stale: Vec<u16> = self
+            .graph_cache
+            .keys()
+            .copied()
+            .filter(|graph_id| {
+                graphs
+                    .get(*graph_id as usize)
+                    .is_none_or(|graph| !graph.get_texture_ready() || graph.get_texture().is_none())
+            })
+            .collect();
+        for id in stale {
+            if let Some(texture) = self.graph_cache.remove(&id) {
+                self.release(texture.handle);
+            }
+        }
+    }
+
+    fn graph_texture(
+        &mut self,
+        graph_id: u16,
+        graph: &GraphBuff,
+        image: &DynamicImage,
+        color: Vec4,
+    ) -> Option<(u64, u32, u32, bool)> {
+        let (width, height) = image.dimensions();
+        if width == 0 || height == 0 {
+            return None;
+        }
+        let generation = graph.get_generation();
+        let tint = [
+            (color.x.clamp(0.0, 1.0) * 255.0).round() as u8,
+            (color.y.clamp(0.0, 1.0) * 255.0).round() as u8,
+            (color.z.clamp(0.0, 1.0) * 255.0).round() as u8,
+        ];
+        if let Some(entry) = self.graph_cache.get(&graph_id) {
+            if entry.generation == generation
+                && entry.width == width
+                && entry.height == height
+                && entry.tint == tint
+            {
+                let nearest = (4064..=4095).contains(&graph_id)
+                    || graph.load_kind == GraphBuffLoadKind::GaijiGlyph;
+                return Some((entry.handle, width, height, nearest));
+            }
+            // The queued draw stores this texture handle, so submit it before
+            // changing the pixels for a new graph generation or tint.
+            self.flush_draws();
+        }
+
+        let base: std::borrow::Cow<'_, [u8]> = match image {
+            DynamicImage::ImageRgba8(pixels) => std::borrow::Cow::Borrowed(pixels.as_raw()),
+            _ => std::borrow::Cow::Owned(image.to_rgba8().into_raw()),
+        };
+        let rgba: std::borrow::Cow<'_, [u8]> = if tint == [255, 255, 255] {
+            base
+        } else {
+            let mut tinted = base.into_owned();
+            for pixel in tinted.chunks_exact_mut(4) {
+                for channel in 0..3 {
+                    pixel[channel] =
+                        ((u16::from(pixel[channel]) * u16::from(tint[channel]) + 127) / 255) as u8;
+                }
+            }
+            std::borrow::Cow::Owned(tinted)
+        };
+        let rect = HostGpuRect {
+            left: 0,
+            top: 0,
+            right: width as i32,
+            bottom: height as i32,
+        };
+        let handle = if let Some(entry) = self.graph_cache.get_mut(&graph_id) {
+            if entry.width == width
+                && entry.height == height
+                && unsafe {
+                    self.callbacks.update_rgba.unwrap()(
+                        entry.handle,
+                        rgba.as_ptr().cast(),
+                        width.saturating_mul(4),
+                        &rect,
+                    )
+                }
+            {
+                entry.generation = generation;
+                entry.tint = tint;
+                entry.handle
+            } else {
+                let old = entry.handle;
+                let replacement = unsafe {
+                    self.callbacks.create_rgba.unwrap()(
+                        width,
+                        height,
+                        rgba.as_ptr().cast(),
+                        width.saturating_mul(4),
+                    )
+                };
+                if replacement == 0 {
+                    self.failed = true;
+                    return None;
+                }
+                *entry = HostGpuTexture {
+                    handle: replacement,
+                    generation,
+                    width,
+                    height,
+                    tint,
+                };
+                unsafe { self.callbacks.release_texture.unwrap()(old) };
+                replacement
+            }
+        } else {
+            let handle = unsafe {
+                self.callbacks.create_rgba.unwrap()(
+                    width,
+                    height,
+                    rgba.as_ptr().cast(),
+                    width.saturating_mul(4),
+                )
+            };
+            if handle == 0 {
+                self.failed = true;
+                return None;
+            }
+            self.graph_cache.insert(
+                graph_id,
+                HostGpuTexture {
+                    handle,
+                    generation,
+                    width,
+                    height,
+                    tint,
+                },
+            );
+            handle
+        };
+        let nearest =
+            (4064..=4095).contains(&graph_id) || graph.load_kind == GraphBuffLoadKind::GaijiGlyph;
+        Some((handle, width, height, nearest))
+    }
+
+    fn color_texture(&mut self, color: Vec4) -> Option<u64> {
+        let bytes = [
+            (color.x.clamp(0.0, 1.0) * 255.0).round() as u8,
+            (color.y.clamp(0.0, 1.0) * 255.0).round() as u8,
+            (color.z.clamp(0.0, 1.0) * 255.0).round() as u8,
+            255,
+        ];
+        let key = u32::from_le_bytes(bytes);
+        if let Some(handle) = self.color_cache.get(&key) {
+            return Some(*handle);
+        }
+        let handle = unsafe { self.callbacks.create_rgba.unwrap()(1, 1, bytes.as_ptr().cast(), 4) };
+        if handle == 0 {
+            self.failed = true;
+            return None;
+        }
+        self.color_cache.insert(key, handle);
+        Some(handle)
+    }
+
+    fn draw_quad(&mut self, vertices: [Vertex; 4], texture: TextureRef<'_>) -> bool {
+        if !self.frame_active {
+            return false;
+        }
+        let color = vertices[0].color;
+        let (source, source_width, source_height, nearest) = match texture {
+            TextureRef::Graph {
+                graph_id,
+                graph,
+                image,
+            } => {
+                let Some(value) = self.graph_texture(graph_id, graph, image, color) else {
+                    return true;
+                };
+                value
+            }
+            TextureRef::White => {
+                let Some(handle) = self.color_texture(color) else {
+                    return true;
+                };
+                (handle, 1, 1, true)
+            }
+        };
+
+        if !vertices
+            .iter()
+            .all(|vertex| vertex.pos.is_finite() && vertex.uv.is_finite())
+        {
+            self.failed = true;
+            return true;
+        }
+        let points = [
+            vertices[0],
+            vertices[1],
+            vertices[2],
+            vertices[2],
+            vertices[1],
+            vertices[3],
+        ];
+        let mut dst = [HostGpuPoint { x: 0.0, y: 0.0 }; 6];
+        let mut src = dst;
+        for (index, vertex) in points.iter().enumerate() {
+            dst[index] = HostGpuPoint {
+                x: vertex.pos.x as f64,
+                y: vertex.pos.y as f64,
+            };
+            // The bridge shader samples edge coordinates (pixel centres are
+            // n + 0.5), while RFVP's software renderer interpolates over
+            // [0, dimension - 1]. Preserve that exact mapping for linear and
+            // nearest sampling instead of stretching the final texel.
+            src[index] = HostGpuPoint {
+                x: (vertex.uv.x * source_width.saturating_sub(1) as f32 + 0.5) as f64,
+                y: (vertex.uv.y * source_height.saturating_sub(1) as f32 + 0.5) as f64,
+            };
+        }
+        let min_x = vertices
+            .iter()
+            .map(|vertex| vertex.pos.x)
+            .fold(f32::INFINITY, f32::min)
+            .floor()
+            .clamp(0.0, self.width as f32) as i32;
+        let min_y = vertices
+            .iter()
+            .map(|vertex| vertex.pos.y)
+            .fold(f32::INFINITY, f32::min)
+            .floor()
+            .clamp(0.0, self.height as f32) as i32;
+        let max_x = vertices
+            .iter()
+            .map(|vertex| vertex.pos.x)
+            .fold(f32::NEG_INFINITY, f32::max)
+            .ceil()
+            .clamp(0.0, self.width as f32) as i32;
+        let max_y = vertices
+            .iter()
+            .map(|vertex| vertex.pos.y)
+            .fold(f32::NEG_INFINITY, f32::max)
+            .ceil()
+            .clamp(0.0, self.height as f32) as i32;
+        if max_x <= min_x || max_y <= min_y {
+            return true;
+        }
+        let clip = HostGpuRect {
+            left: min_x,
+            top: min_y,
+            right: max_x,
+            bottom: max_y,
+        };
+        let mut blend = HOST_GPU_TRIANGLE_TVP_BLEND | HOST_GPU_BLEND_ALPHA_D;
+        if nearest {
+            blend |= HOST_GPU_TRIANGLE_SOURCE_NEAREST;
+        } else {
+            blend |= HOST_GPU_TRIANGLE_SOURCE_STRAIGHT_LINEAR;
+        }
+        self.enqueue_draw(source, clip, &dst, &src, color.w.clamp(0.0, 1.0), blend);
+        true
+    }
+
+    fn readback(&mut self, pixels: &mut [u8], stride: u32) -> bool {
+        if self.frame_active || self.target == 0 {
+            return false;
+        }
+        unsafe {
+            self.callbacks.read_rgba.unwrap()(
+                self.target,
+                pixels.as_mut_ptr().cast(),
+                pixels.len(),
+                stride,
+            )
+        }
+    }
+}
+
+impl Drop for HostGpuRenderer {
+    fn drop(&mut self) {
+        if self.frame_active {
+            self.end_frame();
+        }
+        for texture in self.graph_cache.values() {
+            self.release(texture.handle);
+        }
+        for handle in self.color_cache.values() {
+            self.release(*handle);
+        }
+        self.release(self.target);
+    }
+}
+
 impl SoftRenderer {
+    pub(crate) fn install_host_gpu(&mut self, callbacks: HostGpuCallbacks) -> bool {
+        let renderer = HostGpuRenderer::new(
+            callbacks,
+            self.framebuffer.width(),
+            self.framebuffer.height(),
+        );
+        self.host_gpu = Some(renderer);
+        true
+    }
+
+    fn begin_host_gpu_frame(&mut self) -> bool {
+        let active = self
+            .host_gpu
+            .as_mut()
+            .is_some_and(HostGpuRenderer::begin_frame);
+        if self.host_gpu.is_some() && !active {
+            log::warn!("rfvp GPU frame setup failed; reverting to CPU renderer");
+            self.host_gpu.take();
+        }
+        active
+    }
+
+    fn finish_host_gpu_frame(&mut self) {
+        let healthy = self
+            .host_gpu
+            .as_mut()
+            .is_none_or(HostGpuRenderer::end_frame);
+        if !healthy {
+            log::error!("rfvp GPU frame failed; reverting to CPU renderer");
+            let stride = self.framebuffer.stride() as u32;
+            if let Some(renderer) = self.host_gpu.as_mut() {
+                // Preserve every operation the bridge did accept before the
+                // failure, so the one transition frame is not stale garbage.
+                let _ = renderer.readback(self.framebuffer.pixels_mut(), stride);
+            }
+            self.host_gpu.take();
+        }
+    }
+
+    fn prune_host_gpu_graphs(&mut self, graphs: &[GraphBuff]) {
+        if let Some(renderer) = self.host_gpu.as_mut() {
+            renderer.prune_graphs(graphs);
+        }
+    }
+
+    fn host_gpu_frame_active(&self) -> bool {
+        self.host_gpu
+            .as_ref()
+            .is_some_and(|renderer| renderer.frame_active)
+    }
+
+    fn try_host_gpu_quad(
+        &mut self,
+        v0: Vertex,
+        v1: Vertex,
+        v2: Vertex,
+        v3: Vertex,
+        texture: TextureRef<'_>,
+    ) -> bool {
+        self.host_gpu
+            .as_mut()
+            .is_some_and(|renderer| renderer.draw_quad([v0, v1, v2, v3], texture))
+    }
+
+    pub(crate) fn host_gpu_texture(&self) -> Option<u64> {
+        self.host_gpu
+            .as_ref()
+            .map(|renderer| renderer.target)
+            .filter(|target| *target != 0)
+    }
+
+    pub(crate) fn sync_host_gpu_framebuffer(&mut self) -> bool {
+        let stride = self.framebuffer.stride() as u32;
+        match self.host_gpu.as_mut() {
+            Some(renderer) => renderer.readback(self.framebuffer.pixels_mut(), stride),
+            None => true,
+        }
+    }
+
     fn try_host_axis_quad(
         &mut self,
         top_left: Vec2,
@@ -11,6 +575,9 @@ impl SoftRenderer {
         color: Vec4,
         texture: TextureRef<'_>,
     ) -> bool {
+        if self.host_gpu_frame_active() {
+            return false;
+        }
         if top_left.x != bottom_left.x || top_left.y != top_right.y {
             return false;
         }
@@ -47,6 +614,199 @@ impl SoftRenderer {
 #[cfg(test)]
 mod host_renderer_tests {
     use super::*;
+    use std::ffi::c_void;
+    use std::sync::{Mutex, OnceLock};
+
+    #[derive(Debug, Default)]
+    struct FakeGpuState {
+        creates: Vec<(u32, u32, bool, [u8; 4])>,
+        releases: Vec<u64>,
+        clears: Vec<(u64, u32, HostGpuRect)>,
+        draws: Vec<(u64, u64, u32, HostGpuRect, f32, u32)>,
+        first_source_points: Vec<(f64, f64)>,
+        begins: usize,
+        ends: Vec<u64>,
+        reads: Vec<(u64, usize, u32)>,
+    }
+
+    fn fake_gpu() -> &'static Mutex<FakeGpuState> {
+        static STATE: OnceLock<Mutex<FakeGpuState>> = OnceLock::new();
+        STATE.get_or_init(|| Mutex::new(FakeGpuState::default()))
+    }
+
+    unsafe extern "C" fn fake_create(
+        width: u32,
+        height: u32,
+        pixels: *const c_void,
+        _stride: u32,
+    ) -> u64 {
+        let mut state = fake_gpu().lock().unwrap();
+        let first_pixel = if pixels.is_null() {
+            [0; 4]
+        } else {
+            *(pixels.cast::<[u8; 4]>())
+        };
+        state
+            .creates
+            .push((width, height, !pixels.is_null(), first_pixel));
+        100 + state.creates.len() as u64 - 1
+    }
+
+    unsafe extern "C" fn fake_release(texture: u64) {
+        fake_gpu().lock().unwrap().releases.push(texture);
+    }
+
+    unsafe extern "C" fn fake_update(
+        _texture: u64,
+        _pixels: *const c_void,
+        _stride: u32,
+        _rect: *const HostGpuRect,
+    ) -> bool {
+        true
+    }
+
+    unsafe extern "C" fn fake_clear(texture: u64, rgba: u32, rect: *const HostGpuRect) -> bool {
+        fake_gpu()
+            .lock()
+            .unwrap()
+            .clears
+            .push((texture, rgba, *rect));
+        true
+    }
+
+    unsafe extern "C" fn fake_draw(
+        dst: u64,
+        src: u64,
+        triangles: u32,
+        clip: *const HostGpuRect,
+        _dst_points: *const HostGpuPoint,
+        src_points: *const HostGpuPoint,
+        opacity: f32,
+        blend: u32,
+    ) -> bool {
+        let mut state = fake_gpu().lock().unwrap();
+        state
+            .draws
+            .push((dst, src, triangles, *clip, opacity, blend));
+        state
+            .first_source_points
+            .push(((*src_points).x, (*src_points).y));
+        true
+    }
+
+    unsafe extern "C" fn fake_read(
+        texture: u64,
+        pixels: *mut c_void,
+        size: usize,
+        stride: u32,
+    ) -> bool {
+        fake_gpu()
+            .lock()
+            .unwrap()
+            .reads
+            .push((texture, size, stride));
+        std::slice::from_raw_parts_mut(pixels.cast::<u8>(), size).fill(0x5a);
+        true
+    }
+
+    unsafe extern "C" fn fake_begin() -> u64 {
+        fake_gpu().lock().unwrap().begins += 1;
+        77
+    }
+
+    unsafe extern "C" fn fake_end(token: u64) -> bool {
+        fake_gpu().lock().unwrap().ends.push(token);
+        true
+    }
+
+    unsafe extern "C" fn fake_flush() -> bool {
+        true
+    }
+
+    fn fake_callbacks() -> HostGpuCallbacks {
+        HostGpuCallbacks {
+            struct_size: std::mem::size_of::<HostGpuCallbacks>() as u32,
+            api_version: 0x0100_0000,
+            create_rgba: Some(fake_create),
+            release_texture: Some(fake_release),
+            update_rgba: Some(fake_update),
+            clear_rgba: Some(fake_clear),
+            draw_triangles: Some(fake_draw),
+            read_rgba: Some(fake_read),
+            begin_batch: Some(fake_begin),
+            end_batch: Some(fake_end),
+            flush: Some(fake_flush),
+        }
+    }
+
+    #[test]
+    fn host_gpu_is_lazy_batched_and_read_back_only_on_request() {
+        *fake_gpu().lock().unwrap() = FakeGpuState::default();
+        {
+            let mut renderer = SoftRenderer::new(8, 6, PixelFormat::Rgba8).unwrap();
+            assert!(renderer.install_host_gpu(fake_callbacks()));
+            assert_eq!(renderer.host_gpu_texture(), None);
+            assert!(renderer.begin_host_gpu_frame());
+            assert_eq!(renderer.host_gpu_texture(), Some(100));
+            renderer.fill_rect(1.0, 2.0, 4.0, 3.0, vec4(1.0, 1.0, 1.0, 0.5));
+            renderer.fill_rect(5.0, 2.0, 3.0, 3.0, vec4(1.0, 1.0, 1.0, 0.5));
+            let graph = GraphBuff::new();
+            let image = DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+                2,
+                2,
+                image::Rgba([200, 100, 50, 128]),
+            ));
+            renderer
+                .draw_textured_quad(
+                    Mat4::from_translation(vec3(2.0, 0.0, 0.0)),
+                    2.0,
+                    2.0,
+                    Vec2::ZERO,
+                    Vec2::ONE,
+                    vec4(0.5, 0.25, 1.0, 0.75),
+                    TextureRef::Graph {
+                        graph_id: 7,
+                        graph: &graph,
+                        image: &image,
+                    },
+                )
+                .unwrap();
+            renderer.finish_host_gpu_frame();
+
+            let before_read = fake_gpu().lock().unwrap().reads.len();
+            assert_eq!(before_read, 0);
+            assert!(renderer.sync_host_gpu_framebuffer());
+            assert!(renderer.framebuffer.pixels().iter().all(|v| *v == 0x5a));
+        }
+
+        let state = fake_gpu().lock().unwrap();
+        assert_eq!(
+            state.creates,
+            vec![
+                (8, 6, false, [0; 4]),
+                (1, 1, true, [255, 255, 255, 255]),
+                (2, 2, true, [100, 25, 50, 128]),
+            ]
+        );
+        assert_eq!(state.begins, 1);
+        assert_eq!(state.ends, vec![77]);
+        assert_eq!(state.clears.len(), 1);
+        assert_eq!(state.clears[0].0, 100);
+        assert_eq!(state.clears[0].1, 0xff00_0000);
+        assert_eq!(state.draws.len(), 2);
+        assert_eq!(state.draws[0].0, 100);
+        assert_eq!(state.draws[0].1, 101);
+        assert_eq!(state.draws[0].2, 4);
+        assert_eq!(state.draws[0].4, 0.5);
+        assert_eq!(state.draws[0].5, 0x1001_0002);
+        assert_eq!(state.draws[1].1, 102);
+        assert_eq!(state.draws[1].2, 2);
+        assert_eq!(state.draws[1].4, 0.75);
+        assert_eq!(state.draws[1].5, 0x0401_0002);
+        assert_eq!(state.first_source_points, vec![(0.5, 0.5), (0.5, 1.5)]);
+        assert_eq!(state.reads, vec![(100, 8 * 6 * 4, 8 * 4)]);
+        assert_eq!(state.releases, vec![102, 101, 100]);
+    }
 
     #[test]
     fn invisible_quads_skip_rasterization() {

--- a/bridge/rfvp_runtime/src/rfvp_runtime_provider.cpp
+++ b/bridge/rfvp_runtime/src/rfvp_runtime_provider.cpp
@@ -1,6 +1,7 @@
 #include "rfvp_runtime_provider.h"
 #include "rfvp_host.h"
 #include "engine_runtime_provider.h"
+#include "GodotGpuBridge.h"
 
 #include <cstring>
 #include <memory>
@@ -9,12 +10,78 @@
 
 namespace aetherkiri::rfvp {
 namespace {
+TVPGodotGpuBridgeCallbacks g_gpu_bridge{};
+TVPGodotGpuBatchCallbacks g_gpu_batch{};
+bool g_gpu_bridge_registered = false;
+
+uint64_t GpuCreate(uint32_t width, uint32_t height, const void* pixels,
+                   uint32_t stride) {
+    return g_gpu_bridge_registered && g_gpu_bridge.create_rgba
+        ? g_gpu_bridge.create_rgba(width, height, pixels, stride)
+        : 0;
+}
+void GpuRelease(uint64_t texture) {
+    if (g_gpu_bridge_registered && g_gpu_bridge.release_texture)
+        g_gpu_bridge.release_texture(texture);
+}
+bool GpuUpdate(uint64_t texture, const void* pixels, uint32_t stride,
+               const aether_rfvp_gpu_rect_t* rect) {
+    return g_gpu_bridge_registered && g_gpu_bridge.update_rgba &&
+        g_gpu_bridge.update_rgba(texture, pixels, stride,
+            reinterpret_cast<const tTVPRect*>(rect));
+}
+bool GpuClear(uint64_t texture, uint32_t rgba,
+              const aether_rfvp_gpu_rect_t* rect) {
+    return g_gpu_bridge_registered && g_gpu_bridge.clear_rgba &&
+        g_gpu_bridge.clear_rgba(texture, rgba,
+            reinterpret_cast<const tTVPRect*>(rect));
+}
+bool GpuDraw(uint64_t dst, uint64_t src, uint32_t triangle_count,
+             const aether_rfvp_gpu_rect_t* clip,
+             const aether_rfvp_gpu_point_t* dst_points,
+             const aether_rfvp_gpu_point_t* src_points, float opacity,
+             uint32_t blend_mode) {
+    return g_gpu_bridge_registered && g_gpu_bridge.draw_triangles &&
+        g_gpu_bridge.draw_triangles(
+            dst, src, triangle_count,
+            reinterpret_cast<const tTVPRect*>(clip),
+            reinterpret_cast<const tTVPPointD*>(dst_points),
+            reinterpret_cast<const tTVPPointD*>(src_points), opacity,
+            blend_mode);
+}
+bool GpuRead(uint64_t texture, void* pixels, size_t size, uint32_t stride) {
+    return g_gpu_bridge_registered && g_gpu_bridge.read_rgba &&
+        g_gpu_bridge.read_rgba(texture, pixels, size, stride);
+}
+uint64_t GpuBegin() {
+    return g_gpu_bridge_registered && g_gpu_batch.begin_batch
+        ? g_gpu_batch.begin_batch()
+        : 0;
+}
+bool GpuEnd(uint64_t token) {
+    return g_gpu_bridge_registered && g_gpu_batch.end_batch &&
+        g_gpu_batch.end_batch(token);
+}
+bool GpuFlush() {
+    return g_gpu_bridge_registered && g_gpu_bridge.flush &&
+        g_gpu_bridge.flush();
+}
+const aether_rfvp_gpu_callbacks_t* GpuCallbacks() {
+    static const aether_rfvp_gpu_callbacks_t callbacks{
+        sizeof(aether_rfvp_gpu_callbacks_t),
+        AETHER_RFVP_GPU_CALLBACKS_API_VERSION,
+        GpuCreate, GpuRelease, GpuUpdate, GpuClear, GpuDraw, GpuRead,
+        GpuBegin, GpuEnd, GpuFlush};
+    return g_gpu_bridge_registered ? &callbacks : nullptr;
+}
+
 struct Runtime {
-    void* core = aether_rfvp_new();
+    void* core = nullptr;
     engine_runtime_host_v1_t host{};
-    std::string writable, font, encoding = "sjis", error;
+    std::string writable, font, encoding = "sjis", renderer = "auto", error;
     uint64_t read_serial = 0;
     bool opened = false;
+    Runtime() : core(aether_rfvp_new(GpuCallbacks())) {}
     ~Runtime() { aether_rfvp_free(core); }
     engine_result_t result(int32_t code) {
         char message[4096];
@@ -52,7 +119,8 @@ engine_result_t Open(void* p, const char* path, const char* startup) {
     if (!p || !path) return ENGINE_RESULT_INVALID_ARGUMENT;
     auto& r = *cast(p);
     const auto result = r.result(aether_rfvp_open(r.core, path, startup,
-        r.writable.c_str(), r.font.c_str(), r.encoding.c_str()));
+        r.writable.c_str(), r.font.c_str(), r.encoding.c_str(),
+        r.renderer.c_str()));
     if (result == ENGINE_RESULT_OK) r.opened = true;
     return result;
 }
@@ -73,19 +141,28 @@ engine_result_t Option(void* p, const engine_option_t* option) {
         return ENGINE_RESULT_INVALID_ARGUMENT;
     auto& r = *cast(p);
     const std::string key = option->key_utf8, value = option->value_utf8;
-    if (key == "default_font" || key == "rfvp_encoding") {
-        if (value == (key == "default_font" ? r.font : r.encoding)) return ENGINE_RESULT_OK;
+    if (key == "default_font" || key == "rfvp_encoding" ||
+        key == "rfvp_renderer") {
+        const std::string& current = key == "default_font" ? r.font
+            : key == "rfvp_encoding" ? r.encoding : r.renderer;
+        if (value == current) return ENGINE_RESULT_OK;
         if (r.opened) {
-            r.error = "rfvp font and encoding must be set before opening a game";
+            r.error = "rfvp font, encoding and renderer must be set before opening a game";
             return ENGINE_RESULT_INVALID_STATE;
         }
         if (key == "default_font") r.font = value;
-        else {
+        else if (key == "rfvp_encoding") {
             if (value != "sjis" && value != "gbk" && value != "utf8") {
                 r.error = "rfvp_encoding must be sjis, gbk or utf8";
                 return ENGINE_RESULT_INVALID_ARGUMENT;
             }
             r.encoding = value;
+        } else {
+            if (value != "auto" && value != "gpu" && value != "cpu") {
+                r.error = "rfvp_renderer must be auto, gpu or cpu";
+                return ENGINE_RESULT_INVALID_ARGUMENT;
+            }
+            r.renderer = value;
         }
         return ENGINE_RESULT_OK;
     }
@@ -120,6 +197,17 @@ engine_result_t Read(void* p, void* pixels, size_t size) {
     }
     return result;
 }
+engine_result_t NativeFrame(void* p, uint64_t* texture, uint32_t* width,
+                            uint32_t* height, uint64_t* serial) {
+    if (!p || !texture || !width || !height || !serial)
+        return ENGINE_RESULT_INVALID_ARGUMENT;
+    const auto result = aether_rfvp_gpu_frame(
+        cast(p)->core, texture, width, height, serial);
+    // A CPU-selected runtime legitimately has no native texture. Avoid
+    // replacing its last useful error with an expected capability miss.
+    return result == -3 ? ENGINE_RESULT_NOT_SUPPORTED
+                        : cast(p)->result(result);
+}
 engine_result_t Input(void* p, const engine_input_event_t* event) {
     if (!p || !event || event->struct_size < sizeof(*event)) return ENGINE_RESULT_INVALID_ARGUMENT;
     return cast(p)->result(aether_rfvp_input(cast(p)->core, event->type, event->x, event->y,
@@ -133,10 +221,16 @@ engine_result_t Rendered(void* p, uint32_t* rendered) {
     *rendered = result == ENGINE_RESULT_OK && serial != r.read_serial;
     return result;
 }
-engine_result_t Renderer(void*, char* buffer, uint32_t size) {
-    constexpr char name[] = "rfvp CPU RGBA8 (Godot presentation)";
-    if (!buffer || size < sizeof(name)) return ENGINE_RESULT_INVALID_ARGUMENT;
-    std::memcpy(buffer, name, sizeof(name));
+engine_result_t Renderer(void* p, char* buffer, uint32_t size) {
+    uint64_t texture = 0, serial = 0;
+    uint32_t width = 0, height = 0;
+    const bool gpu = p && aether_rfvp_gpu_frame(
+        cast(p)->core, &texture, &width, &height, &serial) == 0 && texture != 0;
+    const char* name = gpu ? "rfvp Godot GPU Bridge"
+                           : "rfvp CPU RGBA8 (Godot presentation)";
+    const size_t required = std::strlen(name) + 1;
+    if (!buffer || size < required) return ENGINE_RESULT_INVALID_ARGUMENT;
+    std::memcpy(buffer, name, required);
     return ENGINE_RESULT_OK;
 }
 engine_result_t TextInput(void*, uint32_t* flags) {
@@ -152,15 +246,37 @@ const engine_runtime_provider_v1_t& Provider() {
         p.probe = Probe; p.create = Create; p.destroy = Destroy; p.open_game = Open; p.tick = Tick;
         p.pause = Pause; p.resume = Resume; p.set_option = Option; p.set_surface_size = Resize;
         p.get_frame_desc = Frame; p.read_frame_rgba = Read; p.send_input = Input;
+        p.get_godot_native_frame_texture = NativeFrame;
         p.get_frame_rendered_flag = Rendered; p.get_renderer_info = Renderer;
         p.get_text_input_state = TextInput; p.get_last_error = Error;
         return p;
     }();
     return provider;
 }
-}
+} // namespace
+
 void RegisterRuntimeProvider() {
     static std::once_flag once;
     std::call_once(once, [] { engine_register_runtime_provider(&Provider()); });
 }
+void RegisterGpuBridge(const TVPGodotGpuBridgeCallbacks* callbacks,
+                       const TVPGodotGpuBatchCallbacks* batch_callbacks) {
+    g_gpu_bridge = {};
+    g_gpu_batch = {};
+    g_gpu_bridge_registered = false;
+    if (!callbacks || !batch_callbacks ||
+        batch_callbacks->struct_size < sizeof(TVPGodotGpuBatchCallbacks) ||
+        batch_callbacks->abi_version !=
+            TVP_GODOT_GPU_BATCH_CALLBACKS_ABI_VERSION ||
+        !callbacks->create_rgba || !callbacks->release_texture ||
+        !callbacks->update_rgba || !callbacks->clear_rgba ||
+        !callbacks->draw_triangles || !callbacks->read_rgba ||
+        !callbacks->flush || !batch_callbacks->begin_batch ||
+        !batch_callbacks->end_batch) {
+        return;
+    }
+    g_gpu_bridge = *callbacks;
+    g_gpu_batch = *batch_callbacks;
+    g_gpu_bridge_registered = true;
 }
+} // namespace aetherkiri::rfvp

--- a/bridge/rfvp_runtime/tests/provider.cpp
+++ b/bridge/rfvp_runtime/tests/provider.cpp
@@ -37,7 +37,7 @@ struct Instance {
     void ok(engine_result_t code) {
         if (code != ENGINE_RESULT_OK) throw std::runtime_error(provider->get_last_error(value));
     }
-    void open(const fs::path& path) {
+    engine_result_t open_result(const fs::path& path) {
         // Match engine_open_game_async: macOS gives std::thread a much smaller
         // stack than main(). Tick, input and destruction stay on the host thread.
         engine_result_t result = ENGINE_RESULT_INTERNAL_ERROR;
@@ -46,7 +46,10 @@ struct Instance {
             result = provider->open_game(value, utf8.c_str(), nullptr);
         });
         startup.join();
-        ok(result);
+        return result;
+    }
+    void open(const fs::path& path) {
+        ok(open_result(path));
     }
     void step(int count = 1) { while (count--) ok(provider->tick(value, 16)); }
     engine_frame_desc_t frame() {
@@ -90,8 +93,27 @@ int main(int argc, char** argv) {
             Instance painter(scratch);
             painter.open(demo);
             painter.step(2);
+            uint64_t texture = 0, serial = 0;
+            uint32_t width = 0, height = 0;
+            check(provider->get_godot_native_frame_texture(
+                      painter.value, &texture, &width, &height, &serial) ==
+                      ENGINE_RESULT_NOT_SUPPORTED,
+                  "standalone provider uses CPU fallback without a GPU bridge");
             auto pixels = painter.pixels();
             check(pixels[(200 * 1024 + 200) * 4] > 200, "upstream painter renders its canvas");
+        }
+        {
+            Instance forced_gpu(scratch);
+            engine_option_t option{};
+            option.key_utf8 = "rfvp_renderer";
+            option.value_utf8 = "invalid";
+            check(provider->set_option(forced_gpu.value, &option) ==
+                      ENGINE_RESULT_INVALID_ARGUMENT,
+                  "invalid renderer");
+            option.value_utf8 = "gpu";
+            forced_gpu.ok(provider->set_option(forced_gpu.value, &option));
+            check(forced_gpu.open_result(demo) != ENGINE_RESULT_OK,
+                  "forced GPU rejects a missing bridge");
         }
         const auto fixture = scratch / "input.hcb";
         write_input_fixture(fixture);

--- a/cpp/core/visual/godot/GodotGpuBridge.h
+++ b/cpp/core/visual/godot/GodotGpuBridge.h
@@ -188,6 +188,12 @@ constexpr uint32_t TVP_GODOT_GPU_TRIANGLE_TVP_BLEND =
 // The source stores premultiplied RGB (native E-mote/OpenGL output). The
 // triangle sampler must not multiply RGB by alpha a second time.
 constexpr uint32_t TVP_GODOT_GPU_TRIANGLE_SOURCE_PREMULTIPLIED = 0x20000000u;
+// Sample integer texels without interpolation. RFVP text/gaiji graph buffers
+// require this to match their authored pixel grid.
+constexpr uint32_t TVP_GODOT_GPU_TRIANGLE_SOURCE_NEAREST = 0x10000000u;
+// Interpolate straight RGBA without the bridge's premultiplied minification
+// filter. RFVP's software renderer defines graph sampling this way.
+constexpr uint32_t TVP_GODOT_GPU_TRIANGLE_SOURCE_STRAIGHT_LINEAR = 0x04000000u;
 
 extern "C" void TVPGodotGpuBridgeRegister(
     const TVPGodotGpuBridgeCallbacks *callbacks);


### PR DESCRIPTION
## Summary

- render RFVP scene graphs directly into a Godot RenderingDevice texture through a versioned private GPU callback ABI, while retaining automatic CPU fallback and on-demand readback
- cache graph uploads, preserve RFVP nearest/straight-linear sampling, and safely batch disjoint draws to avoid the per-frame CPU RGBA upload bottleneck
- build RFVP Rust release artifacts with ThinLTO and one code-generation unit, add `auto|gpu|cpu` renderer selection, and resolve an iOS probe title to its configured HCB launch entry

This is a focused performance follow-up to #198.

## Validation

- RFVP Release CTest: `rfvp-provider` and `rfvp-host-regressions` (2/2 passed)
- Godot parse plus `game_launch_entry_test`, `game_metadata_test`, `cover_persistence_test`, and `library_search_test`
- macOS Apple M1, same 1280x720 星辰恋曲 sequence: forced CPU 22.00 FPS; forced GPU 60.00 FPS; screenshots visually matched
- iPad mini (A17 Pro), signed Release build 17105: 59.99 FPS, `godot_driver=metal`, `rd_gpu=1`, `texture_backend=godot_native_gpu_presented`, 23,201/23,201 bridge operations completed with zero failures
- iOS Release native build, Godot export, Xcode signing, installation, and title-based launch probe completed successfully
